### PR TITLE
Feat: internal padding

### DIFF
--- a/atlas-onnx-tracer/src/model/mod.rs
+++ b/atlas-onnx-tracer/src/model/mod.rs
@@ -305,7 +305,7 @@ pub struct RunArgs {
     /// The denominator in the fixed point representation used when quantizing the model
     pub scale: quantize::Scale,
     /// Whether to pad all dimensions to powers of 2.
-    /// Defaults to true for optimal cryptographic performance.
+    /// Defaults to false.
     pub pad_to_power_of_2: bool,
     /// When true, divide inputs by 1<<scale BEFORE Square/Cube (to prevent i32 overflow)
     /// instead of dividing the output AFTER (the default rebase).
@@ -320,7 +320,7 @@ impl Default for RunArgs {
         RunArgs {
             variables,
             scale: DEFAULT_SCALE,
-            pad_to_power_of_2: true, // Default to true for prover use-case
+            pad_to_power_of_2: false,
             pre_rebase_nonlinear: false,
         }
     }
@@ -346,7 +346,7 @@ impl RunArgs {
         RunArgs {
             variables,
             scale: DEFAULT_SCALE,
-            pad_to_power_of_2: true,
+            pad_to_power_of_2: false,
             pre_rebase_nonlinear: false,
         }
     }
@@ -370,9 +370,9 @@ impl RunArgs {
         RunArgs {
             variables,
             scale,
-            pad_to_power_of_2: true,
+            pad_to_power_of_2: false,
             pre_rebase_nonlinear: false,
-        } // Default to true for optimal cryptographic performance
+        }
     }
 
     /// Add a variable to the RunArgs

--- a/atlas-onnx-tracer/src/model/mod.rs
+++ b/atlas-onnx-tracer/src/model/mod.rs
@@ -305,7 +305,7 @@ pub struct RunArgs {
     /// The denominator in the fixed point representation used when quantizing the model
     pub scale: quantize::Scale,
     /// Whether to pad all dimensions to powers of 2.
-    /// Defaults to false.
+    /// Defaults to true.
     pub pad_to_power_of_2: bool,
     /// When true, divide inputs by 1<<scale BEFORE Square/Cube (to prevent i32 overflow)
     /// instead of dividing the output AFTER (the default rebase).
@@ -320,7 +320,7 @@ impl Default for RunArgs {
         RunArgs {
             variables,
             scale: DEFAULT_SCALE,
-            pad_to_power_of_2: false,
+            pad_to_power_of_2: true,
             pre_rebase_nonlinear: false,
         }
     }
@@ -346,7 +346,7 @@ impl RunArgs {
         RunArgs {
             variables,
             scale: DEFAULT_SCALE,
-            pad_to_power_of_2: false,
+            pad_to_power_of_2: true,
             pre_rebase_nonlinear: false,
         }
     }
@@ -370,7 +370,7 @@ impl RunArgs {
         RunArgs {
             variables,
             scale,
-            pad_to_power_of_2: false,
+            pad_to_power_of_2: true,
             pre_rebase_nonlinear: false,
         }
     }

--- a/atlas-onnx-tracer/src/model/mod.rs
+++ b/atlas-onnx-tracer/src/model/mod.rs
@@ -222,7 +222,7 @@ impl Model {
         self.graph
             .nodes
             .values()
-            .map(|node| node.num_output_elements().next_power_of_two())
+            .map(|node| node.pow2_padded_num_output_elements().next_power_of_two())
             .max()
             .unwrap_or(0)
     }
@@ -257,15 +257,15 @@ impl Model {
                 | Operator::Erf(_)
                 | Operator::ReLU(_)
                 | Operator::Rsqrt(_)
-                | Operator::Sin(_) => LOG_K_CHUNK + log_2(node.num_output_elements()),
-                Operator::ScalarConstDiv(_) => log_2(node.num_output_elements()),
+                | Operator::Sin(_) => LOG_K_CHUNK + log_2(node.pow2_padded_num_output_elements()),
+                Operator::ScalarConstDiv(_) => log_2(node.pow2_padded_num_output_elements()),
                 Operator::SoftmaxAxes(_) => {
                     LOG_K_CHUNK + log_2(*node.output_dims.last().unwrap_or(&1))
                 }
                 Operator::Gather(_) => {
                     let input_nodes = self.get_input_nodes(node);
                     let num_words = input_nodes[0].output_dims[0];
-                    let num_indices = input_nodes[1].num_output_elements();
+                    let num_indices = input_nodes[1].pow2_padded_num_output_elements();
                     log_2(num_words) + log_2(num_indices) // TODO: Gather ra virtualization
                 }
                 _ => 1,

--- a/atlas-onnx-tracer/src/node/mod.rs
+++ b/atlas-onnx-tracer/src/node/mod.rs
@@ -1,6 +1,7 @@
 //! Node representation and helpers used by the ONNX tracer.
 //! A `ComputationNode` models a single operation in the graph.
 use crate::ops::Operator;
+use crate::utils::dims::UsizeDimsExt;
 use serde::{Deserialize, Serialize};
 
 /// Node-specific handler functions and utilities.
@@ -55,11 +56,16 @@ impl ComputationNode {
         }
     }
 
-    /// Computes the total number of output elements produced by this node.
-    /// This is the product of the output dimensions.
-    /// For example, if `output_dims` is `[2, 3]`, this returns `6`.
+    /// Computes the total number of output elements produced by this node,
+    /// after mapping each output dimension to its next power of two.
+    ///
+    /// For example, if `output_dims` is `[2, 3]`, this returns `8`
+    /// because dimensions are normalized to `[2, 4]` before taking the product.
     pub fn num_output_elements(&self) -> usize {
-        self.output_dims.iter().product()
+        self.output_dims
+            .map_next_power_of_two()
+            .into_iter()
+            .product()
     }
 
     /// Returns true if the output of this node is a scalar (i.e., has exactly one element).

--- a/atlas-onnx-tracer/src/node/mod.rs
+++ b/atlas-onnx-tracer/src/node/mod.rs
@@ -56,20 +56,25 @@ impl ComputationNode {
         }
     }
 
-    /// Computes the total number of output elements produced by this node,
+    /// Computes the total number of output elements produced by this node
     /// after mapping each output dimension to its next power of two.
     ///
     /// For example, if `output_dims` is `[2, 3]`, this returns `8`
     /// because dimensions are normalized to `[2, 4]` before taking the product.
-    pub fn num_output_elements(&self) -> usize {
+    pub fn pow2_padded_num_output_elements(&self) -> usize {
         self.output_dims
             .map_next_power_of_two()
             .into_iter()
             .product()
     }
 
+    /// Backward-compatible alias for [`Self::pow2_padded_num_output_elements`].
+    pub fn num_output_elements(&self) -> usize {
+        self.pow2_padded_num_output_elements()
+    }
+
     /// Returns true if the output of this node is a scalar (i.e., has exactly one element).
     pub fn is_scalar(&self) -> bool {
-        self.num_output_elements() == 1
+        self.pow2_padded_num_output_elements() == 1
     }
 }

--- a/atlas-onnx-tracer/src/node/mod.rs
+++ b/atlas-onnx-tracer/src/node/mod.rs
@@ -68,13 +68,13 @@ impl ComputationNode {
             .product()
     }
 
-    /// Backward-compatible alias for [`Self::pow2_padded_num_output_elements`].
+    /// Computes the total number of output elements produced by this node
+    /// without applying power-of-two padding.
     pub fn num_output_elements(&self) -> usize {
-        self.pow2_padded_num_output_elements()
+        self.output_dims.iter().product()
     }
-
     /// Returns true if the output of this node is a scalar (i.e., has exactly one element).
     pub fn is_scalar(&self) -> bool {
-        self.pow2_padded_num_output_elements() == 1
+        self.num_output_elements() == 1
     }
 }

--- a/atlas-onnx-tracer/src/tensor/mod.rs
+++ b/atlas-onnx-tracer/src/tensor/mod.rs
@@ -493,6 +493,16 @@ impl<T: Clone + TensorType> Tensor<T> {
         );
     }
 
+    /// Returns a cloned tensor padded to power-of-two dimensions with zeros.
+    pub fn padded_next_power_of_two(&self) -> Self
+    where
+        T: Send + Sync,
+    {
+        let mut padded = self.clone();
+        padded.pad_next_power_of_two();
+        padded
+    }
+
     /// Pads the tensor to specific target dimensions with zeros.
     /// Only supports growing dimensions (target must be >= current for each dimension).
     ///

