### PR TITLE
Fix: Add ScalarConstDivPow2 and range-check ScalarConstDiv remainders

### DIFF
--- a/atlas-onnx-tracer/src/model/mod.rs
+++ b/atlas-onnx-tracer/src/model/mod.rs
@@ -267,7 +267,12 @@ impl Model {
                 | Operator::Rsqrt(_)
                 | Operator::Sigmoid(_)
                 | Operator::Sin(_) => LOG_K_CHUNK + log_2(node.pow2_padded_num_output_elements()),
-                Operator::ScalarConstDiv(_) => log_2(node.pow2_padded_num_output_elements()),
+                Operator::ScalarConstDiv(_) => {
+                    LOG_K_CHUNK + log_2(node.pow2_padded_num_output_elements())
+                }
+                Operator::ScalarConstDivPow2(_) => {
+                    LOG_K_CHUNK + log_2(node.pow2_padded_num_output_elements())
+                }
                 Operator::SoftmaxAxes(_) => {
                     LOG_K_CHUNK + log_2(*node.output_dims.last().unwrap_or(&1))
                 }

--- a/atlas-onnx-tracer/src/model/shadow_trace.rs
+++ b/atlas-onnx-tracer/src/model/shadow_trace.rs
@@ -442,6 +442,14 @@ fn shadow_f64(op: &Operator, inputs: Vec<&Tensor<f64>>, scale: Scale) -> Tensor<
                 elementwise_f64(inputs[0], |x| x / d)
             }
         }
+        Operator::ScalarConstDivPow2(scd) => {
+            if is_rebase_divisor(scd.divisor, scale) {
+                inputs[0].clone()
+            } else {
+                let d = scd.divisor as f64;
+                elementwise_f64(inputs[0], |x| x / d)
+            }
+        }
 
         // ── Matrix / tensor contraction ─────────────────────────────────
         Operator::Einsum(e) => tensor::ops::einsum(&e.equation, &inputs).unwrap(),

--- a/atlas-onnx-tracer/src/node/handlers/arith.rs
+++ b/atlas-onnx-tracer/src/node/handlers/arith.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use crate::{
     node::ComputationNode,
-    ops::{Constant, Cube, Mul, Operator, ScalarConstDiv},
+    ops::{Constant, Cube, Mul, Operator, ScalarConstDiv, ScalarConstDivPow2},
     simple_handler,
     utils::{handler_builder::HandlerBuilder, parser::DecompositionBuilder},
 };
@@ -47,7 +47,7 @@ fn build_mul(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
         .simple_op(Operator::Mul(Mul { scale }));
 
     #[cfg(not(feature = "fused-ops"))]
-    let builder = builder.with_auto_rebase();
+    let builder = builder.with_auto_rebase_pow2();
 
     builder.build()
 }
@@ -85,11 +85,11 @@ fn handle_square(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
 /// Builds Square(x) = x²/S to maintain scale S.
 ///
 /// When `pre_rebase_nonlinear` is **false** (default):
-///   Square(x) → ScalarConstDiv(x², S)
+///   Square(x) → ScalarConstDivPow2(x², S)
 ///
 /// HACK: When `pre_rebase_nonlinear` is **true** (for large models like GPT-2):
 ///   Decomposes into existing ops to avoid i32 overflow:
-///     x' = x / S          (ScalarConstDiv)
+///     x' = x / S          (ScalarConstDivPow2)
 ///     result = x' * x     (Mul, no rebase)
 ///   Since x' * x = x²/S, the result is already at scale S.
 ///   TODO: Remove pre_rebase_nonlinear path once fused i64 ops are default.
@@ -106,7 +106,7 @@ fn build_square(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
         // Node 0: x' = x / S
         builder.add_node(ComputationNode {
             idx: builder.idx(0),
-            operator: Operator::ScalarConstDiv(ScalarConstDiv { divisor: s }),
+            operator: Operator::ScalarConstDivPow2(ScalarConstDivPow2 { divisor: s }),
             inputs: vec![x_idx],
             output_dims: output_dims.clone(),
         });
@@ -123,7 +123,7 @@ fn build_square(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
     HandlerBuilder::new(hctx)
         .with_broadcast()
         .simple_op(Operator::Square(Default::default()))
-        .with_auto_rebase()
+        .with_auto_rebase_pow2()
         .build()
 }
 

--- a/atlas-onnx-tracer/src/node/handlers/other.rs
+++ b/atlas-onnx-tracer/src/node/handlers/other.rs
@@ -108,7 +108,7 @@ fn handle_einsum(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
     }));
 
     #[cfg(not(feature = "fused-ops"))]
-    let builder = builder.with_auto_rebase();
+    let builder = builder.with_auto_rebase_pow2();
 
     builder.build()
 }

--- a/atlas-onnx-tracer/src/ops/mod.rs
+++ b/atlas-onnx-tracer/src/ops/mod.rs
@@ -51,6 +51,8 @@ pub mod reshape;
 pub mod rsqrt;
 /// Division by a scalar constant operator.
 pub mod scalar_const_div;
+/// Division by a power-of-two scalar constant operator.
+pub mod scalar_const_div_pow2;
 /// Sigmoid activation operator.
 pub mod sigmoid;
 /// Element-wise sine operator.