--- a/atlas-onnx-tracer/src/tensor/mod.rs
+++ b/atlas-onnx-tracer/src/tensor/mod.rs
@@ -474,37 +474,17 @@ impl<T: Clone + TensorType> Tensor<T> {
 
     /// Pads the tensor to power of 2 dimensions.
     ///
-    /// For tensors where all values are identical (broadcast constants),
-    /// fills padding with the same value. Otherwise, pads with zeros.
+    /// Always pads with zeros.
     pub fn pad_next_power_of_two(&mut self)
     where
-        T: Send + Sync + PartialEq,
+        T: Send + Sync,
     {
         let padded_dims: Vec<usize> = self
             .dims()
             .iter()
             .map(|dim| dim.next_power_of_two())
             .collect();
-
-        // Check if this is a constant that comes from a scalar(all values are the same)
-        let is_scalar_const_tensor = if !self.inner.is_empty() {
-            let first_val = &self.inner[0];
-            self.inner.iter().all(|v| v == first_val)
-        } else {
-            false
-        };
-
-        let result = if is_scalar_const_tensor {
-            // For scalar constant tensors, just resize and update dims — no copy needed
-            // since every element (old and new) should be the same value
-            let target_len: usize = padded_dims.iter().product();
-            let fill_value = self.inner[0].clone();
-            self.inner.resize(target_len, fill_value);
-            self.dims = padded_dims;
-            Ok(())
-        } else {
-            self.pad_to_dims(&padded_dims)
-        };
+        let result = self.pad_to_dims(&padded_dims);
 
         assert!(
             result.is_ok(),

--- a/atlas-onnx-tracer/src/utils/dims.rs
+++ b/atlas-onnx-tracer/src/utils/dims.rs
@@ -1,0 +1,37 @@
+//! Dimension-related extension helpers.
+
+/// Extension methods for dimension vectors/slices.
+pub trait UsizeDimsExt {
+    /// Returns a new vector where each dimension is mapped to its next power of two.
+    fn map_next_power_of_two(&self) -> Vec<usize>;
+}
+
+impl UsizeDimsExt for [usize] {
+    fn map_next_power_of_two(&self) -> Vec<usize> {
+        self.iter().map(|d| d.next_power_of_two()).collect()
+    }
+}
+
+impl UsizeDimsExt for Vec<usize> {
+    fn map_next_power_of_two(&self) -> Vec<usize> {
+        self.as_slice().map_next_power_of_two()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UsizeDimsExt;
+
+    #[test]
+    fn test_map_next_power_of_two_for_slice() {
+        let dims = [1, 3, 8, 9];
+        assert_eq!(dims.map_next_power_of_two(), vec![1, 4, 8, 16]);
+    }
+
+    #[test]
+    fn test_map_next_power_of_two_for_vec() {
+        let dims = vec![2, 5, 7];
+        assert_eq!(dims.map_next_power_of_two(), vec![2, 8, 8]);
+    }
+}
+

--- a/atlas-onnx-tracer/src/utils/dims.rs
+++ b/atlas-onnx-tracer/src/utils/dims.rs
@@ -34,4 +34,3 @@ mod tests {
         assert_eq!(dims.map_next_power_of_two(), vec![2, 8, 8]);
     }
 }
-

--- a/atlas-onnx-tracer/src/utils/mod.rs
+++ b/atlas-onnx-tracer/src/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Utility functions and helper modules for the ONNX tracer.
 
+pub mod dims;
 pub mod f32;
 pub mod handler_builder;
 pub mod parallel_utils;

--- a/jolt-atlas-core/src/onnx_proof/neural_teleport/division.rs
+++ b/jolt-atlas-core/src/onnx_proof/neural_teleport/division.rs
@@ -106,7 +106,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for TeleportDivisionParams<F> {
     }
 
     fn num_rounds(&self) -> usize {
-        self.computation_node.num_output_elements().log_2()
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
@@ -308,9 +308,12 @@ fn append_raf_claims_prover<F: JoltField, LUT>(
     } = Trace::layer_data(trace, &provider.computation_node);
     let is_interleaved_operands = provider.computation_node.is_interleaved_operands();
     if is_interleaved_operands {
-        let [left_operand_tensor, right_operand_tensor] = operands[..] else {
+        let [ left_operand_tensor, right_operand_tensor] = operands[..] else {
             panic!("Expected exactly two input tensors")
         };
+
+        let left_operand_tensor=  left_operand_tensor.padded_next_power_of_two();
+        let right_operand_tensor = right_operand_tensor.padded_next_power_of_two();
 
         // Cache left/right operand claims.
         let left_operand_claim =
@@ -354,7 +357,7 @@ fn append_raf_claims_prover<F: JoltField, LUT>(
             right_operand_claim,
         );
     } else {
-        let right_operand_tensor = operands[0];
+        let right_operand_tensor = operands[0].padded_next_power_of_two();
         let right_operand_claim =
             MultilinearPolynomial::from(right_operand_tensor.into_container_data())
                 .evaluate(&r_cycle.r);

--- a/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
@@ -117,8 +117,15 @@ impl OpLookupProvider {
         LUT: JoltLookupTable + PrefixSuffixDecompositionTrait<XLEN> + Default,
     {
         append_raf_claims_prover::<F, LUT>(self, trace, accumulator, transcript);
+        let padded_operands: Vec<_> = trace
+            .layer_data(&self.computation_node)
+            .operands
+            .iter()
+            .map(|tensor| tensor.padded_next_power_of_two())
+            .collect();
+        let operand_refs: Vec<_> = padded_operands.iter().collect();
         let lookup_bits = compute_lookup_indices_from_operands(
-            &trace.layer_data(&self.computation_node).operands,
+            &operand_refs,
             self.computation_node.is_interleaved_operands(),
         );
         let lookup_indices: Vec<usize> = lookup_bits.iter().map(|&x| x.into()).collect();

--- a/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
@@ -10,6 +10,7 @@ use atlas_onnx_tracer::{
     model::trace::{LayerData, Trace},
     node::ComputationNode,
     ops::Operator,
+    tensor::Tensor,
 };
 use common::{
     consts::{LOG_K, XLEN},
@@ -239,7 +240,7 @@ impl OpLookupEncoding {
         use joltworks::utils::math::Math;
         Self {
             node_idx: computation_node.idx,
-            log_t: computation_node.num_output_elements().log_2(),
+            log_t: computation_node.pow2_padded_num_output_elements().log_2(),
         }
     }
 }
@@ -308,11 +309,11 @@ fn append_raf_claims_prover<F: JoltField, LUT>(
     } = Trace::layer_data(trace, &provider.computation_node);
     let is_interleaved_operands = provider.computation_node.is_interleaved_operands();
     if is_interleaved_operands {
-        let [ left_operand_tensor, right_operand_tensor] = operands[..] else {
+        let [left_operand_tensor, right_operand_tensor] = operands[..] else {
             panic!("Expected exactly two input tensors")
         };
 
-        let left_operand_tensor=  left_operand_tensor.padded_next_power_of_two();
+        let left_operand_tensor = left_operand_tensor.padded_next_power_of_two();
         let right_operand_tensor = right_operand_tensor.padded_next_power_of_two();
 
         // Cache left/right operand claims.

--- a/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/op_lookups/mod.rs
@@ -10,7 +10,6 @@ use atlas_onnx_tracer::{
     model::trace::{LayerData, Trace},
     node::ComputationNode,
     ops::Operator,
-    tensor::Tensor,
 };
 use common::{
     consts::{LOG_K, XLEN},

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -216,7 +216,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "non-power-of-two path not fully supported yet"]
     fn test_add_non_power_of_two_input_len() {
         let t = 1000;
         let mut rng = StdRng::seed_from_u64(0x889);

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -56,8 +56,8 @@ impl<F: JoltField> AddProver<F> {
         let [left_operand, right_operand] = operands[..] else {
             panic!("Expected two operands for Add operation")
         };
-        let left_operand = MultilinearPolynomial::from(left_operand.clone());
-        let right_operand = MultilinearPolynomial::from(right_operand.clone());
+        let left_operand = MultilinearPolynomial::from(left_operand.padded_next_power_of_two());
+        let right_operand = MultilinearPolynomial::from(right_operand.padded_next_power_of_two());
         Self {
             params,
             eq_r_node_output,

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -214,4 +214,14 @@ mod tests {
         let model = add_model(&mut rng, T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_add_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = add_model(&mut rng, t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/broadcast.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/broadcast.rs
@@ -315,4 +315,15 @@ mod tests {
             unit_test_op(model, &[input]);
         }
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two broadcast path not fully validated yet"]
+    fn test_broadcast_non_power_of_two_input_len() {
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input_shape = vec![5];
+        let output_shape = vec![3, 5];
+        let input = Tensor::<i32>::random_small(&mut rng, &input_shape);
+        let model = broadcast_model(&input_shape, &output_shape);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/constant.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/constant.rs
@@ -33,7 +33,8 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Constant {
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
         let (r_node_const, const_claim) = verifier.accumulator.get_node_output_opening(node.idx);
-        let expected_claim = MultilinearPolynomial::from(self.0.clone()).evaluate(&r_node_const.r);
+        let constant_tensor = self.0.padded_next_power_of_two();
+        let expected_claim = MultilinearPolynomial::from(constant_tensor).evaluate(&r_node_const.r);
         if expected_claim != const_claim {
             return Err(ProofVerifyError::InvalidOpeningProof(
                 "Const claim does not match expected claim".to_string(),

--- a/jolt-atlas-core/src/onnx_proof/ops/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cos.rs
@@ -625,4 +625,14 @@ mod tests {
         let model = cos_model(&[8]);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two cos path not fully validated yet"]
+    fn test_cos_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0xC06);
+        let input = Tensor::random_range(&mut rng, &[t], -50000..50000);
+        let model = cos_model(&[t]);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/cube.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cube.rs
@@ -184,4 +184,14 @@ mod tests {
         let model = cube_model(T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_cube_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = cube_model(t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/cube.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cube.rs
@@ -58,7 +58,7 @@ impl<F: JoltField> CubeProver<F> {
         let [operand] = operands[..] else {
             panic!("Expected one operand for Cube operation")
         };
-        let operand = MultilinearPolynomial::from(operand.clone());
+        let operand = MultilinearPolynomial::from(operand.padded_next_power_of_two());
         Self {
             params,
             eq_r_node_output,
@@ -186,7 +186,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "non-power-of-two path not fully supported yet"]
     fn test_cube_non_power_of_two_input_len() {
         let t = 1000;
         let mut rng = StdRng::seed_from_u64(0x889);

--- a/jolt-atlas-core/src/onnx_proof/ops/div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/div.rs
@@ -215,7 +215,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for DivParams<F> {
     }
 
     fn num_rounds(&self) -> usize {
-        self.computation_node.num_output_elements().log_2()
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/div.rs
@@ -504,4 +504,19 @@ mod tests {
         });
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_div_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let mut input = Tensor::<i32>::random_range(&mut rng, &[t], 1..SCALE * SCALE);
+        input.iter_mut().for_each(|v| {
+            if *v == 0 {
+                *v = 1
+            }
+        });
+        let model = div_model(t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
@@ -332,4 +332,14 @@ mod tests {
         let model = bmk_bkn_mbn_model(&mut rng, b, m, k, n);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two einsum path not fully validated yet"]
+    fn test_bmk_bkn_mbn_non_power_of_two_input_len() {
+        let (b, m, k, n) = (3, 5, 9, 7);
+        let mut rng = StdRng::seed_from_u64(0x879);
+        let input = Tensor::<i32>::random_small(&mut rng, &[b, m, k]);
+        let model = bmk_bkn_mbn_model(&mut rng, b, m, k, n);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
@@ -331,4 +331,14 @@ mod tests {
         let model = bmk_kbn_mbn_model(&mut rng, b, m, k, n);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two einsum path not fully validated yet"]
+    fn test_bmk_kbn_mbn_non_power_of_two_input_len() {
+        let (b, m, k, n) = (3, 5, 9, 7);
+        let mut rng = StdRng::seed_from_u64(0x879);
+        let input = Tensor::<i32>::random_small(&mut rng, &[b, m, k]);
+        let model = bmk_kbn_mbn_model(&mut rng, b, m, k, n);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
@@ -268,4 +268,15 @@ mod tests {
         let model = matvec_model(&mut rng, k, n);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two einsum path not fully validated yet"]
+    fn test_k_nk_n_non_power_of_two_input_len() {
+        let k = 65;
+        let n = 33;
+        let mut rng = StdRng::seed_from_u64(0x879);
+        let input = Tensor::<i32>::random_small(&mut rng, &[k]);
+        let model = matvec_model(&mut rng, k, n);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
@@ -333,4 +333,14 @@ mod tests {
         let model = mbk_bnk_bmn_model(&mut rng, m, b, k, n);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two einsum path not fully validated yet"]
+    fn test_mbk_bnk_bmn_non_power_of_two_input_len() {
+        let (m, b, k, n) = (5, 3, 9, 7);
+        let mut rng = StdRng::seed_from_u64(0x86079);
+        let input = Tensor::<i32>::random_small(&mut rng, &[m, b, k]);
+        let model = mbk_bnk_bmn_model(&mut rng, m, b, k, n);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
@@ -331,4 +331,14 @@ mod tests {
         let model = mbk_nbk_bmn_model(&mut rng, m, b, k, n);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two einsum path not fully validated yet"]
+    fn test_mbk_nbk_bmn_non_power_of_two_input_len() {
+        let (m, b, k, n) = (5, 3, 9, 7);
+        let mut rng = StdRng::seed_from_u64(0x879);
+        let input = Tensor::<i32>::random_small(&mut rng, &[m, b, k]);
+        let model = mbk_nbk_bmn_model(&mut rng, m, b, k, n);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
@@ -289,4 +289,16 @@ mod tests {
         let model = matmul_model(&mut rng, m, k, n);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two einsum path not fully validated yet"]
+    fn test_mk_kn_mn_non_power_of_two_input_len() {
+        let m = 33;
+        let k = 65;
+        let n = 17;
+        let mut rng = StdRng::seed_from_u64(0x879);
+        let input = Tensor::<i32>::random_small(&mut rng, &[m, k]);
+        let model = matmul_model(&mut rng, m, k, n);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/erf.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/erf.rs
@@ -624,4 +624,16 @@ mod tests {
         let model = erf_model(&[t]);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two erf path not fully validated yet"]
+    fn test_erf_non_power_of_two_input_len() {
+        let t = 1000;
+        const MIN_INPUT_VALUE: i32 = -(1 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1));
+        const MAX_INPUT_VALUE: i32 = 1 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1);
+        let mut rng = StdRng::seed_from_u64(0x88A);
+        let input = Tensor::random_range(&mut rng, &[t], MIN_INPUT_VALUE..MAX_INPUT_VALUE);
+        let model = erf_model(&[t]);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/gather.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/gather.rs
@@ -197,7 +197,7 @@ impl<F: JoltField> GatherParams<F> {
         let input_dict = &graph.nodes.get(&computation_node.inputs[0]).unwrap();
         let input_indices = &graph.nodes.get(&computation_node.inputs[1]).unwrap();
         let num_words = input_dict.output_dims[gather_op.axis];
-        let lookup_vars = input_indices.num_output_elements().log_2();
+        let lookup_vars = input_indices.pow2_padded_num_output_elements().log_2();
 
         let r_node_output = accumulator
             .get_node_output_opening(computation_node.idx)
@@ -579,7 +579,7 @@ fn build_stage2_verifiers<F: JoltField>(
     let indices = graph.nodes.get(&computation_node.inputs[1]).unwrap();
 
     let num_words = dict.output_dims[gather_op.axis];
-    let num_lookups = indices.num_output_elements();
+    let num_lookups = indices.pow2_padded_num_output_elements();
 
     let hb_params = ra_hamming_bool_params::<F>(
         computation_node,

--- a/jolt-atlas-core/src/onnx_proof/ops/gather.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/gather.rs
@@ -767,4 +767,16 @@ mod tests {
         let model = gather_model(&indices_dims, dict_len, word_dim);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two gather path not fully validated yet"]
+    fn test_gather_non_power_of_two_input_len() {
+        let indices_dims = vec![5, 7];
+        let dict_len = 33;
+        let word_dim = 5;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_range(&mut rng, &indices_dims, 0..dict_len as i32);
+        let model = gather_model(&indices_dims, dict_len, word_dim);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/iff.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/iff.rs
@@ -309,4 +309,14 @@ mod tests {
         let model = iff_model(&mut rng, T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two iff path not fully validated yet"]
+    fn test_iff_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x89A);
+        let input = Tensor::<i32>::random(&mut rng, &[t]);
+        let model = iff_model(&mut rng, t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/iff.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/iff.rs
@@ -71,7 +71,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for IffParams<F> {
     }
 
     fn num_rounds(&self) -> usize {
-        self.computation_node.num_output_elements().log_2()
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/input.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/input.rs
@@ -37,7 +37,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Input {
             .iter()
             .position(|&idx| idx == node.idx)
             .unwrap()]
-        .clone();
+        .padded_next_power_of_two();
         let expected_claim = MultilinearPolynomial::from(input).evaluate(&r_node_input.r);
         if expected_claim != input_claim {
             return Err(ProofVerifyError::InvalidOpeningProof(

--- a/jolt-atlas-core/src/onnx_proof/ops/input.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/input.rs
@@ -47,3 +47,29 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Input {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::onnx_proof::ops::test::unit_test_op;
+    use atlas_onnx_tracer::{
+        model::{test::ModelBuilder, Model},
+        tensor::Tensor,
+    };
+    use rand::{rngs::StdRng, SeedableRng};
+
+    fn input_only_model(input_shape: &[usize]) -> Model {
+        let mut b = ModelBuilder::new();
+        let i = b.input(input_shape.to_vec());
+        b.mark_output(i);
+        b.build()
+    }
+
+    #[test]
+    fn test_input_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x991);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = input_only_model(&[t]);
+        unit_test_op(model, &[input]);
+    }
+}

--- a/jolt-atlas-core/src/onnx_proof/ops/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mod.rs
@@ -354,7 +354,9 @@ macro_rules! impl_standard_params {
 
             fn num_rounds(&self) -> usize {
                 use joltworks::utils::math::Math;
-                self.computation_node.num_output_elements().log_2()
+                self.computation_node
+                    .pow2_padded_num_output_elements()
+                    .log_2()
             }
         }
     };

--- a/jolt-atlas-core/src/onnx_proof/ops/moveaxis.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/moveaxis.rs
@@ -227,4 +227,14 @@ mod tests {
             unit_test_op(model, &[input]);
         }
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two moveaxis path not fully validated yet"]
+    fn test_moveaxis_non_power_of_two_input_len() {
+        let mut rng = StdRng::seed_from_u64(0x778);
+        let input_shape = vec![5, 7];
+        let input = Tensor::<i32>::random_small(&mut rng, &input_shape);
+        let model = moveaxis_model(&input_shape, 0, 1);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/mul.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mul.rs
@@ -56,8 +56,8 @@ impl<F: JoltField> MulProver<F> {
         let [left_operand, right_operand] = operands[..] else {
             panic!("Expected two operands for Mul operation")
         };
-        let left_operand = MultilinearPolynomial::from(left_operand.clone());
-        let right_operand = MultilinearPolynomial::from(right_operand.clone());
+        let left_operand = MultilinearPolynomial::from(left_operand.padded_next_power_of_two());
+        let right_operand = MultilinearPolynomial::from(right_operand.padded_next_power_of_two());
         Self {
             params,
             eq_r_node_output,

--- a/jolt-atlas-core/src/onnx_proof/ops/mul.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mul.rs
@@ -218,4 +218,14 @@ mod tests {
         let model = mul_model(&mut rng, T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_mul_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = mul_model(&mut rng, t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/mul.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mul.rs
@@ -220,7 +220,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "non-power-of-two path not fully supported yet"]
     fn test_mul_non_power_of_two_input_len() {
         let t = 1000;
         let mut rng = StdRng::seed_from_u64(0x889);

--- a/jolt-atlas-core/src/onnx_proof/ops/neg.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/neg.rs
@@ -190,7 +190,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "non-power-of-two path not fully supported yet"]
     fn test_neg_non_power_of_two_input_len() {
         let t = 1000;
         let mut rng = StdRng::seed_from_u64(0x889);

--- a/jolt-atlas-core/src/onnx_proof/ops/neg.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/neg.rs
@@ -188,4 +188,14 @@ mod tests {
         let model = neg_model(T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_neg_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = neg_model(t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/neg.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/neg.rs
@@ -55,7 +55,7 @@ impl<F: JoltField> NegProver<F> {
         let [operand] = operands[..] else {
             panic!("Expected one operand for Neg operation")
         };
-        let operand = MultilinearPolynomial::from(operand.clone());
+        let operand = MultilinearPolynomial::from(operand.padded_next_power_of_two());
         Self {
             params,
             eq_r_node_output,

--- a/jolt-atlas-core/src/onnx_proof/ops/relu.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/relu.rs
@@ -144,4 +144,14 @@ mod tests {
         let model = relu_model(T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_relu_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = relu_model(t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/relu.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/relu.rs
@@ -146,7 +146,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "non-power-of-two path not fully supported yet"]
     fn test_relu_non_power_of_two_input_len() {
         let t = 1000;
         let mut rng = StdRng::seed_from_u64(0x889);

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -110,10 +110,11 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
 /// All padding cells remain zero.
 ///
 /// This lets us compare two differently padded layouts (e.g. input/output of
-/// reshape) under the same extraction order by using the same `rho(t)` sequence.
+/// reshape) under the same extraction order by using the same `rho(t)=gamma^t`
+/// sequence on both sides.
 pub(crate) fn build_reshape_selectors<F: JoltField>(
     dims: &[usize],
-    rho: impl Fn(usize) -> F,
+    gamma: F,
 ) -> Vec<F> {
     fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
         let mut coord = vec![0; dims.len()];
@@ -144,11 +145,11 @@ pub(crate) fn build_reshape_selectors<F: JoltField>(
     // For each raw linear position t, compute its padded linear position by:
     // 1) converting t to a raw coordinate
     // 2) re-encoding that coordinate under padded strides
-    // Then store rho(t) at that padded position.
+    // Then store rho(t)=gamma^t at that padded position.
     for t in 0..raw_len {
         let raw_coord = linear_to_coord(t, dims);
         let padded_index = coord_to_linear(&raw_coord, &padded_dims);
-        selector[padded_index] = rho(t);
+        selector[padded_index] = gamma_power(gamma, t);
     }
 
     selector
@@ -246,8 +247,8 @@ impl<F: JoltField> ReshapeSumcheckProver<F> {
         let input_mle = MultilinearPolynomial::from(input.padded_next_power_of_two());
         let output_mle = MultilinearPolynomial::from(output.padded_next_power_of_two());
 
-        let selector_a = build_reshape_selectors(input.dims(), |t| gamma_power(params.gamma, t));
-        let selector_b = build_reshape_selectors(output.dims(), |t| gamma_power(params.gamma, t));
+        let selector_a = build_reshape_selectors(input.dims(), params.gamma);
+        let selector_b = build_reshape_selectors(output.dims(), params.gamma);
 
         let selector_a_mle = MultilinearPolynomial::from(selector_a);
         let selector_b_mle = MultilinearPolynomial::from(selector_b);
@@ -366,12 +367,8 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReshapeSumc
             self.params.computation_node.idx,
         );
 
-        let selector_a = build_reshape_selectors(&self.params.input_raw_dims, |t| {
-            gamma_power(self.params.gamma, t)
-        });
-        let selector_b = build_reshape_selectors(&self.params.output_raw_dims, |t| {
-            gamma_power(self.params.gamma, t)
-        });
+        let selector_a = build_reshape_selectors(&self.params.input_raw_dims, self.params.gamma);
+        let selector_b = build_reshape_selectors(&self.params.output_raw_dims, self.params.gamma);
         let selector_a_claim =
             MultilinearPolynomial::from(selector_a).evaluate(&r_node_output_prime);
         let selector_b_claim =

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -158,7 +158,6 @@ pub(crate) fn build_reshape_selectors<F: JoltField>(
 ///
 /// Intended claim shape:
 /// sum_i (A(i) * Sa(i) - B(i) * Sb(i)) = 0
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct ReshapeSumcheckParams<F: JoltField> {
     /// Reshape computation node being proven.
@@ -173,7 +172,6 @@ pub struct ReshapeSumcheckParams<F: JoltField> {
     pub gamma: F,
 }
 
-#[allow(dead_code)]
 impl<F: JoltField> ReshapeSumcheckParams<F> {
     /// Build reshape sumcheck parameters from node/opening context and graph metadata.
     pub fn new(
@@ -203,7 +201,6 @@ impl<F: JoltField> ReshapeSumcheckParams<F> {
     }
 }
 
-#[allow(dead_code)]
 impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
     fn degree(&self) -> usize {
         2
@@ -225,7 +222,6 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
 }
 
 /// Prover skeleton for reshape sumcheck.
-#[allow(dead_code)]
 pub struct ReshapeSumcheckProver<F: JoltField> {
     /// Static sumcheck parameters.
     pub params: ReshapeSumcheckParams<F>,
@@ -239,7 +235,6 @@ pub struct ReshapeSumcheckProver<F: JoltField> {
     pub selector_b_mle: MultilinearPolynomial<F>,
 }
 
-#[allow(dead_code)]
 impl<F: JoltField> ReshapeSumcheckProver<F> {
     /// Initialize reshape prover state from trace tensors and prepared parameters.
     pub fn initialize(trace: &Trace, params: ReshapeSumcheckParams<F>) -> Self {
@@ -270,7 +265,6 @@ impl<F: JoltField> ReshapeSumcheckProver<F> {
     }
 }
 
-#[allow(dead_code)]
 impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumcheckProver<F> {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         &self.params
@@ -333,13 +327,11 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumche
 }
 
 /// Verifier skeleton for reshape sumcheck.
-#[allow(dead_code)]
 pub struct ReshapeSumcheckVerifier<F: JoltField> {
     /// Static sumcheck parameters.
     pub params: ReshapeSumcheckParams<F>,
 }
 
-#[allow(dead_code)]
 impl<F: JoltField> ReshapeSumcheckVerifier<F> {
     /// Build the reshape sumcheck verifier from node/opening context and graph metadata.
     pub fn new(
@@ -353,7 +345,6 @@ impl<F: JoltField> ReshapeSumcheckVerifier<F> {
     }
 }
 
-#[allow(dead_code)]
 impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReshapeSumcheckVerifier<F> {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         &self.params

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -1,17 +1,49 @@
+//! Reshape proof (selector-based equality over padded layouts).
+//!
+//! Proof target:
+//! `sum_i (A(i) * Sa(i) - B(i) * Sb(i)) = 0`
+//! which is equivalent to:
+//! `sum_i A(i) * Sa(i) = sum_i B(i) * Sb(i)`.
+//!
+//! Where:
+//! - `A(i)`: input padded MLE values
+//! - `B(i)`: output padded MLE values
+//! - `Sa(i), Sb(i)`: selector MLEs that place the same coefficient `rho(t)=gamma^t`
+//!   on the padded position corresponding to raw element `t`, and `0` on padding cells.
+//!
+//! This aligns input/output raw elements under different padded layouts and checks
+//! reshape consistency via one sumcheck instance.
+
 use crate::onnx_proof::{
     ops::{OperatorProofTrait, Prover, Verifier},
-    ProofId,
+    ProofId, ProofType,
 };
-use atlas_onnx_tracer::{node::ComputationNode, ops::Reshape};
+use atlas_onnx_tracer::{
+    model::{trace::{LayerData, Trace}, ComputationGraph},
+    node::ComputationNode,
+    ops::Reshape,
+};
 use common::VirtualPolynomial;
 use joltworks::{
     field::JoltField,
-    poly::opening_proof::{
-        OpeningAccumulator, ProverOpeningAccumulator, SumcheckId, VerifierOpeningAccumulator,
+    poly::{
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
+        unipoly::UniPoly,
+        opening_proof::{
+            OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+            VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
+        },
     },
-    subprotocols::sumcheck::SumcheckInstanceProof,
+    subprotocols::{
+        sumcheck::Sumcheck,
+        sumcheck::SumcheckInstanceProof,
+        sumcheck_prover::SumcheckInstanceProver,
+        sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
+    },
     transcripts::Transcript,
-    utils::errors::ProofVerifyError,
+    utils::{errors::ProofVerifyError, math::Math},
 };
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
@@ -21,10 +53,22 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
         node: &ComputationNode,
         prover: &mut Prover<F, T>,
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
-        let params = ReshapeParams::<F>::new(node.clone(), &prover.accumulator);
-        let reshape_prover = ReshapeProver::initialize(params);
-        reshape_prover.prove(&mut prover.accumulator, &mut prover.transcript);
-        vec![]
+        // TODO(soundness): Audit challenge derivation/order to ensure this gamma is
+        // transcript-bound to all required prior messages before selector construction.
+        let gamma = prover.transcript.challenge_scalar_optimized::<F>();
+        let params = ReshapeSumcheckParams::<F>::new(
+            node.clone(),
+            &prover.accumulator,
+            &prover.preprocessing.model.graph,
+            gamma.into(),
+        );
+        let mut prover_sumcheck = ReshapeSumcheckProver::initialize(&prover.trace, params);
+        let (proof, _) = Sumcheck::prove(
+            &mut prover_sumcheck,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+        vec![(ProofId(node.idx, ProofType::Execution), proof)]
     }
 
     #[tracing::instrument(skip_all, name = "Reshape::verify")]
@@ -33,124 +77,341 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
-        let reshape_verifier = ReshapeVerifier::new(node.clone(), &verifier.accumulator);
-        reshape_verifier.verify(&mut verifier.accumulator, &mut verifier.transcript)
-    }
-}
-
-/// Parameters for proving reshape operations.
-///
-/// Reshape changes tensor dimensions without modifying data layout in memory.
-#[derive(Clone)]
-pub struct ReshapeParams<F: JoltField> {
-    r_output: Vec<F::Challenge>,
-    computation_node: ComputationNode,
-}
-
-impl<F: JoltField> ReshapeParams<F> {
-    /// Create new reshape parameters from a computation node and opening accumulator.
-    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
-        let r_output = accumulator
-            .get_node_output_opening(computation_node.idx)
-            .0
-            .r;
-        Self {
-            r_output,
-            computation_node,
-        }
-    }
-}
-
-/// Prover state for reshape operations.
-///
-/// Since reshape doesn't change data, proving simply involves showing that input and output
-/// evaluate to the same claim at the same opening point.
-pub struct ReshapeProver<F: JoltField> {
-    params: ReshapeParams<F>,
-}
-
-impl<F: JoltField> ReshapeProver<F> {
-    /// Initialize the prover with parameters.
-    pub fn initialize(params: ReshapeParams<F>) -> Self {
-        Self { params }
-    }
-
-    /// Generate the proof for the reshape operation.
-    pub fn prove(
-        &self,
-        accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut impl Transcript,
-    ) {
-        // For reshape, the opening point is identical to the output's opening point
-        // since the multilinear polynomial representation is the same.
-        // Also, claim_A == claim_O since reshape doesn't change the data.
-        let claim_O = accumulator
-            .get_node_output_opening(self.params.computation_node.idx)
-            .1;
-
-        accumulator.append_virtual(
-            transcript,
-            VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[0]),
-            SumcheckId::NodeExecution(self.params.computation_node.idx),
-            self.params.r_output.clone().into(),
-            claim_O,
+        // TODO(soundness): Keep gamma derivation order exactly aligned with prover
+        // and verify transcript binding assumptions for selector randomization.
+        let gamma = verifier.transcript.challenge_scalar_optimized::<F>();
+        let proof = verifier
+            .proofs
+            .get(&ProofId(node.idx, ProofType::Execution))
+            .ok_or(ProofVerifyError::MissingProof(node.idx))?;
+        let verifier_sumcheck = ReshapeSumcheckVerifier::new(
+            node.clone(),
+            &verifier.accumulator,
+            &verifier.preprocessing.model.graph,
+            gamma.into(),
         );
-    }
-}
-
-/// Verifier for reshape operations.
-///
-/// Verifies that input and output claims match for the reshape operation.
-pub struct ReshapeVerifier<F: JoltField> {
-    params: ReshapeParams<F>,
-}
-
-impl<F: JoltField> ReshapeVerifier<F> {
-    /// Create a new verifier for the reshape operation.
-    pub fn new(
-        computation_node: ComputationNode,
-        accumulator: &VerifierOpeningAccumulator<F>,
-    ) -> Self {
-        let params = ReshapeParams::new(computation_node, accumulator);
-        Self { params }
-    }
-
-    /// Verify the reshape operation.
-    pub fn verify(
-        &self,
-        accumulator: &mut VerifierOpeningAccumulator<F>,
-        transcript: &mut impl Transcript,
-    ) -> Result<(), ProofVerifyError> {
-        // Cache the opening point for the input node
-        // For reshape, the opening point is identical to the output's opening point
-        accumulator.append_virtual(
-            transcript,
-            VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[0]),
-            SumcheckId::NodeExecution(self.params.computation_node.idx),
-            self.params.r_output.clone().into(),
-        );
-
-        // Retrieve the claim for the input node
-        let operand_claim = accumulator.get_node_output_claim(
-            self.params.computation_node.inputs[0],
-            self.params.computation_node.idx,
-        );
-
-        // For reshape, the input claim should equal the output claim
-        let claim_O = accumulator
-            .get_node_output_opening(self.params.computation_node.idx)
-            .1;
-
-        if operand_claim != claim_O {
-            return Err(ProofVerifyError::InvalidOpeningProof(
-                "Reshape claim does not match expected claim".to_string(),
-            ));
-        }
-
+        Sumcheck::verify(
+            proof,
+            &verifier_sumcheck,
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+        )?;
         Ok(())
     }
 }
 
+/// Build a reshape selector vector over the padded tensor domain.
+///
+/// For each raw (unpadded) linear position `t`, this places `rho(t)` at the
+/// corresponding padded linear index that keeps the same raw coordinate.
+/// All padding cells remain zero.
+///
+/// This lets us compare two differently padded layouts (e.g. input/output of
+/// reshape) under the same extraction order by using the same `rho(t)` sequence.
+pub(crate) fn build_reshape_selectors<F: JoltField>(
+    dims: &[usize],
+    rho: impl Fn(usize) -> F,
+) -> Vec<F> {
+    fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
+        let mut coord = vec![0; dims.len()];
+        for axis in (0..dims.len()).rev() {
+            coord[axis] = index % dims[axis];
+            index /= dims[axis];
+        }
+        coord
+    }
+
+    fn coord_to_linear(coord: &[usize], dims: &[usize]) -> usize {
+        let mut index = 0usize;
+        let mut stride = 1usize;
+        for axis in (0..dims.len()).rev() {
+            index += coord[axis] * stride;
+            stride *= dims[axis];
+        }
+        index
+    }
+
+    let raw_len: usize = dims.iter().product();
+    let padded_dims: Vec<usize> = dims.iter().map(|d| d.next_power_of_two()).collect();
+    let padded_len: usize = padded_dims.iter().product();
+
+    // Selector values are zero on padding cells by default.
+    let mut selector = vec![F::zero(); padded_len];
+
+    // For each raw linear position t, compute its padded linear position by:
+    // 1) converting t to a raw coordinate
+    // 2) re-encoding that coordinate under padded strides
+    // Then store rho(t) at that padded position.
+    for t in 0..raw_len {
+        let raw_coord = linear_to_coord(t, dims);
+        let padded_index = coord_to_linear(&raw_coord, &padded_dims);
+        selector[padded_index] = rho(t);
+    }
+
+    selector
+}
+
+/// Parameters for the upcoming reshape sumcheck.
+///
+/// Intended claim shape:
+/// sum_i (A(i) * Sa(i) - B(i) * Sb(i)) = 0
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct ReshapeSumcheckParams<F: JoltField> {
+    /// Reshape computation node being proven.
+    pub computation_node: ComputationNode,
+    /// Output opening point challenge vector for this node.
+    pub r_output: Vec<F::Challenge>,
+    /// Original (unpadded) input shape used to build selector `Sa`.
+    pub input_raw_dims: Vec<usize>,
+    /// Original (unpadded) output shape used to build selector `Sb`.
+    pub output_raw_dims: Vec<usize>,
+    /// Transcript-derived randomizer used in selector coefficients (`gamma^t`).
+    pub gamma: F,
+}
+
+#[allow(dead_code)]
+impl<F: JoltField> ReshapeSumcheckParams<F> {
+    /// Build reshape sumcheck parameters from node/opening context and graph metadata.
+    pub fn new(
+        computation_node: ComputationNode,
+        accumulator: &dyn OpeningAccumulator<F>,
+        graph: &ComputationGraph,
+        gamma: F,
+    ) -> Self {
+        let r_output = accumulator.get_node_output_opening(computation_node.idx).0.r;
+        let input_raw_dims = graph
+            .nodes
+            .get(&computation_node.inputs[0])
+            .expect("Reshape node should have one input")
+            .output_dims
+            .clone();
+        let output_raw_dims = computation_node.output_dims.clone();
+        Self {
+            computation_node,
+            r_output,
+            input_raw_dims,
+            output_raw_dims,
+            gamma,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
+    fn degree(&self) -> usize {
+        2
+    }
+
+    fn input_claim(&self, _accumulator: &dyn OpeningAccumulator<F>) -> F {
+        F::zero()
+    }
+
+    fn normalize_opening_point(
+        &self,
+        challenges: &[F::Challenge],
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.computation_node.num_output_elements().log_2()
+    }
+}
+
+/// Prover skeleton for reshape sumcheck.
+#[allow(dead_code)]
+pub struct ReshapeSumcheckProver<F: JoltField> {
+    /// Static sumcheck parameters.
+    pub params: ReshapeSumcheckParams<F>,
+    /// Input polynomial (padded MLE).
+    pub input_mle: MultilinearPolynomial<F>,
+    /// Output polynomial (padded MLE).
+    pub output_mle: MultilinearPolynomial<F>,
+    /// Selector polynomial for input layout.
+    pub selector_a_mle: MultilinearPolynomial<F>,
+    /// Selector polynomial for output layout.
+    pub selector_b_mle: MultilinearPolynomial<F>,
+}
+
+#[allow(dead_code)]
+impl<F: JoltField> ReshapeSumcheckProver<F> {
+    /// Initialize reshape prover state from trace tensors and prepared parameters.
+    pub fn initialize(trace: &Trace, params: ReshapeSumcheckParams<F>) -> Self {
+        let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
+        let [input] = operands[..] else {
+            panic!("Expected one operand for Reshape operation")
+        };
+
+        let input_mle = MultilinearPolynomial::from(input.padded_next_power_of_two());
+        let output_mle = MultilinearPolynomial::from(output.padded_next_power_of_two());
+
+        let selector_a = build_reshape_selectors(input.dims(), |t| gamma_power(params.gamma, t));
+        let selector_b = build_reshape_selectors(output.dims(), |t| gamma_power(params.gamma, t));
+
+        let selector_a_mle = MultilinearPolynomial::from(selector_a);
+        let selector_b_mle = MultilinearPolynomial::from(selector_b);
+        assert_eq!(input_mle.len(), output_mle.len());
+        assert_eq!(input_mle.len(), selector_a_mle.len());
+        assert_eq!(output_mle.len(), selector_b_mle.len());
+
+        Self {
+            params,
+            input_mle,
+            output_mle,
+            selector_a_mle,
+            selector_b_mle,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumcheckProver<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        const DEGREE_BOUND: usize = 2;
+        let Self {
+            input_mle,
+            output_mle,
+            selector_a_mle,
+            selector_b_mle,
+            ..
+        } = self;
+        let half_poly_len = input_mle.len() / 2;
+        let mut uni_poly_evals = [F::zero(); 2];
+        for i in 0..half_poly_len {
+            let a_evals = input_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+            let b_evals = output_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+            let sa_evals = selector_a_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+            let sb_evals = selector_b_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+
+            uni_poly_evals[0] += a_evals[0] * sa_evals[0] - b_evals[0] * sb_evals[0];
+            uni_poly_evals[1] += a_evals[1] * sa_evals[1] - b_evals[1] * sb_evals[1];
+        }
+        UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        self.input_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.output_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.selector_a_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.selector_b_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point.clone(),
+            self.input_mle.final_sumcheck_claim(),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point,
+            self.output_mle.final_sumcheck_claim(),
+        );
+    }
+}
+
+/// Verifier skeleton for reshape sumcheck.
+#[allow(dead_code)]
+pub struct ReshapeSumcheckVerifier<F: JoltField> {
+    /// Static sumcheck parameters.
+    pub params: ReshapeSumcheckParams<F>,
+}
+
+#[allow(dead_code)]
+impl<F: JoltField> ReshapeSumcheckVerifier<F> {
+    /// Build the reshape sumcheck verifier from node/opening context and graph metadata.
+    pub fn new(
+        computation_node: ComputationNode,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        graph: &ComputationGraph,
+        gamma: F,
+    ) -> Self {
+        let params = ReshapeSumcheckParams::new(computation_node, accumulator, graph, gamma);
+        Self { params }
+    }
+}
+
+#[allow(dead_code)]
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReshapeSumcheckVerifier<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(
+        &self,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) -> F {
+        let r_node_output_prime = self.params.normalize_opening_point(sumcheck_challenges).r;
+
+        let input_claim = accumulator.get_node_output_claim(
+            self.params.computation_node.inputs[0],
+            self.params.computation_node.idx,
+        );
+        let output_claim = accumulator.get_node_output_claim(
+            self.params.computation_node.idx,
+            self.params.computation_node.idx,
+        );
+
+        let selector_a =
+            build_reshape_selectors(&self.params.input_raw_dims, |t| gamma_power(self.params.gamma, t));
+        let selector_b =
+            build_reshape_selectors(&self.params.output_raw_dims, |t| gamma_power(self.params.gamma, t));
+        let selector_a_claim =
+            MultilinearPolynomial::from(selector_a).evaluate(&r_node_output_prime);
+        let selector_b_claim =
+            MultilinearPolynomial::from(selector_b).evaluate(&r_node_output_prime);
+
+        input_claim * selector_a_claim - output_claim * selector_b_claim
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point.clone(),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point,
+        );
+    }
+}
+
+fn gamma_power<F: JoltField>(gamma: F, exponent: usize) -> F {
+    // TODO: This is a naive O(exponent) implementation. Replace with fast exponentiation
+    // (square-and-multiply) or incremental power caching when selector construction is optimized.
+    let mut acc = F::one();
+    for _ in 0..exponent {
+        acc *= gamma;
+    }
+    acc
+}
+ 
 #[cfg(test)]
 mod tests {
     use crate::onnx_proof::ops::test::unit_test_op;

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -187,7 +187,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO: non-power-of-two reshape path not fully validated yet"]
     fn test_reshape_non_power_of_two_input_len() {
         let mut rng = StdRng::seed_from_u64(0x99A);
         let input_shape = vec![10, 10];

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -19,7 +19,10 @@ use crate::onnx_proof::{
     ProofId, ProofType,
 };
 use atlas_onnx_tracer::{
-    model::{trace::{LayerData, Trace}, ComputationGraph},
+    model::{
+        trace::{LayerData, Trace},
+        ComputationGraph,
+    },
     node::ComputationNode,
     ops::Reshape,
 };
@@ -30,11 +33,11 @@ use joltworks::{
         multilinear_polynomial::{
             BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
         },
-        unipoly::UniPoly,
         opening_proof::{
             OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
             VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
         },
+        unipoly::UniPoly,
     },
     subprotocols::{
         sumcheck::Sumcheck,
@@ -179,7 +182,10 @@ impl<F: JoltField> ReshapeSumcheckParams<F> {
         graph: &ComputationGraph,
         gamma: F,
     ) -> Self {
-        let r_output = accumulator.get_node_output_opening(computation_node.idx).0.r;
+        let r_output = accumulator
+            .get_node_output_opening(computation_node.idx)
+            .0
+            .r;
         let input_raw_dims = graph
             .nodes
             .get(&computation_node.inputs[0])
@@ -207,15 +213,14 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
         F::zero()
     }
 
-    fn normalize_opening_point(
-        &self,
-        challenges: &[F::Challenge],
-    ) -> OpeningPoint<BIG_ENDIAN, F> {
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
         OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
     }
 
     fn num_rounds(&self) -> usize {
-        self.computation_node.num_output_elements().log_2()
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
     }
 }
 
@@ -297,8 +302,10 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumche
     fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
         self.input_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
         self.output_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.selector_a_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.selector_b_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.selector_a_mle
+            .bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.selector_b_mle
+            .bind_parallel(r_j, BindingOrder::LowToHigh);
     }
 
     fn cache_openings(
@@ -368,10 +375,12 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReshapeSumc
             self.params.computation_node.idx,
         );
 
-        let selector_a =
-            build_reshape_selectors(&self.params.input_raw_dims, |t| gamma_power(self.params.gamma, t));
-        let selector_b =
-            build_reshape_selectors(&self.params.output_raw_dims, |t| gamma_power(self.params.gamma, t));
+        let selector_a = build_reshape_selectors(&self.params.input_raw_dims, |t| {
+            gamma_power(self.params.gamma, t)
+        });
+        let selector_b = build_reshape_selectors(&self.params.output_raw_dims, |t| {
+            gamma_power(self.params.gamma, t)
+        });
         let selector_a_claim =
             MultilinearPolynomial::from(selector_a).evaluate(&r_node_output_prime);
         let selector_b_claim =
@@ -411,7 +420,7 @@ fn gamma_power<F: JoltField>(gamma: F, exponent: usize) -> F {
     }
     acc
 }
- 
+
 #[cfg(test)]
 mod tests {
     use crate::onnx_proof::ops::test::unit_test_op;

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -185,4 +185,15 @@ mod tests {
             unit_test_op(model, &[input]);
         }
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two reshape path not fully validated yet"]
+    fn test_reshape_non_power_of_two_input_len() {
+        let mut rng = StdRng::seed_from_u64(0x99A);
+        let input_shape = vec![10, 10];
+        let output_shape = vec![20, 5];
+        let input = Tensor::<i32>::random_small(&mut rng, &input_shape);
+        let model = reshape_model(&input_shape, &output_shape);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -112,10 +112,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
 /// This lets us compare two differently padded layouts (e.g. input/output of
 /// reshape) under the same extraction order by using the same `rho(t)=gamma^t`
 /// sequence on both sides.
-pub(crate) fn build_reshape_selectors<F: JoltField>(
-    dims: &[usize],
-    gamma: F,
-) -> Vec<F> {
+pub(crate) fn build_reshape_selectors<F: JoltField>(dims: &[usize], gamma: F) -> Vec<F> {
     fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
         let mut coord = vec![0; dims.len()];
         for axis in (0..dims.len()).rev() {

--- a/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
@@ -603,4 +603,14 @@ mod tests {
         let model = rsqrt_model(T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_rsqrt_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_range(&mut rng, &[t], 1..Q_SQUARE);
+        let model = rsqrt_model(t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
@@ -285,7 +285,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RsqrtParams<F> {
     }
 
     fn num_rounds(&self) -> usize {
-        self.computation_node.num_output_elements().log_2()
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
@@ -318,4 +318,14 @@ mod tests {
         let model = scalar_const_div_model(T, 128);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_scalar_const_div_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = scalar_const_div_model(t, 128);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
@@ -124,7 +124,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivParams<F> {
     }
 
     fn num_rounds(&self) -> usize {
-        self.computation_node.num_output_elements().log_2()
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sin.rs
@@ -625,4 +625,14 @@ mod tests {
         let model = sin_model(&[8]);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two sin path not fully validated yet"]
+    fn test_sin_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0xC06);
+        let input = Tensor::random_range(&mut rng, &[t], -50000..50000);
+        let model = sin_model(&[t]);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_axes/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_axes/mod.rs
@@ -793,4 +793,14 @@ mod tests {
         let model = softmax_axes_model(&input_shape, 2);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two softmax_axes path not fully validated yet"]
+    fn test_softmax_axes_non_power_of_two_input_len() {
+        let input_shape = vec![3, 65, 33];
+        let mut rng = StdRng::seed_from_u64(0x859);
+        let input = Tensor::<i32>::random_small(&mut rng, &input_shape);
+        let model = softmax_axes_model(&input_shape, 2);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_axes/softmax/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_axes/softmax/mod.rs
@@ -308,4 +308,43 @@ mod tests {
             "Sum should be approximately 128, got {sum}"
         );
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two softmax subprotocol path not fully validated yet"]
+    fn test_softmax_non_power_of_two_input_len() {
+        let n_elems: usize = 1000;
+        let n: usize = n_elems.next_power_of_two().ilog2() as usize;
+
+        let mut rng = StdRng::seed_from_u64(0x100082);
+        let input = Tensor::random_small(&mut rng, &[n_elems]);
+        let (_, trace) = softmax_fixed_128::<true>(&input);
+        let trace = trace.unwrap();
+
+        let prover_transcript = &mut Blake2bTranscript::new(&[]);
+        let mut prover_opening_accumulator: ProverOpeningAccumulator<Fr> =
+            ProverOpeningAccumulator::new();
+        let verifier_transcript = &mut Blake2bTranscript::new(&[]);
+        let _r_feature_output: Vec<<Fr as JoltField>::Challenge> =
+            prover_transcript.challenge_vector_optimized::<Fr>(n);
+        let r_feature_output: Vec<<Fr as JoltField>::Challenge> =
+            verifier_transcript.challenge_vector_optimized::<Fr>(n);
+
+        let softmax_index = SoftmaxIndex {
+            node_idx: 0,
+            feature_idx: 0,
+        };
+
+        let div_claim =
+            MultilinearPolynomial::from(trace.softmax_q.clone()).evaluate(&r_feature_output);
+        prover_opening_accumulator.append_virtual(
+            prover_transcript,
+            VirtualPolynomial::SoftmaxFeatureOutput(
+                softmax_index.node_idx,
+                softmax_index.feature_idx,
+            ),
+            SumcheckId::NodeExecution(softmax_index.node_idx),
+            r_feature_output.clone().into(),
+            div_claim,
+        );
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_axes/softmax/scalar_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_axes/softmax/scalar_div.rs
@@ -375,4 +375,92 @@ mod tests {
         let r_sumcheck_verif = res.unwrap();
         assert_eq!(r_sumcheck, r_sumcheck_verif);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two softmax scalar_div path not fully validated yet"]
+    fn test_div_non_power_of_two_input_len() {
+        let n_elems: usize = 1000;
+        let n: usize = n_elems.next_power_of_two().ilog2() as usize;
+
+        let mut rng = StdRng::seed_from_u64(0x100082);
+        let input = Tensor::random_small(&mut rng, &[n_elems]);
+        let (_, trace) = softmax_fixed_128::<true>(&input);
+        let trace = trace.unwrap();
+
+        let prover_transcript = &mut Blake2bTranscript::new(&[]);
+        let mut prover_opening_accumulator: ProverOpeningAccumulator<Fr> =
+            ProverOpeningAccumulator::new();
+        let verifier_transcript = &mut Blake2bTranscript::new(&[]);
+        let mut verifier_opening_accumulator: VerifierOpeningAccumulator<Fr> =
+            VerifierOpeningAccumulator::new();
+
+        let _r_feature_output: Vec<<Fr as JoltField>::Challenge> =
+            prover_transcript.challenge_vector_optimized::<Fr>(n);
+        let r_feature_output: Vec<<Fr as JoltField>::Challenge> =
+            verifier_transcript.challenge_vector_optimized::<Fr>(n);
+
+        let softmax_index = SoftmaxIndex {
+            node_idx: 0,
+            feature_idx: 0,
+        };
+
+        let div_claim =
+            MultilinearPolynomial::from(trace.softmax_q.clone()).evaluate(&r_feature_output);
+        prover_opening_accumulator.append_virtual(
+            prover_transcript,
+            VirtualPolynomial::SoftmaxFeatureOutput(
+                softmax_index.node_idx,
+                softmax_index.feature_idx,
+            ),
+            SumcheckId::NodeExecution(softmax_index.node_idx),
+            r_feature_output.clone().into(),
+            div_claim,
+        );
+        prover_opening_accumulator.append_virtual(
+            prover_transcript,
+            VirtualPolynomial::SoftmaxSumOutput(softmax_index.node_idx, softmax_index.feature_idx),
+            SumcheckId::NodeExecution(softmax_index.node_idx),
+            vec![].into(),
+            Fr::from_i32(trace.exp_sum_q),
+        );
+
+        let params: DivParams<Fr> = DivParams::new(softmax_index, &prover_opening_accumulator);
+        let mut prover_sumcheck = DivProver::initialize(&trace, params);
+        let (proof, _r_sumcheck) = Sumcheck::prove(
+            &mut prover_sumcheck,
+            &mut prover_opening_accumulator,
+            prover_transcript,
+        );
+
+        for (key, (_, value)) in &prover_opening_accumulator.openings {
+            let empty_point = OpeningPoint::<BIG_ENDIAN, Fr>::new(vec![]);
+            verifier_opening_accumulator
+                .openings
+                .insert(*key, (empty_point, *value));
+        }
+
+        verifier_opening_accumulator.append_virtual(
+            verifier_transcript,
+            VirtualPolynomial::SoftmaxFeatureOutput(
+                softmax_index.node_idx,
+                softmax_index.feature_idx,
+            ),
+            SumcheckId::NodeExecution(softmax_index.node_idx),
+            r_feature_output.into(),
+        );
+        verifier_opening_accumulator.append_virtual(
+            verifier_transcript,
+            VirtualPolynomial::SoftmaxSumOutput(softmax_index.node_idx, softmax_index.feature_idx),
+            SumcheckId::NodeExecution(softmax_index.node_idx),
+            vec![].into(),
+        );
+
+        let verifier_sumcheck = DivVerifier::new(softmax_index, &verifier_opening_accumulator);
+        let _ = Sumcheck::verify(
+            &proof,
+            &verifier_sumcheck,
+            &mut verifier_opening_accumulator,
+            verifier_transcript,
+        );
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -55,7 +55,7 @@ impl<F: JoltField> SquareProver<F> {
         let [operand] = operands[..] else {
             panic!("Expected one operand for Square operation")
         };
-        let operand = MultilinearPolynomial::from(operand.clone());
+        let operand = MultilinearPolynomial::from(operand.padded_next_power_of_two());
         Self {
             params,
             eq_r_node_output,
@@ -191,7 +191,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "non-power-of-two path not fully supported yet"]
     fn test_square_non_power_of_two_input_len() {
         let t = 1000;
         let mut rng = StdRng::seed_from_u64(0x889);

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -189,4 +189,14 @@ mod tests {
         let model = square_model(T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_square_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = square_model(t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sub.rs
@@ -56,8 +56,8 @@ impl<F: JoltField> SubProver<F> {
         let [left_operand, right_operand] = operands[..] else {
             panic!("Expected two operands for Sub operation")
         };
-        let left_operand = MultilinearPolynomial::from(left_operand.clone());
-        let right_operand = MultilinearPolynomial::from(right_operand.clone());
+        let left_operand = MultilinearPolynomial::from(left_operand.padded_next_power_of_two());
+        let right_operand = MultilinearPolynomial::from(right_operand.padded_next_power_of_two());
         Self {
             params,
             eq_r_node_output,

--- a/jolt-atlas-core/src/onnx_proof/ops/sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sub.rs
@@ -214,4 +214,13 @@ mod tests {
         let model = sub_model(&mut rng, T);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    fn test_sub_non_power_of_two_input_len() {
+        let t = 1000;
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = sub_model(&mut rng, t);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
@@ -280,4 +280,15 @@ mod tests {
     fn test_sum_axis_1_1d() {
         test_sum_axis_generic(4, 0, 0x844, 1);
     }
+
+    #[test]
+    #[ignore = "TODO: non-power-of-two sum(axis) path not fully validated yet"]
+    fn test_sum_axis_non_power_of_two_input_len() {
+        let mut rng = StdRng::seed_from_u64(0x845);
+        let m = 33;
+        let n = 65;
+        let input = Tensor::<i32>::random_small(&mut rng, &[m, n]);
+        let model = sum_model::<1>(m, n);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
@@ -652,4 +652,16 @@ mod tests {
         let model = tanh_model(&[T]);
         unit_test_op(model, &[input]);
     }
+
+    #[test]
+    #[ignore = "non-power-of-two path not fully supported yet"]
+    fn test_tanh_non_power_of_two_input_len() {
+        let t = 1000;
+        const MIN_INPUT_VALUE: i32 = -(1 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1));
+        const MAX_INPUT_VALUE: i32 = 1 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1);
+        let mut rng = StdRng::seed_from_u64(0x889);
+        let input = Tensor::random_range(&mut rng, &[t], MIN_INPUT_VALUE..MAX_INPUT_VALUE);
+        let model = tanh_model(&[t]);
+        unit_test_op(model, &[input]);
+    }
 }

--- a/jolt-atlas-core/src/onnx_proof/prover.rs
+++ b/jolt-atlas-core/src/onnx_proof/prover.rs
@@ -100,7 +100,7 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
         // Sample challenge from verifier
         let r_node_output = prover
             .transcript
-            .challenge_vector_optimized::<F>(output.len().log_2());
+            .challenge_vector_optimized::<F>(output.len().ceil_log_2());
 
         // Evaluate output polynomial at r_node_output
         let output_claim = MultilinearPolynomial::from(output.clone()).evaluate(&r_node_output);

--- a/jolt-atlas-core/src/onnx_proof/prover.rs
+++ b/jolt-atlas-core/src/onnx_proof/prover.rs
@@ -97,10 +97,13 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
             output,
         } = Trace::layer_data(&prover.trace, output_computation_node);
 
+        // Pad output tensor to power of 2 with 0 for MLE constructions
+        let output = output.padded_next_power_of_two();
+
         // Sample challenge from verifier
         let r_node_output = prover
             .transcript
-            .challenge_vector_optimized::<F>(output.len().ceil_log_2());
+            .challenge_vector_optimized::<F>(output.len().log_2());
 
         // Evaluate output polynomial at r_node_output
         let output_claim = MultilinearPolynomial::from(output.clone()).evaluate(&r_node_output);

--- a/jolt-atlas-core/src/onnx_proof/range_checking/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/range_checking/mod.rs
@@ -239,7 +239,7 @@ impl<H: RangeCheckingOperandsTrait> RangeCheckEncoding<H> {
     pub fn new(computation_node: &ComputationNode) -> Self {
         Self {
             operands: H::new(computation_node),
-            log_t: computation_node.num_output_elements().log_2(),
+            log_t: computation_node.pow2_padded_num_output_elements().log_2(),
         }
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/verifier.rs
+++ b/jolt-atlas-core/src/onnx_proof/verifier.rs
@@ -91,7 +91,7 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
             .transcript
             .challenge_vector_optimized::<F>(output_computation_node.num_output_elements().log_2());
         let expected_output_claim =
-            MultilinearPolynomial::from(io.outputs[0].clone()).evaluate(&r_node_output);
+            MultilinearPolynomial::from(io.outputs[0].padded_next_power_of_two()).evaluate(&r_node_output);
 
         // append_virtual now handles both transcript append and opening point update.
         // The claim was loaded from opening_claims in populate_accumulator.

--- a/jolt-atlas-core/src/onnx_proof/verifier.rs
+++ b/jolt-atlas-core/src/onnx_proof/verifier.rs
@@ -91,7 +91,8 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
             .transcript
             .challenge_vector_optimized::<F>(output_computation_node.num_output_elements().log_2());
         let expected_output_claim =
-            MultilinearPolynomial::from(io.outputs[0].padded_next_power_of_two()).evaluate(&r_node_output);
+            MultilinearPolynomial::from(io.outputs[0].padded_next_power_of_two())
+                .evaluate(&r_node_output);
 
         // append_virtual now handles both transcript append and opening point update.
         // The claim was loaded from opening_claims in populate_accumulator.

--- a/jolt-atlas-core/src/onnx_proof/verifier.rs
+++ b/jolt-atlas-core/src/onnx_proof/verifier.rs
@@ -87,9 +87,11 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
     ) -> Result<(), ProofVerifyError> {
         let output_index = model.outputs()[0];
         let output_computation_node = &model[output_index];
-        let r_node_output = verifier
-            .transcript
-            .challenge_vector_optimized::<F>(output_computation_node.num_output_elements().log_2());
+        let r_node_output = verifier.transcript.challenge_vector_optimized::<F>(
+            output_computation_node
+                .pow2_padded_num_output_elements()
+                .log_2(),
+        );
         let expected_output_claim =
             MultilinearPolynomial::from(io.outputs[0].padded_next_power_of_two())
                 .evaluate(&r_node_output);

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -182,10 +182,14 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 let computation_node = &model.graph.nodes[node_idx];
                 let layer_data = Trace::layer_data(trace, computation_node);
                 let is_interleaved_operands = computation_node.is_interleaved_operands();
-                let lookup_indices = compute_lookup_indices_from_operands(
-                    &layer_data.operands,
-                    is_interleaved_operands,
-                );
+                let padded_operands: Vec<_> = layer_data
+                    .operands
+                    .iter()
+                    .map(|tensor| tensor.padded_next_power_of_two())
+                    .collect();
+                let operand_refs: Vec<_> = padded_operands.iter().collect();
+                let lookup_indices =
+                    compute_lookup_indices_from_operands(&operand_refs, is_interleaved_operands);
                 build_one_hot_rad_witness(&lookup_indices, *d)
             }
             CommittedPolynomial::DivNodeQuotient(node_idx) => {

--- a/jolt-atlas-core/src/utils/mod.rs
+++ b/jolt-atlas-core/src/utils/mod.rs
@@ -54,16 +54,16 @@ pub fn compute_lookup_indices_from_operands(
 
         let left_operand = operand_tensors[0];
         let right_operand = operand_tensors[1];
- 
-         debug_assert!(
-             left_operand.dims().iter().all(|d| d.is_power_of_two()),
-             "left operand dims must all be power-of-two, got {:?}",
-             left_operand.dims()
-         );
-         debug_assert!(
-             right_operand.dims().iter().all(|d| d.is_power_of_two()),
-             "right operand dims must all be power-of-two, got {:?}",
-             right_operand.dims()
+
+        debug_assert!(
+            left_operand.dims().iter().all(|d| d.is_power_of_two()),
+            "left operand dims must all be power-of-two, got {:?}",
+            left_operand.dims()
+        );
+        debug_assert!(
+            right_operand.dims().iter().all(|d| d.is_power_of_two()),
+            "right operand dims must all be power-of-two, got {:?}",
+            right_operand.dims()
         );
 
         // Validate that both tensors have the same length
@@ -98,11 +98,11 @@ pub fn compute_lookup_indices_from_operands(
         );
 
         let operand = operand_tensors[0];
- 
-         debug_assert!(
-             operand.dims().iter().all(|d| d.is_power_of_two()),
-             "operand dims must all be power-of-two, got {:?}",
-             operand.dims()
+
+        debug_assert!(
+            operand.dims().iter().all(|d| d.is_power_of_two()),
+            "operand dims must all be power-of-two, got {:?}",
+            operand.dims()
         );
 
         // Use tensor values directly as lookup indices

--- a/jolt-atlas-core/src/utils/mod.rs
+++ b/jolt-atlas-core/src/utils/mod.rs
@@ -52,8 +52,8 @@ pub fn compute_lookup_indices_from_operands(
             operand_tensors.len()
         );
 
-        let left_operand = operand_tensors[0];
-        let right_operand = operand_tensors[1];
+        let left_operand = operand_tensors[0].padded_next_power_of_two();
+        let right_operand = operand_tensors[1].padded_next_power_of_two();
 
         // Validate that both tensors have the same length
         assert_eq!(
@@ -86,7 +86,7 @@ pub fn compute_lookup_indices_from_operands(
             operand_tensors.len()
         );
 
-        let operand = operand_tensors[0];
+        let operand = operand_tensors[0].padded_next_power_of_two();
 
         // Use tensor values directly as lookup indices
         operand

--- a/jolt-atlas-core/src/utils/mod.rs
+++ b/jolt-atlas-core/src/utils/mod.rs
@@ -52,8 +52,19 @@ pub fn compute_lookup_indices_from_operands(
             operand_tensors.len()
         );
 
-        let left_operand = operand_tensors[0].padded_next_power_of_two();
-        let right_operand = operand_tensors[1].padded_next_power_of_two();
+        let left_operand = operand_tensors[0];
+        let right_operand = operand_tensors[1];
+ 
+         debug_assert!(
+             left_operand.dims().iter().all(|d| d.is_power_of_two()),
+             "left operand dims must all be power-of-two, got {:?}",
+             left_operand.dims()
+         );
+         debug_assert!(
+             right_operand.dims().iter().all(|d| d.is_power_of_two()),
+             "right operand dims must all be power-of-two, got {:?}",
+             right_operand.dims()
+        );
 
         // Validate that both tensors have the same length
         assert_eq!(
@@ -86,7 +97,13 @@ pub fn compute_lookup_indices_from_operands(
             operand_tensors.len()
         );
 
-        let operand = operand_tensors[0].padded_next_power_of_two();
+        let operand = operand_tensors[0];
+ 
+         debug_assert!(
+             operand.dims().iter().all(|d| d.is_power_of_two()),
+             "operand dims must all be power-of-two, got {:?}",
+             operand.dims()
+        );
 
         // Use tensor values directly as lookup indices
         operand

--- a/joltworks/src/utils/math.rs
+++ b/joltworks/src/utils/math.rs
@@ -3,6 +3,7 @@ use ark_ff::biginteger::S64;
 pub trait Math {
     fn pow2(self) -> usize;
     fn log_2(self) -> usize;
+    fn ceil_log_2(self) -> usize;
 }
 
 impl Math for usize {
@@ -19,6 +20,11 @@ impl Math for usize {
             "log_2 is only defined for power-of-two values, got {self}"
         );
         (1usize.leading_zeros() - self.leading_zeros()) as usize
+    }
+
+    fn ceil_log_2(self) -> usize {
+        assert_ne!(self, 0);
+        self.next_power_of_two().log_2()
     }
 }
 

--- a/joltworks/src/utils/math.rs
+++ b/joltworks/src/utils/math.rs
@@ -14,12 +14,11 @@ impl Math for usize {
 
     fn log_2(self) -> usize {
         assert_ne!(self, 0);
-
-        if self.is_power_of_two() {
-            (1usize.leading_zeros() - self.leading_zeros()) as usize
-        } else {
-            (0usize.leading_zeros() - self.leading_zeros()) as usize
-        }
+        assert!(
+            self.is_power_of_two(),
+            "log_2 is only defined for power-of-two values, got {self}"
+        );
+        (1usize.leading_zeros() - self.leading_zeros()) as usize
     }
 }
 


### PR DESCRIPTION
## Summary

  This PR introduces non-power-of-2 input-length support in the ONNX proof pipeline, with explicit per-operator coverage tracking via
  non_power_of_two_input_len tests.

  The current branch intentionally supports a subset of operators first and keeps the remaining ones marked as pending.

  ## What changed

  - Added/updated non-power-of-2 test coverage at the operator level.
  - Implemented proof-path updates for currently supported operators so they work when input lengths are not powers of two.
  - Added/kept explicit TODO notes in Tanh/Erf/Div range-check related paths for soundness follow-up.

  ## Support status (measured)

  I ran:

  cargo test -p jolt-atlas-core non_power_of_two_input_len

  Result:

  - 12 passed
  - 18 ignored

  ### Supported operators (passed)

  - reshape
  - add
  - cube
  - mul
  - input
  - sub
  - square
  - neg
  - relu

  ### Not supported yet (ignored)

  - tanh
  - erf
  - div
  - broadcast
  - cos
  - einsum:
      - bmk_bkn_mbn
      - bmk_kbn_mbn
      - k_nk_n
      - mbk_bnk_bmn
      - mbk_nbk_bmn
      - mk_kn_mn
  - gather
  - iff
  - moveaxis
  - rsqrt
  - scalar_const_div
  - sin
  - softmax_axes::softmax::scalar_div
  - softmax_axes::softmax
  - softmax_axes
  - sum::axis

  ## Note

  - Unignore and implement remaining operators listed above.