@@ -145,6 +147,7 @@ define_operators! {
         Reshape { shape:Vec<usize> },
         Rsqrt { scale: F32 },
         ScalarConstDiv {divisor: i32},
+        ScalarConstDivPow2 {divisor: i32},
         Sigmoid { scale: F32, tau: i32, log_table: usize },
         Sin { scale: F32 },
         Slice { axis: usize, start: usize, end: usize},

--- a/atlas-onnx-tracer/src/ops/scalar_const_div_pow2.rs
+++ b/atlas-onnx-tracer/src/ops/scalar_const_div_pow2.rs
@@ -1,19 +1,22 @@
 use super::Op;
-use crate::{ops::ScalarConstDiv, tensor::Tensor};
+use crate::{ops::ScalarConstDivPow2, tensor::Tensor};
 
-impl Op for ScalarConstDiv {
-    #[tracing::instrument(name = "ScalarConstDiv::f", skip_all)]
+impl Op for ScalarConstDivPow2 {
+    #[tracing::instrument(name = "ScalarConstDivPow2::f", skip_all)]
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
         let a = inputs[0];
         let b = self.divisor;
-        assert!(b > 0, "ScalarConstDiv requires a positive divisor, got {b}");
+        assert!(
+            b > 0 && (b as u32).is_power_of_two(),
+            "ScalarConstDivPow2 requires a positive power-of-two divisor, got {b}"
+        );
         let data: Vec<i32> = a
             .data()
             .iter()
             .map(|&x| {
-                let mut d_inv_x = x / (b);
+                let mut d_inv_x = x / b;
                 let remainder = x % b;
-                if (remainder < 0 && b > 0) || (remainder > 0 && b < 0) {
+                if remainder < 0 {
                     d_inv_x -= 1;
                 }
                 d_inv_x

--- a/atlas-onnx-tracer/src/utils/handler_builder.rs
+++ b/atlas-onnx-tracer/src/utils/handler_builder.rs
@@ -28,7 +28,7 @@
 
 use crate::{
     node::{ComputationNode, handlers::HandlerContext},
-    ops::{Constant, Operator, ScalarConstDiv},
+    ops::{Constant, Operator, ScalarConstDiv, ScalarConstDivPow2},
     tensor::Tensor,
 };
 
@@ -45,6 +45,7 @@ pub struct HandlerBuilder<'a, 'b> {
     broadcast_nodes: Vec<ComputationNode>,
     stages: Vec<Stage>,
     auto_rebase: bool,
+    auto_rebase_pow2: bool,
     custom_rebase_factor: Option<i32>,
 }
 
@@ -79,6 +80,7 @@ impl<'a, 'b> HandlerBuilder<'a, 'b> {
             broadcast_nodes: vec![],
             stages: vec![],
             auto_rebase: false,
+            auto_rebase_pow2: false,
             custom_rebase_factor: None,
         }
     }
@@ -124,6 +126,15 @@ impl<'a, 'b> HandlerBuilder<'a, 'b> {
     /// to rebase the result.
     pub fn with_auto_rebase(mut self) -> Self {
         self.auto_rebase = true;
+        self
+    }
+
+    /// Automatically adds a power-of-two rebase node.
+    ///
+    /// This should only be used when the rebase factor is known to be a positive
+    /// power of two, such as fixed-point scale restoration after Mul/Square/Einsum.
+    pub fn with_auto_rebase_pow2(mut self) -> Self {
+        self.auto_rebase_pow2 = true;
         self
     }
 
@@ -260,10 +271,15 @@ impl<'a, 'b> HandlerBuilder<'a, 'b> {
         if let Some(factor) = self.determine_rebase_factor() {
             let prev_idx = current_output_idx.expect("Rebase requires a previous node");
             let output_dims = self.hctx.output_dims.clone();
+            let operator = if self.auto_rebase_pow2 {
+                Operator::ScalarConstDivPow2(ScalarConstDivPow2 { divisor: factor })
+            } else {
+                Operator::ScalarConstDiv(ScalarConstDiv { divisor: factor })
+            };
 
             builder.add_node(ComputationNode {
                 idx: builder.idx(node_offset),
-                operator: Operator::ScalarConstDiv(ScalarConstDiv { divisor: factor }),
+                operator,
                 inputs: vec![prev_idx],
                 output_dims,
             });
@@ -302,7 +318,7 @@ impl<'a, 'b> HandlerBuilder<'a, 'b> {
             return Some(factor);
         }
 
-        if self.auto_rebase {
+        if self.auto_rebase || self.auto_rebase_pow2 {
             // Find the last operator that might need rebase
             for stage in self.stages.iter().rev() {
                 let operator = match stage {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,11 +15,13 @@ pub enum CommittedPolynomial {
     ///
     /// `1` - d
     NodeOutputRaD(usize, usize),
-    CosRaD(usize, usize),     // One-hot read addresses for Cos lookup
-    ErfRaD(usize, usize),     // One-hot read addresses for Erf lookup
-    SigmoidRaD(usize, usize), // One-hot read addresses for Sigmoid lookup
-    SinRaD(usize, usize),     // One-hot read addresses for Sin lookup
-    TanhRaD(usize, usize),    // One-hot read addresses for Tanh lookup
+    CosRaD(usize, usize),                // One-hot read addresses for Cos lookup
+    ErfRaD(usize, usize),                // One-hot read addresses for Erf lookup
+    SigmoidRaD(usize, usize),            // One-hot read addresses for Sigmoid lookup
+    SinRaD(usize, usize),                // One-hot read addresses for Sin lookup
+    ScalarConstDivPow2RaD(usize, usize), // One-hot read addresses for ScalarConstDivPow2 remainder lookup
+    ScalarConstDivRangeCheckRaD(usize, usize), // Interleaved remainder and constant divisor for ScalarConstDiv
+    TanhRaD(usize, usize),                     // One-hot read addresses for Tanh lookup
 
     /// Fields:
     ///
@@ -86,10 +88,14 @@ pub enum VirtualPolynomial {
     // Those are proven by the ReadRafSumcheckProver,
     // from Committed one-hot polynomials.
     DivRangeCheckRa(usize),
+    ScalarConstDivDivisor(usize),
+    ScalarConstDivRangeCheckRa(usize),
     SqrtRangeCheckRa(usize),
     TeleportRangeCheckRa(usize),
 
     DivRemainder(usize),
+    ScalarConstDivPow2Divisor(usize),
+    ScalarConstDivPow2Ra(usize),
     SqrtRemainder(usize),
     TeleportQuotient(usize), // Quotient polynomial for neural teleportation lookups
     TeleportRemainder(usize), // Remainder polynomial for neural teleportation lookups
@@ -187,6 +193,16 @@ impl CanonicalSerialize for CommittedPolynomial {
                 a.serialize_with_mode(&mut writer, compress)?;
                 b.serialize_with_mode(&mut writer, compress)?;
             }
+            Self::ScalarConstDivPow2RaD(a, b) => {
+                17u8.serialize_with_mode(&mut writer, compress)?;
+                a.serialize_with_mode(&mut writer, compress)?;
+                b.serialize_with_mode(&mut writer, compress)?;
+            }
+            Self::ScalarConstDivRangeCheckRaD(a, b) => {
+                18u8.serialize_with_mode(&mut writer, compress)?;
+                a.serialize_with_mode(&mut writer, compress)?;
+                b.serialize_with_mode(&mut writer, compress)?;
+            }
         }
         Ok(())
     }
@@ -199,6 +215,8 @@ impl CanonicalSerialize for CommittedPolynomial {
             | Self::SigmoidRaD(a, b)
             | Self::CosRaD(a, b)
             | Self::SinRaD(a, b)
+            | Self::ScalarConstDivPow2RaD(a, b)
+            | Self::ScalarConstDivRangeCheckRaD(a, b)
             | Self::SoftmaxRemainder(a, b)
             | Self::DivRangeCheckRaD(a, b)
             | Self::SqrtDivRangeCheckRaD(a, b)
@@ -303,6 +321,14 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 usize::deserialize_with_mode(&mut reader, compress, validate)?,
             )),
             16 => Ok(Self::SigmoidRaD(
+                usize::deserialize_with_mode(&mut reader, compress, validate)?,
+                usize::deserialize_with_mode(&mut reader, compress, validate)?,
+            )),
+            17 => Ok(Self::ScalarConstDivPow2RaD(
+                usize::deserialize_with_mode(&mut reader, compress, validate)?,
+                usize::deserialize_with_mode(&mut reader, compress, validate)?,
+            )),
+            18 => Ok(Self::ScalarConstDivRangeCheckRaD(
                 usize::deserialize_with_mode(&mut reader, compress, validate)?,
                 usize::deserialize_with_mode(&mut reader, compress, validate)?,
             )),
@@ -421,6 +447,22 @@ impl CanonicalSerialize for VirtualPolynomial {
                 22u8.serialize_with_mode(&mut writer, compress)?;
                 a.serialize_with_mode(&mut writer, compress)?;
             }
+            Self::ScalarConstDivDivisor(a) => {
+                23u8.serialize_with_mode(&mut writer, compress)?;
+                a.serialize_with_mode(&mut writer, compress)?;
+            }
+            Self::ScalarConstDivRangeCheckRa(a) => {
+                24u8.serialize_with_mode(&mut writer, compress)?;
+                a.serialize_with_mode(&mut writer, compress)?;
+            }
+            Self::ScalarConstDivPow2Divisor(a) => {
+                25u8.serialize_with_mode(&mut writer, compress)?;
+                a.serialize_with_mode(&mut writer, compress)?;
+            }
+            Self::ScalarConstDivPow2Ra(a) => {
+                26u8.serialize_with_mode(&mut writer, compress)?;
+                a.serialize_with_mode(&mut writer, compress)?;
+            }
         }
         Ok(())
     }
@@ -436,9 +478,13 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::SinRa(a)
             | Self::TanhRa(a)
             | Self::DivRangeCheckRa(a)
+            | Self::ScalarConstDivDivisor(a)
+            | Self::ScalarConstDivRangeCheckRa(a)
             | Self::SqrtRangeCheckRa(a)
             | Self::TeleportRangeCheckRa(a)
             | Self::DivRemainder(a)
+            | Self::ScalarConstDivPow2Divisor(a)
+            | Self::ScalarConstDivPow2Ra(a)
             | Self::SqrtRemainder(a)
             | Self::TeleportQuotient(a)
             | Self::TeleportRemainder(a) => a.serialized_size(compress),
@@ -569,6 +615,22 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 validate,
             )?)),
             22 => Ok(Self::SigmoidRa(usize::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?)),
+            23 => Ok(Self::ScalarConstDivDivisor(usize::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?)),
+            24 => Ok(Self::ScalarConstDivRangeCheckRa(
+                usize::deserialize_with_mode(&mut reader, compress, validate)?,
+            )),
+            25 => Ok(Self::ScalarConstDivPow2Divisor(
+                usize::deserialize_with_mode(&mut reader, compress, validate)?,
+            )),
+            26 => Ok(Self::ScalarConstDivPow2Ra(usize::deserialize_with_mode(
                 &mut reader,
                 compress,
                 validate,

--- a/jolt-atlas-core/src/onnx_proof/ops/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mod.rs
@@ -84,6 +84,8 @@ pub mod reshape;
 pub mod rsqrt;
 /// Division by a scalar constant.
 pub mod scalar_const_div;
+/// Division by a power-of-two scalar constant.
+pub mod scalar_const_div_pow2;
 /// Sigmoid activation function.
 pub mod sigmoid;
 /// Sin trigonometric function.
@@ -241,6 +243,7 @@ macro_rules! dispatch_operator {
             Operator::Reshape($inner) => $body,
             Operator::Rsqrt($inner) => $body,
             Operator::ScalarConstDiv($inner) => $body,
+            Operator::ScalarConstDivPow2($inner) => $body,
             Operator::Sigmoid($inner) => $body,
             Operator::Sin($inner) => $body,
             Operator::Slice($inner) => $body,

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
@@ -1,13 +1,21 @@
-use crate::onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier};
+use crate::onnx_proof::{
+    ops::{eval_reduction::NodeEvalReduction, OperatorProofTrait, ReductionFlow},
+    range_checking::{
+        range_check_operands::ScalarConstDivRangeCheckOperands, RangeCheckEncoding,
+        RangeCheckProvider,
+    },
+    ProofId, ProofType, Prover, Verifier,
+};
 use atlas_onnx_tracer::{
     model::trace::{LayerData, Trace},
     node::ComputationNode,
     ops::{Operator, ScalarConstDiv},
     tensor::Tensor,
 };
-use common::{CommittedPolynomial, VirtualPolynomial};
+use common::{consts::XLEN, CommittedPolynomial, VirtualPolynomial};
 use joltworks::{
     field::{IntoOpening, JoltField},
+    lookup_tables::unsigned_less_than::UnsignedLessThanTable,
     poly::{
         eq_poly::EqPolynomial,
         multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
@@ -19,6 +27,7 @@ use joltworks::{
         unipoly::UniPoly,
     },
     subprotocols::{
+        shout::{self, RaOneHotEncoding},
         sumcheck::{Sumcheck, SumcheckInstanceProof},
         sumcheck_prover::SumcheckInstanceProver,
         sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
@@ -28,6 +37,10 @@ use joltworks::{
 };
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDiv {
+    fn reduction_flow(&self) -> ReductionFlow {
+        ReductionFlow::Custom
+    }
+
     #[tracing::instrument(skip_all, name = "ScalarConstDiv::prove")]
     fn prove(
         &self,
@@ -36,8 +49,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDiv {
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
         let mut results = Vec::new();
 
-        // Execution proof
-        let params = ScalarConstDivParams::new(node.clone(), &prover.accumulator);
+        let params = ScalarConstDivParams::new(node.clone(), &mut prover.transcript);
         let mut exec_sumcheck = ScalarConstDivProver::initialize(&prover.trace, params);
         let (proof, _) = Sumcheck::prove(
             &mut exec_sumcheck,
@@ -45,7 +57,21 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDiv {
             &mut prover.transcript,
         );
         results.push((ProofId(node.idx, ProofType::Execution), proof));
+        results.extend(prove_range_and_onehot(node, prover));
         results
+    }
+
+    fn prove_with_reduction(
+        &self,
+        node: &ComputationNode,
+        prover: &mut Prover<F, T>,
+    ) -> (
+        joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
+        Vec<(ProofId, SumcheckInstanceProof<F, T>)>,
+    ) {
+        let proofs = self.prove(node, prover);
+        let eval_reduction_proof = NodeEvalReduction::prove(prover, node);
+        (eval_reduction_proof, proofs)
     }
 
     #[tracing::instrument(skip_all, name = "ScalarConstDiv::verify")]
@@ -54,34 +80,48 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDiv {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
-        // Execution verification
         let proof = verifier
             .proofs
             .get(&ProofId(node.idx, ProofType::Execution))
             .ok_or(ProofVerifyError::MissingProof(node.idx))?;
-        let exec_sumcheck = ScalarConstDivVerifier::new(node.clone(), &verifier.accumulator);
+        let exec_sumcheck = ScalarConstDivVerifier::new(node.clone(), &mut verifier.transcript);
         Sumcheck::verify(
             proof,
             &exec_sumcheck,
             &mut verifier.accumulator,
             &mut verifier.transcript,
         )?;
+        verify_range_and_onehot(node, verifier)?;
 
         Ok(())
     }
 
+    fn verify_with_reduction(
+        &self,
+        node: &ComputationNode,
+        verifier: &mut Verifier<'_, F, T>,
+        eval_reduction_proof: &joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
+    ) -> Result<(), ProofVerifyError> {
+        self.verify(node, verifier)?;
+        NodeEvalReduction::verify(verifier, node, eval_reduction_proof)
+    }
+
     fn get_committed_polynomials(&self, node: &ComputationNode) -> Vec<CommittedPolynomial> {
-        let polys = vec![CommittedPolynomial::ScalarConstDivNodeRemainder(node.idx)];
-        polys
+        let encoding = RangeCheckEncoding::<ScalarConstDivRangeCheckOperands>::new(node);
+        let d = encoding.one_hot_params().instruction_d;
+        (0..d)
+            .map(|i| CommittedPolynomial::ScalarConstDivRangeCheckRaD(node.idx, i))
+            .collect()
     }
 }
 
 const DEGREE_BOUND: usize = 2;
 
-/// Parameters for proving division by a scalar constant.
+/// Sumcheck parameters for `ScalarConstDiv`.
 ///
-/// For division a/b where b is a constant, proves a = b*q + R where R is the remainder.
-/// This is more efficient than general division since the divisor is known.
+/// Stores the verifier challenge point for the node output together with the
+/// computation node metadata and the positive constant divisor used by the
+/// execution relation.
 #[derive(Clone)]
 pub struct ScalarConstDivParams<F: JoltField> {
     r_node_output: OpeningPoint<BIG_ENDIAN, F>,
@@ -90,15 +130,18 @@ pub struct ScalarConstDivParams<F: JoltField> {
 }
 
 impl<F: JoltField> ScalarConstDivParams<F> {
-    /// Create new scalar constant division parameters from a computation node and opening accumulator.
-    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
-        let r_node_output = accumulator
-            .get_node_output_opening(computation_node.idx)
-            .0
-            .r;
+    /// Samples the output challenge point and validates the constant divisor.
+    pub fn new<T: Transcript>(computation_node: ComputationNode, transcript: &mut T) -> Self {
+        let num_vars = computation_node.pow2_padded_num_output_elements().log_2();
+        let r_node_output = transcript.challenge_vector_optimized::<F>(num_vars);
         let Operator::ScalarConstDiv(scalar_const_div) = &computation_node.operator else {
             panic!("Expected ScalarConstDiv operator")
         };
+        assert!(
+            scalar_const_div.divisor > 0,
+            "ScalarConstDiv proof requires a positive divisor, got {0}",
+            scalar_const_div.divisor
+        );
         Self {
             r_node_output: r_node_output.into(),
             scalar_const_divisor: scalar_const_div.divisor,
@@ -113,10 +156,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivParams<F> {
     }
 
     fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
-        let q_claim = accumulator
-            .get_node_output_opening(self.computation_node.idx)
-            .1;
-        q_claim * F::from_i32(self.scalar_const_divisor)
+        let _ = accumulator;
+        F::zero()
     }
 
     fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
@@ -130,48 +171,50 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivParams<F> {
     }
 }
 
-/// Prover state for scalar constant division sumcheck protocol.
+/// Prover state for the `ScalarConstDiv` execution sumcheck.
 ///
-/// Maintains the equality polynomial, operand polynomial, and remainder R
-/// needed to prove the division relation: operand = divisor * q + R where divisor is constant.
+/// The relation enforces `divisor * q + r - a = 0` at the sampled point, where
+/// `q` is the node output and `r` is the virtual remainder reconstructed by the
+/// range-check / RA pipeline.
 pub struct ScalarConstDivProver<F: JoltField> {
     params: ScalarConstDivParams<F>,
     eq_r_node_output: GruenSplitEqPolynomial<F>,
     left_operand: MultilinearPolynomial<F>,
-    R: MultilinearPolynomial<F>,
+    q: MultilinearPolynomial<F>,
+    remainder: MultilinearPolynomial<F>,
 }
 
 impl<F: JoltField> ScalarConstDivProver<F> {
-    /// Initialize the prover with trace data and parameters.
+    /// Builds prover polynomials from the execution trace for one `ScalarConstDiv` node.
     #[tracing::instrument(skip_all)]
     pub fn initialize(trace: &Trace, params: ScalarConstDivParams<F>) -> Self {
         let eq_r_node_output =
             GruenSplitEqPolynomial::new(&params.r_node_output.r, BindingOrder::LowToHigh);
-        let LayerData { operands, .. } = Trace::layer_data(trace, &params.computation_node);
+        let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
         let [left_operand] = operands[..] else {
             panic!("Expected one operands for ScalarConstDiv operation")
         };
         let b = params.scalar_const_divisor;
-        let R_tensor = {
+        let remainder_tensor = {
             let data: Vec<i32> = left_operand
                 .iter()
                 .map(|&a| {
-                    let mut R = a % b;
-                    if (R < 0 && b > 0) || R > 0 && b < 0 {
-                        R += b
+                    let mut remainder = a % b;
+                    if (remainder < 0 && b > 0) || (remainder > 0 && b < 0) {
+                        remainder += b
                     }
-                    R
+                    remainder
                 })
                 .collect();
             Tensor::<i32>::construct(data, left_operand.dims().to_vec())
         };
-        let left_operand = MultilinearPolynomial::from(left_operand.clone());
-        let R = MultilinearPolynomial::from(R_tensor);
+        let q = MultilinearPolynomial::from(output.clone());
         Self {
             params,
             eq_r_node_output,
-            left_operand,
-            R,
+            left_operand: MultilinearPolynomial::from(left_operand.clone()),
+            q,
+            remainder: MultilinearPolynomial::from(remainder_tensor),
         }
     }
 }
@@ -182,26 +225,24 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ScalarConstDi
     }
 
     fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
-        let Self {
-            eq_r_node_output,
-            left_operand,
-            R,
-            ..
-        } = self;
-        let [q_constant] = eq_r_node_output.par_fold_out_in_unreduced::<9, 1>(&|g| {
-            let lo0 = left_operand.get_bound_coeff(2 * g);
-            let R0 = R.get_bound_coeff(2 * g);
-            let c0 = lo0 - R0;
-            [c0]
-        });
-        eq_r_node_output.gruen_poly_deg_2(q_constant, previous_claim)
+        let [q_constant] = self
+            .eq_r_node_output
+            .par_fold_out_in_unreduced::<9, 1>(&|g| {
+                let lo0 = self.left_operand.get_bound_coeff(2 * g);
+                let q0 = self.q.get_bound_coeff(2 * g);
+                let r0 = self.remainder.get_bound_coeff(2 * g);
+                [F::from_i32(self.params.scalar_const_divisor) * q0 + r0 - lo0]
+            });
+        self.eq_r_node_output
+            .gruen_poly_deg_2(q_constant, previous_claim)
     }
 
     fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
         self.eq_r_node_output.bind(r_j);
         self.left_operand
             .bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.R.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.q.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.remainder.bind_parallel(r_j, BindingOrder::LowToHigh);
     }
 
     fn cache_openings(
@@ -220,31 +261,42 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ScalarConstDi
             opening_point.clone(),
             self.left_operand.final_sumcheck_claim(),
         );
-        accumulator.append_dense(
+        accumulator.append_virtual(
             transcript,
-            CommittedPolynomial::ScalarConstDivNodeRemainder(self.params.computation_node.idx),
+            VirtualPolynomial::NodeOutput(self.params.computation_node.idx),
             SumcheckId::NodeExecution(self.params.computation_node.idx),
-            opening_point.r.clone(),
-            self.R.final_sumcheck_claim(),
+            opening_point.clone(),
+            self.q.final_sumcheck_claim(),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::ScalarConstDivDivisor(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point.clone(),
+            F::from_i32(self.params.scalar_const_divisor),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::DivRemainder(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point,
+            self.remainder.final_sumcheck_claim(),
         );
     }
 }
 
-/// Verifier for scalar constant division sumcheck protocol.
+/// Verifier state for the `ScalarConstDiv` execution sumcheck.
 ///
-/// Verifies that the prover's sumcheck messages are consistent with the claimed
-/// division by scalar constant output and the division relation.
+/// This verifier checks the virtual quotient, divisor, and remainder openings
+/// that witness the element-wise relation against the sampled output point.
 pub struct ScalarConstDivVerifier<F: JoltField> {
     params: ScalarConstDivParams<F>,
 }
 
 impl<F: JoltField> ScalarConstDivVerifier<F> {
-    /// Create a new verifier for the scalar constant division operation.
-    pub fn new(
-        computation_node: ComputationNode,
-        accumulator: &VerifierOpeningAccumulator<F>,
-    ) -> Self {
-        let params = ScalarConstDivParams::new(computation_node, accumulator);
+    /// Samples the output challenge point for verifying one `ScalarConstDiv` node.
+    pub fn new<T: Transcript>(computation_node: ComputationNode, transcript: &mut T) -> Self {
+        let params = ScalarConstDivParams::new(computation_node, transcript);
         Self { params }
     }
 }
@@ -259,18 +311,21 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ScalarConst
         accumulator: &VerifierOpeningAccumulator<F>,
         sumcheck_challenges: &[F::Challenge],
     ) -> F {
-        let r_node_output = accumulator
-            .get_node_output_opening(self.params.computation_node.idx)
-            .0
-            .r;
+        let r_node_output = self.params.r_node_output.r.clone();
         let r_node_output_prime = self
             .params
             .normalize_opening_point(&sumcheck_challenges.into_opening())
             .r;
         let eq_eval = EqPolynomial::mle(&r_node_output, &r_node_output_prime);
-        let R_claim = accumulator
-            .get_committed_polynomial_opening(
-                CommittedPolynomial::ScalarConstDivNodeRemainder(self.params.computation_node.idx),
+        let q_claim = accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::NodeOutput(self.params.computation_node.idx),
+                SumcheckId::NodeExecution(self.params.computation_node.idx),
+            )
+            .1;
+        let remainder_claim = accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::DivRemainder(self.params.computation_node.idx),
                 SumcheckId::NodeExecution(self.params.computation_node.idx),
             )
             .1;
@@ -278,7 +333,13 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ScalarConst
             self.params.computation_node.inputs[0],
             self.params.computation_node.idx,
         );
-        eq_eval * (left_operand_claim - R_claim)
+        let divisor_claim = accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::ScalarConstDivDivisor(self.params.computation_node.idx),
+                SumcheckId::NodeExecution(self.params.computation_node.idx),
+            )
+            .1;
+        eq_eval * ((divisor_claim * q_claim) + remainder_claim - left_operand_claim)
     }
 
     fn cache_openings(
@@ -296,13 +357,110 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ScalarConst
             SumcheckId::NodeExecution(self.params.computation_node.idx),
             opening_point.clone(),
         );
-        accumulator.append_dense(
+        accumulator.append_virtual(
             transcript,
-            CommittedPolynomial::ScalarConstDivNodeRemainder(self.params.computation_node.idx),
+            VirtualPolynomial::NodeOutput(self.params.computation_node.idx),
             SumcheckId::NodeExecution(self.params.computation_node.idx),
-            opening_point.r.clone(),
+            opening_point.clone(),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::ScalarConstDivDivisor(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point.clone(),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::DivRemainder(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point,
         );
     }
+}
+
+fn prove_range_and_onehot<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    prover: &mut Prover<F, T>,
+) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
+    let mut results = Vec::new();
+
+    let rangecheck_provider = RangeCheckProvider::<ScalarConstDivRangeCheckOperands>::new(node);
+    let (mut rangecheck_sumcheck, lookup_indices) = rangecheck_provider
+        .read_raf_prove::<F, T, UnsignedLessThanTable<XLEN>>(
+            &prover.trace,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+    let (rangecheck_proof, _) = Sumcheck::prove(
+        &mut rangecheck_sumcheck,
+        &mut prover.accumulator,
+        &mut prover.transcript,
+    );
+    results.push((ProofId(node.idx, ProofType::RangeCheck), rangecheck_proof));
+
+    let encoding = RangeCheckEncoding::<ScalarConstDivRangeCheckOperands>::new(node);
+    let [ra_sumcheck, hw_sumcheck, bool_sumcheck] = shout::ra_onehot_provers(
+        &encoding,
+        &lookup_indices,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let mut instances: Vec<
+        Box<dyn joltworks::subprotocols::sumcheck_prover::SumcheckInstanceProver<_, _>>,
+    > = vec![ra_sumcheck, hw_sumcheck, bool_sumcheck];
+    let (ra_one_hot_proof, _) = joltworks::subprotocols::sumcheck::BatchedSumcheck::prove(
+        instances.iter_mut().map(|v| &mut **v as _).collect(),
+        &mut prover.accumulator,
+        &mut prover.transcript,
+    );
+    results.push((
+        ProofId(node.idx, ProofType::RaOneHotChecks),
+        ra_one_hot_proof,
+    ));
+
+    results
+}
+
+fn verify_range_and_onehot<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    verifier: &mut Verifier<'_, F, T>,
+) -> Result<(), ProofVerifyError> {
+    let rangecheck_proof = verifier
+        .proofs
+        .get(&ProofId(node.idx, ProofType::RangeCheck))
+        .ok_or(ProofVerifyError::MissingProof(node.idx))?;
+
+    let rangecheck_provider = RangeCheckProvider::<ScalarConstDivRangeCheckOperands>::new(node);
+    let rangecheck_verifier = rangecheck_provider
+        .read_raf_verify::<F, T, UnsignedLessThanTable<XLEN>>(
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+        );
+    Sumcheck::verify(
+        rangecheck_proof,
+        &rangecheck_verifier,
+        &mut verifier.accumulator,
+        &mut verifier.transcript,
+    )?;
+
+    let ra_one_hot_proof = verifier
+        .proofs
+        .get(&ProofId(node.idx, ProofType::RaOneHotChecks))
+        .ok_or(ProofVerifyError::MissingProof(node.idx))?;
+    let encoding = RangeCheckEncoding::<ScalarConstDivRangeCheckOperands>::new(node);
+    let [ra_sumcheck, hw_sumcheck, bool_sumcheck] =
+        shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+    let mut instances: Vec<
+        Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<_, _>>,
+    > = vec![ra_sumcheck, hw_sumcheck, bool_sumcheck];
+    joltworks::subprotocols::sumcheck::BatchedSumcheck::verify(
+        ra_one_hot_proof,
+        instances.iter_mut().map(|v| &mut **v as _).collect(),
+        &mut verifier.accumulator,
+        &mut verifier.transcript,
+    )?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -311,9 +469,9 @@ mod tests {
     use atlas_onnx_tracer::{model::test::ModelBuilder, model::Model, tensor::Tensor};
     use rand::{rngs::StdRng, SeedableRng};
 
-    fn scalar_const_div_model(T: usize, divisor: i32) -> Model {
+    fn scalar_const_div_model(t: usize, divisor: i32) -> Model {
         let mut b = ModelBuilder::new();
-        let i = b.input(vec![T]);
+        let i = b.input(vec![t]);
         let res = b.scalar_const_div(i, divisor);
         b.mark_output(res);
         b.build()
@@ -321,10 +479,10 @@ mod tests {
 
     #[test]
     fn test_scalar_const_div() {
-        let T = 1 << 16;
+        let t = 1 << 16;
         let mut rng = StdRng::seed_from_u64(0x888);
-        let input = Tensor::<i32>::random_small(&mut rng, &[T]);
-        let model = scalar_const_div_model(T, 128);
+        let input = Tensor::<i32>::random_small(&mut rng, &[t]);
+        let model = scalar_const_div_model(t, 128);
         unit_test_op(model, &[input]);
     }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div_pow2.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div_pow2.rs
@@ -1,0 +1,507 @@
+use crate::onnx_proof::neural_teleport::utils::compute_ra_evals_direct;
+use crate::onnx_proof::{
+    ops::{eval_reduction::NodeEvalReduction, OperatorProofTrait, ReductionFlow},
+    ProofId, ProofType, Prover, Verifier,
+};
+use crate::utils::adjusted_remainder;
+use atlas_onnx_tracer::{
+    model::trace::{LayerData, Trace},
+    node::ComputationNode,
+    ops::{Operator, ScalarConstDivPow2},
+    tensor::Tensor,
+};
+use common::{CommittedPolynomial, VirtualPolynomial};
+use joltworks::{
+    config::{OneHotConfig, OneHotParams},
+    field::{IntoOpening, JoltField},
+    poly::{
+        identity_poly::IdentityPolynomial,
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
+        opening_proof::{
+            OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+            VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
+        },
+        unipoly::UniPoly,
+    },
+    subprotocols::{
+        shout::{self, RaOneHotEncoding},
+        sumcheck::{BatchedSumcheck, Sumcheck, SumcheckInstanceProof},
+        sumcheck_prover::SumcheckInstanceProver,
+        sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
+    },
+    transcripts::Transcript,
+    utils::{errors::ProofVerifyError, math::Math},
+};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+
+const DEGREE_BOUND: usize = 2;
+
+impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDivPow2 {
+    fn reduction_flow(&self) -> ReductionFlow {
+        ReductionFlow::Custom
+    }
+
+    #[tracing::instrument(skip_all, name = "ScalarConstDivPow2::prove")]
+    fn prove(
+        &self,
+        node: &ComputationNode,
+        prover: &mut Prover<F, T>,
+    ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
+        let mut results = Vec::new();
+
+        let params = ScalarConstDivPow2Params::new(node.clone(), &mut prover.transcript);
+        let mut exec_sumcheck = ScalarConstDivPow2Prover::initialize(
+            &prover.trace,
+            params,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+        let (exec_proof, _) = Sumcheck::prove(
+            &mut exec_sumcheck,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+        results.push((ProofId(node.idx, ProofType::Execution), exec_proof));
+
+        let encoding = ScalarConstDivPow2RaEncoding::new(node);
+        let lookup_indices = scalar_const_div_pow2_lookup_indices(&prover.trace, node);
+        let [ra_sumcheck, hw_sumcheck, bool_sumcheck] = shout::ra_onehot_provers(
+            &encoding,
+            &lookup_indices,
+            &prover.accumulator,
+            &mut prover.transcript,
+        );
+        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> =
+            vec![ra_sumcheck, hw_sumcheck, bool_sumcheck];
+        let (ra_one_hot_proof, _) = BatchedSumcheck::prove(
+            instances.iter_mut().map(|v| &mut **v as _).collect(),
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+        results.push((
+            ProofId(node.idx, ProofType::RaOneHotChecks),
+            ra_one_hot_proof,
+        ));
+
+        results
+    }
+
+    fn prove_with_reduction(
+        &self,
+        node: &ComputationNode,
+        prover: &mut Prover<F, T>,
+    ) -> (
+        joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
+        Vec<(ProofId, SumcheckInstanceProof<F, T>)>,
+    ) {
+        let proofs = self.prove(node, prover);
+        let eval_reduction_proof = NodeEvalReduction::prove(prover, node);
+        (eval_reduction_proof, proofs)
+    }
+
+    #[tracing::instrument(skip_all, name = "ScalarConstDivPow2::verify")]
+    fn verify(
+        &self,
+        node: &ComputationNode,
+        verifier: &mut Verifier<'_, F, T>,
+    ) -> Result<(), ProofVerifyError> {
+        let proof = verifier
+            .proofs
+            .get(&ProofId(node.idx, ProofType::Execution))
+            .ok_or(ProofVerifyError::MissingProof(node.idx))?;
+        let exec_sumcheck = ScalarConstDivPow2Verifier::new(
+            node.clone(),
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+        );
+        Sumcheck::verify(
+            proof,
+            &exec_sumcheck,
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+        )?;
+
+        let ra_one_hot_proof = verifier
+            .proofs
+            .get(&ProofId(node.idx, ProofType::RaOneHotChecks))
+            .ok_or(ProofVerifyError::MissingProof(node.idx))?;
+        let encoding = ScalarConstDivPow2RaEncoding::new(node);
+        let [ra_sumcheck, hw_sumcheck, bool_sumcheck] =
+            shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+        BatchedSumcheck::verify(
+            ra_one_hot_proof,
+            vec![&*ra_sumcheck, &*hw_sumcheck, &*bool_sumcheck],
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+        )?;
+
+        Ok(())
+    }
+
+    fn verify_with_reduction(
+        &self,
+        node: &ComputationNode,
+        verifier: &mut Verifier<'_, F, T>,
+        eval_reduction_proof: &joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
+    ) -> Result<(), ProofVerifyError> {
+        self.verify(node, verifier)?;
+        NodeEvalReduction::verify(verifier, node, eval_reduction_proof)
+    }
+
+    fn get_committed_polynomials(&self, node: &ComputationNode) -> Vec<CommittedPolynomial> {
+        let encoding = ScalarConstDivPow2RaEncoding::new(node);
+        let d = encoding.one_hot_params().instruction_d;
+        (0..d)
+            .map(|i| CommittedPolynomial::ScalarConstDivPow2RaD(node.idx, i))
+            .collect()
+    }
+}
+
+/// Sumcheck parameters for `ScalarConstDivPow2`.
+///
+/// Stores the sampled output point together with the constant power-of-two
+/// divisor and its log table size used by the one-hot remainder encoding.
+#[derive(Clone)]
+pub struct ScalarConstDivPow2Params<F: JoltField> {
+    r_node_output: OpeningPoint<BIG_ENDIAN, F>,
+    computation_node: ComputationNode,
+    scalar_const_divisor: i32,
+    log_table_size: usize,
+}
+
+impl<F: JoltField> ScalarConstDivPow2Params<F> {
+    /// Samples the output challenge point and validates the power-of-two divisor.
+    pub fn new<T: Transcript>(computation_node: ComputationNode, transcript: &mut T) -> Self {
+        let num_vars = computation_node.pow2_padded_num_output_elements().log_2();
+        let r_node_output = transcript.challenge_vector_optimized::<F>(num_vars);
+        let Operator::ScalarConstDivPow2(op) = &computation_node.operator else {
+            panic!("Expected ScalarConstDivPow2 operator")
+        };
+        let divisor = op.divisor;
+        assert!(
+            divisor > 0 && (divisor as u32).is_power_of_two(),
+            "ScalarConstDivPow2 proof requires a positive power-of-two divisor, got {divisor}"
+        );
+        Self {
+            r_node_output: r_node_output.into(),
+            computation_node,
+            scalar_const_divisor: divisor,
+            log_table_size: (divisor as u32).trailing_zeros() as usize,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivPow2Params<F> {
+    fn degree(&self) -> usize {
+        DEGREE_BOUND
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        let left_operand_claim = accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
+                SumcheckId::NodeExecution(self.computation_node.idx),
+            )
+            .1;
+        let quotient_claim = accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::NodeOutput(self.computation_node.idx),
+                SumcheckId::NodeExecution(self.computation_node.idx),
+            )
+            .1;
+        left_operand_claim - F::from_i32(self.scalar_const_divisor) * quotient_claim
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.log_table_size
+    }
+}
+
+/// Prover state for the `ScalarConstDivPow2` execution sumcheck.
+///
+/// The remainder is represented by a one-hot polynomial, so the prover only
+/// needs that encoding and the identity polynomial over the lookup domain.
+pub struct ScalarConstDivPow2Prover<F: JoltField> {
+    params: ScalarConstDivPow2Params<F>,
+    remainder_onehot: MultilinearPolynomial<F>,
+    identity: IdentityPolynomial<F>,
+}
+
+impl<F: JoltField> ScalarConstDivPow2Prover<F> {
+    /// Initializes the prover and caches the virtual execution openings used by the sumcheck.
+    #[tracing::instrument(skip_all)]
+    pub fn initialize(
+        trace: &Trace,
+        params: ScalarConstDivPow2Params<F>,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+    ) -> Self {
+        let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
+        let [left_operand] = operands[..] else {
+            panic!("Expected one operand for ScalarConstDivPow2 operation")
+        };
+
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::ScalarConstDivPow2Divisor(params.computation_node.idx),
+            SumcheckId::NodeExecution(params.computation_node.idx),
+            params.r_node_output.clone(),
+            F::from_i32(params.scalar_const_divisor),
+        );
+        let left_claim =
+            MultilinearPolynomial::from(left_operand.clone()).evaluate(&params.r_node_output.r);
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(params.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(params.computation_node.idx),
+            params.r_node_output.clone(),
+            left_claim,
+        );
+
+        let output_claim =
+            MultilinearPolynomial::from(output.clone()).evaluate(&params.r_node_output.r);
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(params.computation_node.idx),
+            SumcheckId::NodeExecution(params.computation_node.idx),
+            params.r_node_output.clone(),
+            output_claim,
+        );
+
+        let remainder_tensor =
+            scalar_const_div_pow2_remainder_tensor(left_operand, params.scalar_const_divisor);
+        let remainder_onehot = MultilinearPolynomial::from(compute_ra_evals_direct(
+            &params.r_node_output.r,
+            &remainder_tensor,
+            params.scalar_const_divisor as usize,
+        ));
+
+        Self {
+            identity: IdentityPolynomial::new(params.log_table_size),
+            params,
+            remainder_onehot,
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ScalarConstDivPow2Prover<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        let uni_poly_evals: [F; 2] = (0..self.remainder_onehot.len() / 2)
+            .into_par_iter()
+            .map(|i| {
+                let ra_evals =
+                    self.remainder_onehot
+                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                let id_evals =
+                    self.identity
+                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                [ra_evals[0] * id_evals[0], ra_evals[1] * id_evals[1]]
+            })
+            .reduce(
+                || [F::zero(); 2],
+                |running, new| [running[0] + new[0], running[1] + new[1]],
+            );
+
+        UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        self.remainder_onehot
+            .bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.identity.bind_parallel(r_j, BindingOrder::LowToHigh);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+        let r = [
+            opening_point.r.as_slice(),
+            self.params.r_node_output.r.as_slice(),
+        ]
+        .concat();
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::ScalarConstDivPow2Ra(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            r.into(),
+            self.remainder_onehot.final_sumcheck_claim(),
+        );
+    }
+}
+
+/// Verifier state for the `ScalarConstDivPow2` execution sumcheck.
+///
+/// The verifier samples the output point and pre-registers the virtual openings
+/// that the execution relation will reference.
+pub struct ScalarConstDivPow2Verifier<F: JoltField> {
+    params: ScalarConstDivPow2Params<F>,
+}
+
+impl<F: JoltField> ScalarConstDivPow2Verifier<F> {
+    /// Initializes the verifier and records the virtual openings used by the execution relation.
+    pub fn new<T: Transcript>(
+        computation_node: ComputationNode,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+    ) -> Self {
+        let params = ScalarConstDivPow2Params::new(computation_node, transcript);
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::ScalarConstDivPow2Divisor(params.computation_node.idx),
+            SumcheckId::NodeExecution(params.computation_node.idx),
+            params.r_node_output.clone(),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(params.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(params.computation_node.idx),
+            params.r_node_output.clone(),
+        );
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(params.computation_node.idx),
+            SumcheckId::NodeExecution(params.computation_node.idx),
+            params.r_node_output.clone(),
+        );
+        Self { params }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ScalarConstDivPow2Verifier<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(
+        &self,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) -> F {
+        let opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+        let ra_claim = accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::ScalarConstDivPow2Ra(self.params.computation_node.idx),
+                SumcheckId::NodeExecution(self.params.computation_node.idx),
+            )
+            .1;
+        let int_eval =
+            IdentityPolynomial::new(self.params.log_table_size).evaluate(&opening_point.r);
+        ra_claim * int_eval
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+        let r = [
+            opening_point.r.as_slice(),
+            self.params.r_node_output.r.as_slice(),
+        ]
+        .concat();
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::ScalarConstDivPow2Ra(self.params.computation_node.idx),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            r.into(),
+        );
+    }
+}
+
+/// One-hot encoding configuration for `ScalarConstDivPow2` remainder lookups.
+pub struct ScalarConstDivPow2RaEncoding {
+    /// Node index whose remainder one-hot columns are being committed.
+    pub node_idx: usize,
+    /// Log-size of the power-of-two lookup domain.
+    pub log_table_size: usize,
+}
+
+impl ScalarConstDivPow2RaEncoding {
+    /// Builds the one-hot encoding metadata for a single `ScalarConstDivPow2` node.
+    pub fn new(node: &ComputationNode) -> Self {
+        let Operator::ScalarConstDivPow2(op) = &node.operator else {
+            panic!("Expected ScalarConstDivPow2 operator")
+        };
+        assert!(
+            op.divisor > 0 && (op.divisor as u32).is_power_of_two(),
+            "ScalarConstDivPow2 one-hot encoding requires a positive power-of-two divisor, got {0}",
+            op.divisor
+        );
+        Self {
+            node_idx: node.idx,
+            log_table_size: (op.divisor as u32).trailing_zeros() as usize,
+        }
+    }
+}
+
+impl RaOneHotEncoding for ScalarConstDivPow2RaEncoding {
+    fn committed_poly(&self, d: usize) -> CommittedPolynomial {
+        CommittedPolynomial::ScalarConstDivPow2RaD(self.node_idx, d)
+    }
+
+    fn r_cycle_source(&self) -> (VirtualPolynomial, SumcheckId) {
+        (
+            VirtualPolynomial::ScalarConstDivPow2Divisor(self.node_idx),
+            SumcheckId::NodeExecution(self.node_idx),
+        )
+    }
+
+    fn ra_source(&self) -> (VirtualPolynomial, SumcheckId) {
+        (
+            VirtualPolynomial::ScalarConstDivPow2Ra(self.node_idx),
+            SumcheckId::NodeExecution(self.node_idx),
+        )
+    }
+
+    fn log_k(&self) -> usize {
+        self.log_table_size
+    }
+
+    fn one_hot_params(&self) -> OneHotParams {
+        OneHotParams::from_config_and_log_K(&OneHotConfig::default(), self.log_table_size)
+    }
+}
+
+fn scalar_const_div_pow2_lookup_indices(trace: &Trace, node: &ComputationNode) -> Vec<usize> {
+    let LayerData { operands, .. } = Trace::layer_data(trace, node);
+    let [input] = operands[..] else {
+        panic!("Expected one operand for ScalarConstDivPow2 operation")
+    };
+    let Operator::ScalarConstDivPow2(op) = &node.operator else {
+        panic!("Expected ScalarConstDivPow2 operator")
+    };
+    input
+        .par_iter()
+        .map(|&x| adjusted_remainder(x, op.divisor) as usize)
+        .collect()
+}
+
+fn scalar_const_div_pow2_remainder_tensor(input: &Tensor<i32>, divisor: i32) -> Tensor<i32> {
+    let remainder_data: Vec<i32> = input
+        .iter()
+        .map(|&a| adjusted_remainder(a, divisor))
+        .collect();
+    Tensor::<i32>::construct(remainder_data, input.dims().to_vec())
+}

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div_pow2.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div_pow2.rs
@@ -65,6 +65,14 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDivPow
         );
         results.push((ProofId(node.idx, ProofType::Execution), exec_proof));
 
+        // TODO(soundness): scalar outputs currently skip the RA one-hot range
+        // check, matching the existing Div behavior. Add a scalar-specific
+        // remainder range proof instead of relying only on the execution
+        // relation.
+        if node.is_scalar() {
+            return results;
+        }
+
         let encoding = ScalarConstDivPow2RaEncoding::new(node);
         let lookup_indices = scalar_const_div_pow2_lookup_indices(&prover.trace, node);
         let [ra_sumcheck, hw_sumcheck, bool_sumcheck] = shout::ra_onehot_provers(
@@ -123,6 +131,14 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDivPow
             &mut verifier.transcript,
         )?;
 
+        // TODO(soundness): scalar outputs currently skip the RA one-hot range
+        // check, matching the existing Div behavior. Add a scalar-specific
+        // remainder range proof instead of relying only on the execution
+        // relation.
+        if node.is_scalar() {
+            return Ok(());
+        }
+
         let ra_one_hot_proof = verifier
             .proofs
             .get(&ProofId(node.idx, ProofType::RaOneHotChecks))
@@ -151,6 +167,14 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDivPow
     }
 
     fn get_committed_polynomials(&self, node: &ComputationNode) -> Vec<CommittedPolynomial> {
+        // TODO(soundness): scalar outputs currently skip the RA one-hot range
+        // check, matching the existing Div behavior. Add a scalar-specific
+        // remainder range proof instead of relying only on the execution
+        // relation.
+        if node.is_scalar() {
+            return Vec::new();
+        }
+
         let encoding = ScalarConstDivPow2RaEncoding::new(node);
         let d = encoding.one_hot_params().instruction_d;
         (0..d)

--- a/jolt-atlas-core/src/onnx_proof/range_checking/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/range_checking/mod.rs
@@ -251,7 +251,7 @@ impl<H: RangeCheckingOperandsTrait> RaOneHotEncoding for RangeCheckEncoding<H> {
 
     fn r_cycle_source(&self) -> (VirtualPolynomial, SumcheckId) {
         (
-            VirtualPolynomial::NodeOutput(self.operands.node_idx()),
+            self.operands.get_input_operands()[0],
             SumcheckId::NodeExecution(self.operands.node_idx()),
         )
     }

--- a/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
+++ b/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
@@ -135,6 +135,14 @@ pub struct RsRangeCheckOperands {
     base: RangeCheckOperandsBase,
 }
 
+/// Operands for scalar-constant division range-checking.
+///
+/// For integer division `a / b = q` with constant positive `b`, verifies that
+/// the remainder `r` satisfies `0 ≤ r < b`.
+pub struct ScalarConstDivRangeCheckOperands {
+    base: RangeCheckOperandsBase,
+}
+
 impl RangeCheckingOperandsTrait for DivRangeCheckOperands {
     fn new(node: &ComputationNode) -> Self {
         Self {
@@ -175,6 +183,59 @@ impl RangeCheckingOperandsTrait for DivRangeCheckOperands {
 
     fn rad_poly(&self, d: usize) -> CommittedPolynomial {
         CommittedPolynomial::DivRangeCheckRaD(self.base.node_idx, d)
+    }
+}
+
+impl RangeCheckingOperandsTrait for ScalarConstDivRangeCheckOperands {
+    fn new(node: &ComputationNode) -> Self {
+        Self {
+            base: RangeCheckOperandsBase {
+                node_idx: node.idx,
+                input_operands: vec![
+                    VirtualPolynomial::DivRemainder(node.idx),
+                    VirtualPolynomial::ScalarConstDivDivisor(node.idx),
+                ],
+                virtual_ra: VirtualPolynomial::ScalarConstDivRangeCheckRa(node.idx),
+            },
+        }
+    }
+
+    fn base(&self) -> &RangeCheckOperandsBase {
+        &self.base
+    }
+
+    fn get_operands_tensors(trace: &Trace, node: &ComputationNode) -> (Tensor<i32>, Tensor<i32>) {
+        let LayerData {
+            output: _,
+            operands,
+        } = Trace::layer_data(trace, node);
+
+        let [dividend] = operands[..] else {
+            panic!("Expected exactly one input tensor");
+        };
+        let Operator::ScalarConstDiv(op) = &node.operator else {
+            panic!("Expected ScalarConstDiv node");
+        };
+        assert!(
+            op.divisor > 0,
+            "ScalarConstDiv range-check requires a positive divisor, got {}",
+            op.divisor
+        );
+
+        let remainder_data: Vec<i32> = dividend
+            .iter()
+            .map(|&a| adjusted_remainder(a, op.divisor))
+            .collect();
+        let divisor_data = vec![op.divisor; dividend.len()];
+
+        (
+            Tensor::<i32>::construct(remainder_data, dividend.dims().to_vec()),
+            Tensor::<i32>::construct(divisor_data, dividend.dims().to_vec()),
+        )
+    }
+
+    fn rad_poly(&self, d: usize) -> CommittedPolynomial {
+        CommittedPolynomial::ScalarConstDivRangeCheckRaD(self.base.node_idx, d)
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -22,7 +22,7 @@ use crate::{
         ops::{rsqrt::Q_SQUARE, softmax_axes::softmax::scalar_div::S},
         range_checking::range_check_operands::{
             DivRangeCheckOperands, RangeCheckingOperandsTrait, RiRangeCheckOperands,
-            RsRangeCheckOperands, TeleportRangeCheckOperands,
+            RsRangeCheckOperands, ScalarConstDivRangeCheckOperands, TeleportRangeCheckOperands,
         },
     },
     utils::{adjusted_remainder, compute_lookup_indices_from_operands},
@@ -96,6 +96,23 @@ fn build_one_hot_rad_witness<F: JoltField>(
         .collect();
     MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
         addresses,
+        one_hot_params.k_chunk,
+    ))
+}
+
+fn build_custom_one_hot_rad_witness<F: JoltField>(
+    lookup_indices: &[usize],
+    log_k: usize,
+    d: usize,
+) -> MultilinearPolynomial<F> {
+    let one_hot_params = OneHotParams::from_config_and_log_K(&OneHotConfig::default(), log_k);
+    let h_indices =
+        subprotocols::shout::compute_instruction_h_indices(lookup_indices, &one_hot_params);
+    MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
+        h_indices[d]
+            .par_iter()
+            .map(|&h| h.map(|h| h as u16))
+            .collect(),
         one_hot_params.k_chunk,
     ))
 }
@@ -218,24 +235,10 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 let (quotient, _remainder) = compute_division(input, tau);
                 MultilinearPolynomial::from(quotient)
             }
-            CommittedPolynomial::ScalarConstDivNodeRemainder(node_idx) => {
-                let computation_node = &model.graph.nodes[node_idx];
-                let Operator::ScalarConstDiv(op) = &computation_node.operator else {
-                    panic!("Expected ScalarConstDiv operator at node {node_idx}");
-                };
-                let b = op.divisor;
-                let layer_data = Trace::layer_data(trace, computation_node);
-                let [left_operand] = layer_data.operands[..] else {
-                    panic!("Expected one operand for ScalarConstDiv operation")
-                };
-                let remainder_data: Vec<i32> = left_operand
-                    .iter()
-                    .map(|&a| adjusted_remainder(a, b))
-                    .collect();
-                MultilinearPolynomial::from(Tensor::<i32>::construct(
-                    remainder_data,
-                    left_operand.dims().to_vec(),
-                ))
+            CommittedPolynomial::ScalarConstDivNodeRemainder(_node_idx) => {
+                panic!(
+                    "ScalarConstDivNodeRemainder is no longer committed; use ScalarConstDivRangeCheckRaD / DivRemainder"
+                )
             }
             CommittedPolynomial::RsqrtNodeInv(node_idx) => {
                 let computation_node = &model.graph.nodes[node_idx];
@@ -251,6 +254,34 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 build_range_check_rad_witness::<F, DivRangeCheckOperands>(
                     model, trace, *node_idx, *d,
                 )
+            }
+            CommittedPolynomial::ScalarConstDivRangeCheckRaD(node_idx, d) => {
+                build_range_check_rad_witness::<F, ScalarConstDivRangeCheckOperands>(
+                    model, trace, *node_idx, *d,
+                )
+            }
+            CommittedPolynomial::ScalarConstDivPow2RaD(node_idx, d) => {
+                let computation_node = &model.graph.nodes[node_idx];
+                let Operator::ScalarConstDivPow2(op) = &computation_node.operator else {
+                    panic!(
+                        "Expected ScalarConstDivPow2 operator for ScalarConstDivPow2RaD witness"
+                    );
+                };
+                assert!(
+                    op.divisor > 0 && (op.divisor as u32).is_power_of_two(),
+                    "ScalarConstDivPow2RaD witness requires a positive power-of-two divisor, got {}",
+                    op.divisor
+                );
+                let log_table = (op.divisor as u32).trailing_zeros() as usize;
+                let layer_data = Trace::layer_data(trace, computation_node);
+                let [input] = layer_data.operands[..] else {
+                    panic!("Expected one operand for ScalarConstDivPow2 operation")
+                };
+                let lookup_indices: Vec<usize> = input
+                    .par_iter()
+                    .map(|&x| adjusted_remainder(x, op.divisor) as usize)
+                    .collect();
+                build_custom_one_hot_rad_witness(&lookup_indices, log_table, *d)
             }
             CommittedPolynomial::SqrtRangeCheckRaD(node_idx, d) => {
                 build_range_check_rad_witness::<F, RsRangeCheckOperands>(


### PR DESCRIPTION
This PR adds `ScalarConstDivPow2` as a dedicated path for fixed-point rebasing when the divisor is a power of two. Operations like `Mul` and `Einsum` now use this path when possible.

`ScalarConstDivPow2` represents the remainder with a one-hot RA encoding and range-checks it with the existing LUT and `commit_to_onehot()` flow. The reason for using a LUT here is that it fits the current lookup and RA machinery, so we can add this optimization without changing the commitment layer. A future `commit_to_bits()`-style path should be even lighter, but in this PR I prioritized an implementation that works with the current commitment design.

This PR also updates `ScalarConstDiv` for the general-divisor case. It now proves `0 <= r < divisor` with the same LUT/RA idea that `Div` uses. As part of that change, the dense remainder commitment is removed and replaced with a virtual remainder plus range-check claims.

One more issue showed up while testing this change. In `onnx_proof::e2e_tests::test_multihead_attention`, a `ScalarConstDivPow2` node can produce an output tensor of length 1. In that case, the RA sumcheck ends up with zero rounds and panics. Fixing this properly requires a change in the sumcheck side so that zero-round RA virtualization is handled correctly. For now, scalar `ScalarConstDivPow2` skips the RA one-hot checks, matching the current `Div` behavior. This is a real soundness issue, so it should be fixed in a separate PR.

Close #203