### PR TITLE
Fix: Rewrite reshape/concat/slice with eq-selector

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/ops/concat.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/concat.rs
@@ -1,87 +1,56 @@
 use atlas_onnx_tracer::{
-    model::trace::{LayerData, Trace},
+    model::{
+        trace::{LayerData, Trace},
+        ComputationGraph,
+    },
     node::ComputationNode,
     ops::{Concat, Operator},
-    utils::dims::Pad,
 };
 use common::VirtualPolynomial;
 use joltworks::{
-    field::JoltField,
-    poly::opening_proof::{OpeningAccumulator, SumcheckId},
+    field::{IntoOpening, JoltField},
+    poly::{
+        eq_poly::EqPolynomial,
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
+        opening_proof::{
+            OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+            VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
+        },
+        unipoly::UniPoly,
+    },
     subprotocols::{
-        gamma_fold::{gamma_powers, GammaFoldProver, GammaFoldVerifier},
-        sumcheck::{BatchedSumcheck, SumcheckInstanceProof},
+        sumcheck::Sumcheck,
+        sumcheck::SumcheckInstanceProof,
         sumcheck_prover::SumcheckInstanceProver,
-        sumcheck_verifier::SumcheckInstanceVerifier,
+        sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::errors::ProofVerifyError,
+    utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
 };
 
-use crate::onnx_proof::{
-    ops::{eval_reduction::NodeEvalReduction, OperatorProofTrait, ReductionFlow},
-    ProofId, ProofType, Prover, Verifier,
-};
+use crate::onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier};
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Concat {
-    fn reduction_flow(&self) -> ReductionFlow {
-        ReductionFlow::Custom
-    }
-
     #[tracing::instrument(skip_all, name = "Concat::prove")]
     fn prove(
         &self,
         node: &ComputationNode,
         prover: &mut Prover<F, T>,
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
-        let Operator::Concat(concat_op) = &node.operator else {
-            panic!("Expected Concat operator")
-        };
-
-        let gamma: F = prover.transcript.challenge_scalar();
-
-        let raw_inputs_dims = {
-            let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
-            operands
-                .iter()
-                .map(|tensor| tensor.dims())
-                .collect::<Vec<_>>()
-        };
-        let input_count = raw_inputs_dims.len();
-        assert!(input_count > 0, "Concat expects at least one operand");
-
-        let axis = normalize_axis(concat_op.axis, node.output_dims.len());
-        let ctx = ConcatGammaWeightsContext::new(&raw_inputs_dims, &node.output_dims, axis, gamma);
-
-        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> =
-            Vec::with_capacity(1 + input_count);
-
-        instances.push(Box::new(initialize_output_prover(node, &ctx, prover)));
-        for input_idx in 0..input_count {
-            instances.push(Box::new(initialize_input_prover(
-                node, input_idx, &ctx, prover,
-            )));
-        }
-        let (proof, _) = BatchedSumcheck::prove(
-            instances.iter_mut().map(|v| &mut **v as _).collect(),
+        let params = ConcatSumcheckParams::new(
+            node.clone(),
+            &prover.accumulator,
+            &prover.preprocessing.model.graph,
+        );
+        let mut prover_sumcheck = ConcatSumcheckProver::initialize(&prover.trace, params);
+        let (proof, _) = Sumcheck::prove(
+            &mut prover_sumcheck,
             &mut prover.accumulator,
             &mut prover.transcript,
         );
-
         vec![(ProofId(node.idx, ProofType::Execution), proof)]
-    }
-
-    fn prove_with_reduction(
-        &self,
-        node: &ComputationNode,
-        prover: &mut Prover<F, T>,
-    ) -> (
-        joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
-        Vec<(ProofId, SumcheckInstanceProof<F, T>)>,
-    ) {
-        let execution_proofs = self.prove(node, prover);
-        let eval_reduction_proof = NodeEvalReduction::prove(prover, node);
-        (eval_reduction_proof, execution_proofs)
     }
 
     #[tracing::instrument(skip_all, name = "Concat::verify")]
@@ -94,149 +63,392 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Concat {
             .proofs
             .get(&ProofId(node.idx, ProofType::Execution))
             .ok_or(ProofVerifyError::MissingProof(node.idx))?;
-
-        let Operator::Concat(concat_op) = &node.operator else {
-            panic!("Expected Concat operator")
-        };
-
-        let gamma: F = verifier.transcript.challenge_scalar();
-
-        let raw_inputs_dims = {
-            let graph = &verifier.preprocessing.model.graph;
-            let input_nodes = graph.get_input_nodes(node);
-            input_nodes
-                .iter()
-                .map(|input_node| input_node.output_dims.as_slice())
-                .collect::<Vec<&[usize]>>()
-        };
-        let input_count = raw_inputs_dims.len();
-        assert!(input_count > 0, "Concat expects at least one input node");
-
-        let axis = normalize_axis(concat_op.axis, node.output_dims.len());
-        let ctx = ConcatGammaWeightsContext::new(&raw_inputs_dims, &node.output_dims, axis, gamma);
-
-        let mut verifiers = Vec::with_capacity(1 + input_count);
-        verifiers.push(initialize_output_verifier(node, &ctx, verifier));
-        for input_idx in 0..input_count {
-            verifiers.push(initialize_input_verifier(node, input_idx, &ctx, verifier));
-        }
-
-        let instances: Vec<&dyn SumcheckInstanceVerifier<F, T>> = verifiers
-            .iter()
-            .map(|instance| instance as &dyn SumcheckInstanceVerifier<F, T>)
-            .collect();
-        BatchedSumcheck::verify(
+        let verifier_sumcheck = ConcatSumcheckVerifier::new(
+            node.clone(),
+            &verifier.accumulator,
+            &verifier.preprocessing.model.graph,
+        );
+        Sumcheck::verify(
             proof,
-            instances,
+            &verifier_sumcheck,
             &mut verifier.accumulator,
             &mut verifier.transcript,
         )?;
-
-        let claim_c = verifier
-            .accumulator
-            .get_virtual_polynomial_opening(claim_poly_output(node), SumcheckId::RLC(node.idx))
-            .1;
-        let expected_claim_c = (0..input_count).fold(F::zero(), |running, input_idx| {
-            let input_claim = verifier
-                .accumulator
-                .get_virtual_polynomial_opening(
-                    claim_poly_input(node, input_idx),
-                    SumcheckId::RLC(node.idx),
-                )
-                .1;
-            running + input_claim
-        });
-        if claim_c != expected_claim_c {
-            return Err(ProofVerifyError::InvalidOpeningProof(
-                "Concat folded-claim relation failed".to_string(),
-            ));
-        }
-
         Ok(())
     }
+}
 
-    fn verify_with_reduction(
-        &self,
-        node: &ComputationNode,
-        verifier: &mut Verifier<'_, F, T>,
-        eval_reduction_proof: &joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
-    ) -> Result<(), ProofVerifyError> {
-        self.verify(node, verifier)?;
-        NodeEvalReduction::verify(verifier, node, eval_reduction_proof)
+/// Parameters for the concat selector sumcheck.
+#[derive(Clone)]
+pub struct ConcatSumcheckParams<F: JoltField> {
+    /// Concat node being proven.
+    pub computation_node: ComputationNode,
+    /// Reduced opening point for the concat output.
+    pub r_output: OpeningPoint<BIG_ENDIAN, F>,
+    /// Raw input shapes for each concat operand.
+    pub input_raw_dims: Vec<Vec<usize>>,
+    /// Raw output shape for the concat result.
+    pub output_raw_dims: Vec<usize>,
+    /// Normalized concat axis.
+    pub axis: usize,
+    /// Maximum padded input domain size, in variables.
+    pub max_input_num_vars: usize,
+}
+
+impl<F: JoltField> ConcatSumcheckParams<F> {
+    /// Build concat sumcheck parameters from the graph metadata and reduced output opening.
+    pub fn new(
+        computation_node: ComputationNode,
+        accumulator: &dyn OpeningAccumulator<F>,
+        graph: &ComputationGraph,
+    ) -> Self {
+        let Operator::Concat(concat_op) = &computation_node.operator else {
+            panic!("Expected Concat operator")
+        };
+        let r_output = accumulator.get_node_output_opening(computation_node.idx).0;
+        let input_raw_dims = graph
+            .get_input_nodes(&computation_node)
+            .iter()
+            .map(|input_node| input_node.output_dims.clone())
+            .collect::<Vec<_>>();
+        let output_raw_dims = computation_node.output_dims.clone();
+        let axis = normalize_axis(concat_op.axis, output_raw_dims.len());
+        validate_concat_shapes(
+            &input_raw_dims
+                .iter()
+                .map(|dims| dims.as_slice())
+                .collect::<Vec<_>>(),
+            &output_raw_dims,
+            axis,
+        );
+        let max_input_num_vars = input_raw_dims
+            .iter()
+            .map(|dims| padded_domain_len(dims).log_2())
+            .max()
+            .unwrap_or(0);
+
+        Self {
+            computation_node,
+            r_output,
+            input_raw_dims,
+            output_raw_dims,
+            axis,
+            max_input_num_vars,
+        }
     }
 }
 
-fn initialize_output_prover<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
-    ctx: &ConcatGammaWeightsContext<F>,
-    prover: &mut Prover<F, T>,
-) -> GammaFoldProver<F> {
-    let LayerData { output, .. } = Trace::layer_data(&prover.trace, node);
+impl<F: JoltField> SumcheckInstanceParams<F> for ConcatSumcheckParams<F> {
+    fn degree(&self) -> usize {
+        2
+    }
 
-    GammaFoldProver::initialize(
-        node.idx,
-        claim_poly_output(node),
-        output,
-        ctx.output_gamma_weights(),
-        &mut prover.accumulator,
-        &mut prover.transcript,
-    )
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.max_input_num_vars
+    }
 }
 
-fn initialize_input_prover<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
+struct ConcatInputTerm<F: JoltField> {
+    producer_idx: usize,
+    input_num_vars: usize,
+    input_mle: MultilinearPolynomial<F>,
+    selector_mle: MultilinearPolynomial<F>,
+}
+
+/// Prover state for the concat selector sumcheck.
+pub struct ConcatSumcheckProver<F: JoltField> {
+    /// Static concat parameters shared across all rounds.
+    pub params: ConcatSumcheckParams<F>,
+    input_terms: Vec<ConcatInputTerm<F>>,
+}
+
+impl<F: JoltField> ConcatSumcheckProver<F> {
+    /// Initialize prover state from trace tensors and prepared concat parameters.
+    pub fn initialize(trace: &Trace, params: ConcatSumcheckParams<F>) -> Self {
+        let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
+        assert!(!operands.is_empty(), "Concat expects at least one operand");
+        assert_eq!(
+            operands.len(),
+            params.input_raw_dims.len(),
+            "Concat input shape count mismatch"
+        );
+
+        let output_padded_len = output.padded_next_power_of_two().len();
+        let max_input_domain_len = 1usize << params.max_input_num_vars;
+        assert!(
+            max_input_domain_len <= output_padded_len,
+            "Concat max input domain cannot exceed output padded domain"
+        );
+
+        let input_terms = operands
+            .iter()
+            .enumerate()
+            .map(|(input_idx, input_tensor)| {
+                let input_padded = input_tensor.padded_next_power_of_two();
+                let input_num_vars = input_padded.len().log_2();
+                let extended_input = extend_input_to_max_domain(
+                    input_padded.data(),
+                    input_num_vars,
+                    params.max_input_num_vars,
+                );
+                let selector = build_concat_selector(
+                    &params.input_raw_dims,
+                    &params.output_raw_dims,
+                    params.axis,
+                    input_idx,
+                    &params.r_output.r,
+                    params.max_input_num_vars,
+                );
+                ConcatInputTerm {
+                    producer_idx: params.computation_node.inputs[input_idx],
+                    input_num_vars,
+                    input_mle: MultilinearPolynomial::from(extended_input),
+                    selector_mle: MultilinearPolynomial::from(selector),
+                }
+            })
+            .collect();
+
+        Self {
+            params,
+            input_terms,
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ConcatSumcheckProver<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        const DEGREE_BOUND: usize = 2;
+        let half_poly_len = self
+            .input_terms
+            .first()
+            .map(|term| term.input_mle.len() / 2)
+            .unwrap_or(0);
+        let mut uni_poly_evals = [F::zero(); 2];
+
+        for term in &self.input_terms {
+            for i in 0..half_poly_len {
+                let input_evals =
+                    term.input_mle
+                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                let selector_evals =
+                    term.selector_mle
+                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                uni_poly_evals[0] += input_evals[0] * selector_evals[0];
+                uni_poly_evals[1] += input_evals[1] * selector_evals[1];
+            }
+        }
+
+        UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        for term in &mut self.input_terms {
+            term.input_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
+            term.selector_mle
+                .bind_parallel(r_j, BindingOrder::LowToHigh);
+        }
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let full_opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+        for term in &self.input_terms {
+            let live_opening_point = full_opening_point.r[..term.input_num_vars].to_vec();
+            accumulator.append_virtual(
+                transcript,
+                VirtualPolynomial::NodeOutput(term.producer_idx),
+                SumcheckId::NodeExecution(self.params.computation_node.idx),
+                live_opening_point.into(),
+                term.input_mle.final_sumcheck_claim(),
+            );
+        }
+    }
+}
+
+/// Verifier state for the concat selector sumcheck.
+pub struct ConcatSumcheckVerifier<F: JoltField> {
+    /// Static concat parameters shared across all rounds.
+    pub params: ConcatSumcheckParams<F>,
+}
+
+impl<F: JoltField> ConcatSumcheckVerifier<F> {
+    /// Build the concat verifier from the reduced output opening and graph metadata.
+    pub fn new(
+        computation_node: ComputationNode,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        graph: &ComputationGraph,
+    ) -> Self {
+        let params = ConcatSumcheckParams::new(computation_node, accumulator, graph);
+        Self { params }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ConcatSumcheckVerifier<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(
+        &self,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) -> F {
+        let full_opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+
+        self.params.input_raw_dims.iter().enumerate().fold(
+            F::zero(),
+            |running, (input_idx, input_raw_dims)| {
+                let input_num_vars = padded_domain_len(input_raw_dims).log_2();
+                let input_claim = accumulator.get_node_output_claim(
+                    self.params.computation_node.inputs[input_idx],
+                    self.params.computation_node.idx,
+                );
+                let selector = build_concat_selector(
+                    &self.params.input_raw_dims,
+                    &self.params.output_raw_dims,
+                    self.params.axis,
+                    input_idx,
+                    &self.params.r_output.r,
+                    self.params.max_input_num_vars,
+                );
+                let selector_claim =
+                    MultilinearPolynomial::from(selector).evaluate(&full_opening_point.r);
+                let _ = input_num_vars;
+                running + input_claim * selector_claim
+            },
+        )
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let full_opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+        for (input_idx, input_raw_dims) in self.params.input_raw_dims.iter().enumerate() {
+            let input_num_vars = padded_domain_len(input_raw_dims).log_2();
+            let live_opening_point = full_opening_point.r[..input_num_vars].to_vec();
+            accumulator.append_virtual(
+                transcript,
+                VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[input_idx]),
+                SumcheckId::NodeExecution(self.params.computation_node.idx),
+                live_opening_point.into(),
+            );
+        }
+    }
+}
+
+fn padded_domain_len(dims: &[usize]) -> usize {
+    dims.iter().map(|dim| dim.next_power_of_two()).product()
+}
+
+fn extend_input_to_max_domain<T: Copy>(
+    input_padded: &[T],
+    input_num_vars: usize,
+    max_num_vars: usize,
+) -> Vec<T> {
+    let pad_repeat = 1usize << (max_num_vars - input_num_vars);
+    let mut extended = Vec::with_capacity(input_padded.len() * pad_repeat);
+    for value in input_padded {
+        for _ in 0..pad_repeat {
+            extended.push(*value);
+        }
+    }
+    extended
+}
+
+fn build_concat_selector<F: JoltField>(
+    raw_input_dims: &[Vec<usize>],
+    output_raw_dims: &[usize],
+    axis: usize,
     input_idx: usize,
-    ctx: &ConcatGammaWeightsContext<F>,
-    prover: &mut Prover<F, T>,
-) -> GammaFoldProver<F> {
-    let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
-    let input_tensor = operands
+    r_output: &[F],
+    max_input_num_vars: usize,
+) -> Vec<F> {
+    let input_raw_dims = raw_input_dims
         .get(input_idx)
         .unwrap_or_else(|| panic!("Concat input_idx {input_idx} out of range"));
+    let input_raw_len: usize = input_raw_dims.iter().product();
+    let input_padded_dims: Vec<usize> = input_raw_dims
+        .iter()
+        .map(|dim| dim.next_power_of_two())
+        .collect();
+    let input_domain_len: usize = input_padded_dims.iter().product();
+    let input_num_vars = input_domain_len.log_2();
 
-    GammaFoldProver::initialize(
-        node.idx,
-        claim_poly_input(node, input_idx),
-        input_tensor,
-        ctx.gamma_weights(input_idx),
-        &mut prover.accumulator,
-        &mut prover.transcript,
-    )
+    let output_padded_dims: Vec<usize> = output_raw_dims
+        .iter()
+        .map(|dim| dim.next_power_of_two())
+        .collect();
+    let output_domain_len: usize = output_padded_dims.iter().product();
+    let output_num_vars = output_domain_len.log_2();
+    assert_eq!(
+        output_num_vars,
+        r_output.len(),
+        "Concat selector expects output challenge length to match output padded domain"
+    );
+
+    let max_domain_len = 1usize << max_input_num_vars;
+    let axis_offset = axis_offset(raw_input_dims, input_idx, axis);
+    let mut selector = vec![F::zero(); max_domain_len];
+
+    for linear_idx in 0..input_raw_len {
+        let input_coord = linear_to_coord(linear_idx, input_raw_dims);
+        let mut output_coord = input_coord.clone();
+        output_coord[axis] += axis_offset;
+
+        let input_index = coord_to_linear(&input_coord, &input_padded_dims);
+        let output_index = coord_to_linear(&output_coord, &output_padded_dims);
+        let output_bits = index_to_field_bitvector::<F>(output_index as u64, output_num_vars);
+        let full_index = input_index << (max_input_num_vars - input_num_vars);
+        selector[full_index] = EqPolynomial::mle(&output_bits, r_output);
+    }
+
+    selector
 }
 
-fn initialize_output_verifier<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
-    ctx: &ConcatGammaWeightsContext<F>,
-    verifier: &mut Verifier<'_, F, T>,
-) -> GammaFoldVerifier<F> {
-    GammaFoldVerifier::initialize(
-        node.idx,
-        claim_poly_output(node),
-        node.pow2_padded_num_output_elements(),
-        ctx.output_gamma_weights(),
-        &mut verifier.accumulator,
-        &mut verifier.transcript,
-    )
+fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
+    let mut coord = vec![0; dims.len()];
+    for axis in (0..dims.len()).rev() {
+        coord[axis] = index % dims[axis];
+        index /= dims[axis];
+    }
+    coord
 }
 
-fn initialize_input_verifier<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
-    input_idx: usize,
-    ctx: &ConcatGammaWeightsContext<F>,
-    verifier: &mut Verifier<'_, F, T>,
-) -> GammaFoldVerifier<F> {
-    let graph = &verifier.preprocessing.model.graph;
-    let input_nodes = graph.get_input_nodes(node);
-    let input_num_elements = input_nodes[input_idx].pow2_padded_num_output_elements();
-
-    GammaFoldVerifier::initialize(
-        node.idx,
-        claim_poly_input(node, input_idx),
-        input_num_elements,
-        ctx.gamma_weights(input_idx),
-        &mut verifier.accumulator,
-        &mut verifier.transcript,
-    )
+fn coord_to_linear(coord: &[usize], dims: &[usize]) -> usize {
+    let mut index = 0usize;
+    let mut stride = 1usize;
+    for axis in (0..dims.len()).rev() {
+        index += coord[axis] * stride;
+        stride *= dims[axis];
+    }
+    index
 }
 
 /// Normalizes an ONNX-style axis (possibly negative) to a canonical `[0, rank)` axis.
@@ -251,12 +463,6 @@ fn normalize_axis(axis: isize, rank: usize) -> usize {
 }
 
 /// Validates concat shape rules.
-///
-/// All inputs must share rank with output. Non-concat dimensions must match output,
-/// and concat dimension in output must equal the sum of the same dimension across inputs.
-///
-/// Note:
-/// Requires non-padded shapes.
 fn validate_concat_shapes(inputs_dims: &[&[usize]], out_dims: &[usize], axis: usize) {
     assert!(!inputs_dims.is_empty(), "Concat expects at least one input");
     let rank = out_dims.len();
@@ -283,141 +489,22 @@ fn validate_concat_shapes(inputs_dims: &[&[usize]], out_dims: &[usize], axis: us
     }
 }
 
-/// Context for generating concat-aware gamma weights for each input polynomial.
-struct ConcatGammaWeightsContext<F: JoltField> {
-    /// Raw input dims, the source of truth for concat indexing.
-    inputs_dims: Vec<Vec<usize>>,
-    /// Raw output dims are used for stride computation.
-    output_dims: Vec<usize>,
-    /// Concat axis index.
-    axis: usize,
-    /// Gamma powers over raw output linear indices.
-    gamma_powers: Vec<F>,
-}
-
-impl<F: JoltField> ConcatGammaWeightsContext<F> {
-    fn new(raw_inputs: &[&[usize]], raw_output_dims: &[usize], axis: usize, gamma: F) -> Self {
-        validate_concat_shapes(raw_inputs, raw_output_dims, axis);
-
-        let raw_inputs = raw_inputs.iter().map(|dims| dims.to_vec()).collect();
-        let output_len: usize = raw_output_dims.iter().product();
-        let gamma_powers = gamma_powers(output_len, gamma);
-
-        Self {
-            inputs_dims: raw_inputs,
-            output_dims: raw_output_dims.to_vec(),
-            axis,
-            gamma_powers,
-        }
-    }
-
-    /// Returns the linearized gamma weights for the concat output polynomial.
-    fn output_gamma_weights(&self) -> Vec<F> {
-        self.gamma_powers.pad_next_power_of_two(&self.output_dims)
-    }
-
-    fn input_dims(&self, input_idx: usize) -> &[usize] {
-        self.inputs_dims
-            .get(input_idx)
-            .unwrap_or_else(|| panic!("Concat input_idx {input_idx} out of range"))
-    }
-
-    /// Returns the axis offset (in output coordinates) for the given input.
-    fn axis_offset(&self, input_idx: usize) -> usize {
-        self.inputs_dims[..input_idx]
-            .iter()
-            .map(|dims| dims[self.axis])
-            .sum()
-    }
-
-    /// Builds concat-aware gamma weights for one input tensor.
-    ///
-    /// The produced vector aligns with row-major linearization of the padded input.
-    /// Weights are built directly in unpadded layout using concat recursion,
-    /// And then padded with 0s.
-    ///
-    /// Example
-    /// ```ignore
-    /// // For concat of [2,2] and [2,1] on axis 1.
-    /// // Position of input 1, index [0,0] in output is [0, 2]
-    /// // i.e. 2 in row-major order, so it's weight is gamma^2.
-    /// // Complete weight vector for input 1 is [gamma^2, gamma^5]
-    /// ```
-    ///
-    fn gamma_weights(&self, input_idx: usize) -> Vec<F> {
-        let input_dims = self.input_dims(input_idx);
-        let poly_len: usize = input_dims.iter().product();
-
-        if poly_len == 0 {
-            return Vec::new();
-        }
-
-        let rank = input_dims.len();
-        assert!(rank > 0, "Concat input rank must be non-zero");
-
-        let weights_slice = self.build_weights_recursive(rank - 1, vec![F::one()], input_idx);
-
-        debug_assert_eq!(weights_slice.len(), poly_len);
-
-        weights_slice.pad_next_power_of_two(input_dims)
-    }
-
-    /// Recursively expands an inner weight slice to outer dimensions.
-    ///
-    /// At each dimension, each block is multiplied by the appropriate gamma stride,
-    /// and by an axis offset when this is the concat dimension.
-    fn build_weights_recursive(
-        &self,
-        dim: usize,
-        current_slice: Vec<F>,
-        input_idx: usize,
-    ) -> Vec<F> {
-        let input_dims = self.input_dims(input_idx);
-        let dim_offset = if self.axis == dim {
-            self.axis_offset(input_idx)
-        } else {
-            0
-        };
-        let output_linear_factor: usize = self.output_dims.iter().skip(dim + 1).product();
-
-        let mut outer_slice = Vec::with_capacity(input_dims[dim] * current_slice.len());
-        for i in 0..input_dims[dim] {
-            let exp = (i + dim_offset) * output_linear_factor;
-
-            let dim_factor = self.gamma_powers[exp];
-            outer_slice.extend(current_slice.iter().map(|w| *w * dim_factor));
-        }
-
-        if dim == 0 {
-            outer_slice
-        } else {
-            self.build_weights_recursive(dim - 1, outer_slice, input_idx)
-        }
-    }
-}
-
-fn claim_poly_output(node: &ComputationNode) -> VirtualPolynomial {
-    VirtualPolynomial::NodeOutput(node.idx)
-}
-
-fn claim_poly_input(node: &ComputationNode, input_idx: usize) -> VirtualPolynomial {
-    let input_node_idx = *node
-        .inputs
-        .get(input_idx)
-        .unwrap_or_else(|| panic!("Concat input_idx {input_idx} out of range"));
-    VirtualPolynomial::NodeOutput(input_node_idx)
+/// Returns the axis offset (in output coordinates) for the given input.
+fn axis_offset(raw_input_dims: &[Vec<usize>], input_idx: usize, axis: usize) -> usize {
+    raw_input_dims
+        .iter()
+        .take(input_idx)
+        .map(|dims| dims[axis])
+        .sum()
 }
 
 #[cfg(test)]
 mod tests {
     use crate::onnx_proof::ops::test::unit_test_op;
-    use ark_bn254::Fr;
     use atlas_onnx_tracer::{
         model::{test::ModelBuilder, Model},
         tensor::Tensor,
-        utils::dims::Pad,
     };
-    use joltworks::field::JoltField;
     use rand::{rngs::StdRng, SeedableRng};
 
     fn concat_model(input_shapes: Vec<Vec<usize>>, axis: isize) -> Model {
@@ -431,26 +518,13 @@ mod tests {
         b.build()
     }
 
-    fn gamma_pow<F: JoltField>(gamma: F, power: usize) -> F {
-        (0..power).fold(F::one(), |acc, _| acc * gamma)
-    }
-
-    fn weights_from_exponents<F: JoltField>(gamma: F, exponents: &[usize]) -> Vec<F> {
-        exponents.iter().map(|exp| gamma_pow(gamma, *exp)).collect()
-    }
-
     #[test]
     fn test_concat_power_of_two_shapes() {
         let cases: Vec<(Vec<usize>, Vec<usize>, isize)> = vec![
-            // Rank 2, concat on positive axis.
             (vec![4, 2], vec![4, 2], 1),
-            // Rank 2, concat on axis 0.
             (vec![2, 4], vec![2, 4], 0),
-            // Rank 3, concat on last axis.
             (vec![2, 4, 2], vec![2, 4, 2], 2),
-            // Rank 3, concat on negative axis (-2 => axis 1).
             (vec![2, 2, 4], vec![2, 2, 4], -2),
-            // Rank 4, concat on last axis.
             (vec![2, 2, 2, 2], vec![2, 2, 2, 2], 3),
         ];
 
@@ -466,15 +540,10 @@ mod tests {
     #[test]
     fn test_concat_arbitrary_shapes() {
         let cases: Vec<(Vec<usize>, Vec<usize>, isize)> = vec![
-            // Rank 2, concat on positive axis.
             (vec![3, 2], vec![3, 3], 1),
-            // Rank 2, concat on axis 0.
             (vec![2, 3], vec![4, 3], 0),
-            // Rank 3, concat on last axis.
             (vec![2, 3, 3], vec![2, 3, 2], 2),
-            // Rank 3, concat on negative axis (-2 => axis 1).
             (vec![2, 1, 3], vec![2, 2, 3], -2),
-            // Rank 4, concat on last axis.
             (vec![1, 2, 3, 1], vec![1, 2, 3, 2], 3),
         ];
 
@@ -516,36 +585,5 @@ mod tests {
         let input = Tensor::<i32>::random_small(&mut rng, &shape);
         let model = concat_model(vec![shape], 1);
         unit_test_op(model, &[input]);
-    }
-
-    #[test]
-    fn test_concat_gamma_weights_visual_layout_rank3_axis1() {
-        let gamma = Fr::from(5u64);
-        // Concat inputs [2,3,2] and [2,1,2] along axis 1.
-        // Raw output [2,4,2] (3+1=4, already pow2).
-        // Padded input A [2,4,2], padded input B [2,1,2], padded output [2,4,2].
-        let ctx =
-            super::ConcatGammaWeightsContext::new(&[&[2, 3, 2], &[2, 1, 2]], &[2, 4, 2], 1, gamma);
-
-        let output_weights = ctx.output_gamma_weights();
-        let a_weights = ctx.gamma_weights(0);
-        let b_weights = ctx.gamma_weights(1);
-
-        // Output [2,4,2] is already pow2 (len=16), so all 16 entries are γ^0..γ^15.
-        let expected_output = weights_from_exponents(
-            gamma,
-            &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-        );
-        assert_eq!(output_weights, expected_output.as_slice());
-
-        let expected_a = weights_from_exponents(gamma, &[0, 1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13])
-            .pad_next_power_of_two(&[2, 3, 2]);
-        assert_eq!(a_weights, expected_a);
-
-        // Input B raw [2,1,2] padded to [2,1,2], axis-1 offset 3.
-        // d0=0: exp=(0+3)*2=6 → [γ^6, γ^7]
-        // d0=1: d0 * γ^8      → [γ^14, γ^15]
-        let expected_b = weights_from_exponents(gamma, &[6, 7, 14, 15]);
-        assert_eq!(b_weights, expected_b);
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/concat.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/concat.rs
@@ -1,3 +1,4 @@
+use crate::utils::dims::{coord_to_linear, linear_to_coord};
 use atlas_onnx_tracer::{
     model::{
         trace::{LayerData, Trace},
@@ -29,6 +30,7 @@ use joltworks::{
     transcripts::Transcript,
     utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
 };
+use rayon::prelude::*;
 
 use crate::onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier};
 
@@ -237,20 +239,23 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ConcatSumchec
             .first()
             .map(|term| term.input_mle.len() / 2)
             .unwrap_or(0);
-        let mut uni_poly_evals = [F::zero(); 2];
-
-        for term in &self.input_terms {
-            for i in 0..half_poly_len {
-                let input_evals =
-                    term.input_mle
-                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-                let selector_evals =
-                    term.selector_mle
-                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-                uni_poly_evals[0] += input_evals[0] * selector_evals[0];
-                uni_poly_evals[1] += input_evals[1] * selector_evals[1];
-            }
-        }
+        let uni_poly_evals: [F; 2] = (0..half_poly_len)
+            .into_par_iter()
+            .map(|i| {
+                let mut evals = [F::zero(); 2];
+                for term in &self.input_terms {
+                    let input_evals =
+                        term.input_mle
+                            .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                    let selector_evals =
+                        term.selector_mle
+                            .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                    evals[0] += input_evals[0] * selector_evals[0];
+                    evals[1] += input_evals[1] * selector_evals[1];
+                }
+                evals
+            })
+            .reduce(|| [F::zero(); 2], |a, b| [a[0] + b[0], a[1] + b[1]]);
 
         UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
     }
@@ -319,8 +324,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ConcatSumch
 
         self.params.input_raw_dims.iter().enumerate().fold(
             F::zero(),
-            |running, (input_idx, input_raw_dims)| {
-                let input_num_vars = padded_domain_len(input_raw_dims).log_2();
+            |running, (input_idx, _input_raw_dims)| {
                 let input_claim = accumulator.get_node_output_claim(
                     self.params.computation_node.inputs[input_idx],
                     self.params.computation_node.idx,
@@ -335,7 +339,6 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ConcatSumch
                 );
                 let selector_claim =
                     MultilinearPolynomial::from(selector).evaluate(&full_opening_point.r);
-                let _ = input_num_vars;
                 running + input_claim * selector_claim
             },
         )
@@ -430,25 +433,6 @@ fn build_concat_selector<F: JoltField>(
     }
 
     selector
-}
-
-fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
-    let mut coord = vec![0; dims.len()];
-    for axis in (0..dims.len()).rev() {
-        coord[axis] = index % dims[axis];
-        index /= dims[axis];
-    }
-    coord
-}
-
-fn coord_to_linear(coord: &[usize], dims: &[usize]) -> usize {
-    let mut index = 0usize;
-    let mut stride = 1usize;
-    for axis in (0..dims.len()).rev() {
-        index += coord[axis] * stride;
-        stride *= dims[axis];
-    }
-    index
 }
 
 /// Normalizes an ONNX-style axis (possibly negative) to a canonical `[0, rank)` axis.

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -1,20 +1,14 @@
-//! Reshape proof (selector-based equality over padded layouts).
+//! Reshape proof using an eq-selector over the padded input domain.
 //!
-//! Proof target:
-//! `sum_i (A(i) * Sa(i) - B(i) * Sb(i)) = 0`
-//! which is equivalent to:
-//! `sum_i A(i) * Sa(i) = sum_i B(i) * Sb(i)`.
+//! For each raw input element `t`, we compute the padded output index that the
+//! same element occupies after reshape and place `eq(r_output, mapped_index(t))`
+//! at the corresponding padded input position. The resulting selector MLE
+//! satisfies:
 //!
-//! Where:
-//! - `A(i)`: input padded MLE values
-//! - `B(i)`: output padded MLE values
-//! - `Sa(i), Sb(i)`: selector MLEs that place the same coefficient `rho(t)=gamma^t`
-//!   on the padded position corresponding to raw element `t`, and `0` on padding cells.
-//!
-//! This aligns input/output raw elements under different padded layouts and checks
-//! reshape consistency via one sumcheck instance.
+//! `out(r_output) = sum_i selector(i) * input(i)`.
 
 use crate::onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier};
+use crate::utils::dims::{coord_to_linear, linear_to_coord};
 use atlas_onnx_tracer::{
     model::{
         trace::{LayerData, Trace},
@@ -46,6 +40,7 @@ use joltworks::{
     transcripts::Transcript,
     utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
 };
+use rayon::prelude::*;
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
     #[tracing::instrument(skip_all, name = "Reshape::prove")]
@@ -54,8 +49,6 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
         node: &ComputationNode,
         prover: &mut Prover<F, T>,
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
-        // TODO(soundness): Audit challenge derivation/order to ensure this gamma is
-        // transcript-bound to all required prior messages before selector construction.
         let params = ReshapeSumcheckParams::<F>::new(
             node.clone(),
             &prover.accumulator,
@@ -76,8 +69,6 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
-        // TODO(soundness): Keep gamma derivation order exactly aligned with prover
-        // and verify transcript binding assumptions for selector randomization.
         let proof = verifier
             .proofs
             .get(&ProofId(node.idx, ProofType::Execution))
@@ -111,25 +102,6 @@ pub(crate) fn build_reshape_selectors<F: JoltField + ChallengeFieldOps<F>>(
     output_raw_dims: &[usize],
     r_output: &[F],
 ) -> Vec<F> {
-    fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
-        let mut coord = vec![0; dims.len()];
-        for axis in (0..dims.len()).rev() {
-            coord[axis] = index % dims[axis];
-            index /= dims[axis];
-        }
-        coord
-    }
-
-    fn coord_to_linear(coord: &[usize], dims: &[usize]) -> usize {
-        let mut index = 0usize;
-        let mut stride = 1usize;
-        for axis in (0..dims.len()).rev() {
-            index += coord[axis] * stride;
-            stride *= dims[axis];
-        }
-        index
-    }
-
     let input_raw_len: usize = input_raw_dims.iter().product();
     let output_raw_len: usize = output_raw_dims.iter().product();
     assert_eq!(
@@ -167,10 +139,7 @@ pub(crate) fn build_reshape_selectors<F: JoltField + ChallengeFieldOps<F>>(
     selector
 }
 
-/// Parameters for the upcoming reshape sumcheck.
-///
-/// Intended claim shape:
-/// sum_i (A(i) * Sa(i) - B(i) * Sb(i)) = 0
+/// Static metadata for the reshape selector sumcheck.
 #[derive(Clone)]
 pub struct ReshapeSumcheckParams<F: JoltField> {
     /// Reshape computation node being proven.
@@ -248,11 +217,8 @@ impl<F: JoltField> ReshapeSumcheckProver<F> {
         };
 
         let input_mle = MultilinearPolynomial::from(input.padded_next_power_of_two());
-        let output_mle: MultilinearPolynomial<F> =
-            MultilinearPolynomial::from(output.padded_next_power_of_two());
         let selector = build_reshape_selectors(input.dims(), output.dims(), &params.r_output.r);
         let selector_mle = MultilinearPolynomial::from(selector);
-        assert_eq!(input_mle.len(), output_mle.len());
         assert_eq!(input_mle.len(), selector_mle.len());
 
         Self {
@@ -276,15 +242,18 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumche
             ..
         } = self;
         let half_poly_len = input_mle.len() / 2;
-        let mut uni_poly_evals = [F::zero(); 2];
-        for i in 0..half_poly_len {
-            let a_evals = input_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-            let selector_evals =
-                selector_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-
-            uni_poly_evals[0] += a_evals[0] * selector_evals[0];
-            uni_poly_evals[1] += a_evals[1] * selector_evals[1];
-        }
+        let uni_poly_evals: [F; 2] = (0..half_poly_len)
+            .into_par_iter()
+            .map(|i| {
+                let a_evals = input_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                let selector_evals =
+                    selector_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                [
+                    a_evals[0] * selector_evals[0],
+                    a_evals[1] * selector_evals[1],
+                ]
+            })
+            .reduce(|| [F::zero(); 2], |a, b| [a[0] + b[0], a[1] + b[1]]);
         UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
     }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -14,10 +14,7 @@
 //! This aligns input/output raw elements under different padded layouts and checks
 //! reshape consistency via one sumcheck instance.
 
-use crate::onnx_proof::{
-    ops::{eval_reduction::NodeEvalReduction, OperatorProofTrait, ReductionFlow},
-    ProofId, ProofType, Prover, Verifier,
-};
+use crate::onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier};
 use atlas_onnx_tracer::{
     model::{
         trace::{LayerData, Trace},
@@ -28,8 +25,9 @@ use atlas_onnx_tracer::{
 };
 use common::VirtualPolynomial;
 use joltworks::{
-    field::{IntoOpening, JoltField},
+    field::{ChallengeFieldOps, IntoOpening, JoltField},
     poly::{
+        eq_poly::EqPolynomial,
         multilinear_polynomial::{
             BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
         },
@@ -46,14 +44,10 @@ use joltworks::{
         sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::{errors::ProofVerifyError, math::Math},
+    utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
 };
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
-    fn reduction_flow(&self) -> ReductionFlow {
-        ReductionFlow::Custom
-    }
-
     #[tracing::instrument(skip_all, name = "Reshape::prove")]
     fn prove(
         &self,
@@ -62,12 +56,10 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
         // TODO(soundness): Audit challenge derivation/order to ensure this gamma is
         // transcript-bound to all required prior messages before selector construction.
-        let gamma = prover.transcript.challenge_scalar_optimized::<F>();
         let params = ReshapeSumcheckParams::<F>::new(
             node.clone(),
+            &prover.accumulator,
             &prover.preprocessing.model.graph,
-            gamma.into(),
-            &mut prover.transcript,
         );
         let mut prover_sumcheck = ReshapeSumcheckProver::initialize(&prover.trace, params);
         let (proof, _) = Sumcheck::prove(
@@ -78,19 +70,6 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
         vec![(ProofId(node.idx, ProofType::Execution), proof)]
     }
 
-    fn prove_with_reduction(
-        &self,
-        node: &ComputationNode,
-        prover: &mut Prover<F, T>,
-    ) -> (
-        joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
-        Vec<(ProofId, SumcheckInstanceProof<F, T>)>,
-    ) {
-        let execution_proofs = self.prove(node, prover);
-        let eval_reduction_proof = NodeEvalReduction::prove(prover, node);
-        (eval_reduction_proof, execution_proofs)
-    }
-
     #[tracing::instrument(skip_all, name = "Reshape::verify")]
     fn verify(
         &self,
@@ -99,16 +78,14 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
     ) -> Result<(), ProofVerifyError> {
         // TODO(soundness): Keep gamma derivation order exactly aligned with prover
         // and verify transcript binding assumptions for selector randomization.
-        let gamma = verifier.transcript.challenge_scalar_optimized::<F>();
         let proof = verifier
             .proofs
             .get(&ProofId(node.idx, ProofType::Execution))
             .ok_or(ProofVerifyError::MissingProof(node.idx))?;
         let verifier_sumcheck = ReshapeSumcheckVerifier::new(
             node.clone(),
+            &verifier.accumulator,
             &verifier.preprocessing.model.graph,
-            gamma.into(),
-            &mut verifier.transcript,
         );
         Sumcheck::verify(
             proof,
@@ -118,28 +95,22 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Reshape {
         )?;
         Ok(())
     }
-
-    fn verify_with_reduction(
-        &self,
-        node: &ComputationNode,
-        verifier: &mut Verifier<'_, F, T>,
-        eval_reduction_proof: &joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
-    ) -> Result<(), ProofVerifyError> {
-        self.verify(node, verifier)?;
-        NodeEvalReduction::verify(verifier, node, eval_reduction_proof)
-    }
 }
 
-/// Build a reshape selector vector over the padded tensor domain.
+/// Build a reshape selector vector over the padded input domain.
 ///
-/// For each raw (unpadded) linear position `t`, this places `rho(t)` at the
-/// corresponding padded linear index that keeps the same raw coordinate.
-/// All padding cells remain zero.
+/// For each raw input position `t`, this computes the padded input index
+/// corresponding to `t`, the padded output index that the same raw element maps
+/// to after reshape, and stores `eq(r_output, mapped_output_index)` at that
+/// padded input position. Padding cells remain zero.
 ///
-/// This lets us compare two differently padded layouts (e.g. input/output of
-/// reshape) under the same extraction order by using the same `rho(t)=gamma^t`
-/// sequence on both sides.
-pub(crate) fn build_reshape_selectors<F: JoltField>(dims: &[usize], gamma: F) -> Vec<F> {
+/// This gives a selector MLE such that:
+/// `out(r_output) = Σ_i selector(i) * input(i)`.
+pub(crate) fn build_reshape_selectors<F: JoltField + ChallengeFieldOps<F>>(
+    input_raw_dims: &[usize],
+    output_raw_dims: &[usize],
+    r_output: &[F],
+) -> Vec<F> {
     fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
         let mut coord = vec![0; dims.len()];
         for axis in (0..dims.len()).rev() {
@@ -159,21 +130,38 @@ pub(crate) fn build_reshape_selectors<F: JoltField>(dims: &[usize], gamma: F) ->
         index
     }
 
-    let raw_len: usize = dims.iter().product();
-    let padded_dims: Vec<usize> = dims.iter().map(|d| d.next_power_of_two()).collect();
-    let padded_len: usize = padded_dims.iter().product();
+    let input_raw_len: usize = input_raw_dims.iter().product();
+    let output_raw_len: usize = output_raw_dims.iter().product();
+    assert_eq!(
+        input_raw_len, output_raw_len,
+        "Reshape selector requires equal raw element counts"
+    );
+
+    let input_padded_dims: Vec<usize> = input_raw_dims
+        .iter()
+        .map(|d| d.next_power_of_two())
+        .collect();
+    let output_padded_dims: Vec<usize> = output_raw_dims
+        .iter()
+        .map(|d| d.next_power_of_two())
+        .collect();
+    let input_padded_len: usize = input_padded_dims.iter().product();
+    let output_padded_len: usize = output_padded_dims.iter().product();
+    assert_eq!(
+        input_padded_len, output_padded_len,
+        "Reshape selector requires equal padded domain sizes"
+    );
 
     // Selector values are zero on padding cells by default.
-    let mut selector = vec![F::zero(); padded_len];
+    let mut selector = vec![F::zero(); input_padded_len];
 
-    // For each raw linear position t, compute its padded linear position by:
-    // 1) converting t to a raw coordinate
-    // 2) re-encoding that coordinate under padded strides
-    // Then store rho(t)=gamma^t at that padded position.
-    for t in 0..raw_len {
-        let raw_coord = linear_to_coord(t, dims);
-        let padded_index = coord_to_linear(&raw_coord, &padded_dims);
-        selector[padded_index] = gamma_power(gamma, t);
+    for t in 0..input_raw_len {
+        let input_coord = linear_to_coord(t, input_raw_dims);
+        let output_coord = linear_to_coord(t, output_raw_dims);
+        let input_padded_index = coord_to_linear(&input_coord, &input_padded_dims);
+        let output_padded_index = coord_to_linear(&output_coord, &output_padded_dims);
+        let output_bits = index_to_field_bitvector::<F>(output_padded_index as u64, r_output.len());
+        selector[input_padded_index] = EqPolynomial::mle(&output_bits, r_output);
     }
 
     selector
@@ -193,20 +181,16 @@ pub struct ReshapeSumcheckParams<F: JoltField> {
     pub input_raw_dims: Vec<usize>,
     /// Original (unpadded) output shape used to build selector `Sb`.
     pub output_raw_dims: Vec<usize>,
-    /// Transcript-derived randomizer used in selector coefficients (`gamma^t`).
-    pub gamma: F,
 }
 
 impl<F: JoltField> ReshapeSumcheckParams<F> {
     /// Build reshape sumcheck parameters from node/opening context and graph metadata.
     pub fn new(
         computation_node: ComputationNode,
+        accumulator: &dyn OpeningAccumulator<F>,
         graph: &ComputationGraph,
-        gamma: F,
-        transcript: &mut impl Transcript,
     ) -> Self {
-        let num_vars = computation_node.pow2_padded_num_output_elements().log_2();
-        let r_output = transcript.challenge_vector_optimized::<F>(num_vars);
+        let r_output = accumulator.get_node_output_opening(computation_node.idx).0;
         let input_raw_dims = graph
             .nodes
             .get(&computation_node.inputs[0])
@@ -216,10 +200,9 @@ impl<F: JoltField> ReshapeSumcheckParams<F> {
         let output_raw_dims = computation_node.output_dims.clone();
         Self {
             computation_node,
-            r_output: r_output.into(),
+            r_output,
             input_raw_dims,
             output_raw_dims,
-            gamma,
         }
     }
 }
@@ -229,8 +212,10 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
         2
     }
 
-    fn input_claim(&self, _accumulator: &dyn OpeningAccumulator<F>) -> F {
-        F::zero()
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
     }
 
     fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
@@ -250,12 +235,8 @@ pub struct ReshapeSumcheckProver<F: JoltField> {
     pub params: ReshapeSumcheckParams<F>,
     /// Input polynomial (padded MLE).
     pub input_mle: MultilinearPolynomial<F>,
-    /// Output polynomial (padded MLE).
-    pub output_mle: MultilinearPolynomial<F>,
-    /// Selector polynomial for input layout.
-    pub selector_a_mle: MultilinearPolynomial<F>,
-    /// Selector polynomial for output layout.
-    pub selector_b_mle: MultilinearPolynomial<F>,
+    /// Selector polynomial mapping padded input coordinates to the output point.
+    pub selector_mle: MultilinearPolynomial<F>,
 }
 
 impl<F: JoltField> ReshapeSumcheckProver<F> {
@@ -267,23 +248,17 @@ impl<F: JoltField> ReshapeSumcheckProver<F> {
         };
 
         let input_mle = MultilinearPolynomial::from(input.padded_next_power_of_two());
-        let output_mle = MultilinearPolynomial::from(output.padded_next_power_of_two());
-
-        let selector_a = build_reshape_selectors(input.dims(), params.gamma);
-        let selector_b = build_reshape_selectors(output.dims(), params.gamma);
-
-        let selector_a_mle = MultilinearPolynomial::from(selector_a);
-        let selector_b_mle = MultilinearPolynomial::from(selector_b);
+        let output_mle: MultilinearPolynomial<F> =
+            MultilinearPolynomial::from(output.padded_next_power_of_two());
+        let selector = build_reshape_selectors(input.dims(), output.dims(), &params.r_output.r);
+        let selector_mle = MultilinearPolynomial::from(selector);
         assert_eq!(input_mle.len(), output_mle.len());
-        assert_eq!(input_mle.len(), selector_a_mle.len());
-        assert_eq!(output_mle.len(), selector_b_mle.len());
+        assert_eq!(input_mle.len(), selector_mle.len());
 
         Self {
             params,
             input_mle,
-            output_mle,
-            selector_a_mle,
-            selector_b_mle,
+            selector_mle,
         }
     }
 }
@@ -297,31 +272,25 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumche
         const DEGREE_BOUND: usize = 2;
         let Self {
             input_mle,
-            output_mle,
-            selector_a_mle,
-            selector_b_mle,
+            selector_mle,
             ..
         } = self;
         let half_poly_len = input_mle.len() / 2;
         let mut uni_poly_evals = [F::zero(); 2];
         for i in 0..half_poly_len {
             let a_evals = input_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-            let b_evals = output_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-            let sa_evals = selector_a_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-            let sb_evals = selector_b_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+            let selector_evals =
+                selector_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
 
-            uni_poly_evals[0] += a_evals[0] * sa_evals[0] - b_evals[0] * sb_evals[0];
-            uni_poly_evals[1] += a_evals[1] * sa_evals[1] - b_evals[1] * sb_evals[1];
+            uni_poly_evals[0] += a_evals[0] * selector_evals[0];
+            uni_poly_evals[1] += a_evals[1] * selector_evals[1];
         }
         UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
     }
 
     fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
         self.input_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.output_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.selector_a_mle
-            .bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.selector_b_mle
+        self.selector_mle
             .bind_parallel(r_j, BindingOrder::LowToHigh);
     }
 
@@ -341,13 +310,6 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumche
             opening_point.clone(),
             self.input_mle.final_sumcheck_claim(),
         );
-        accumulator.append_virtual(
-            transcript,
-            VirtualPolynomial::NodeOutput(self.params.computation_node.idx),
-            SumcheckId::NodeExecution(self.params.computation_node.idx),
-            opening_point,
-            self.output_mle.final_sumcheck_claim(),
-        );
     }
 }
 
@@ -361,11 +323,10 @@ impl<F: JoltField> ReshapeSumcheckVerifier<F> {
     /// Build the reshape sumcheck verifier from node/opening context and graph metadata.
     pub fn new(
         computation_node: ComputationNode,
+        accumulator: &VerifierOpeningAccumulator<F>,
         graph: &ComputationGraph,
-        gamma: F,
-        transcript: &mut impl Transcript,
     ) -> Self {
-        let params = ReshapeSumcheckParams::new(computation_node, graph, gamma, transcript);
+        let params = ReshapeSumcheckParams::new(computation_node, accumulator, graph);
         Self { params }
     }
 }
@@ -380,28 +341,22 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReshapeSumc
         accumulator: &VerifierOpeningAccumulator<F>,
         sumcheck_challenges: &[F::Challenge],
     ) -> F {
-        let r_node_output_prime = self
-            .params
-            .normalize_opening_point(&sumcheck_challenges.into_opening())
-            .r;
-
         let input_claim = accumulator.get_node_output_claim(
             self.params.computation_node.inputs[0],
             self.params.computation_node.idx,
         );
-        let output_claim = accumulator.get_node_output_claim(
-            self.params.computation_node.idx,
-            self.params.computation_node.idx,
+        let selector = build_reshape_selectors(
+            &self.params.input_raw_dims,
+            &self.params.output_raw_dims,
+            &self.params.r_output.r,
         );
-
-        let selector_a = build_reshape_selectors(&self.params.input_raw_dims, self.params.gamma);
-        let selector_b = build_reshape_selectors(&self.params.output_raw_dims, self.params.gamma);
-        let selector_a_claim =
-            MultilinearPolynomial::from(selector_a).evaluate(&r_node_output_prime);
-        let selector_b_claim =
-            MultilinearPolynomial::from(selector_b).evaluate(&r_node_output_prime);
-
-        input_claim * selector_a_claim - output_claim * selector_b_claim
+        let selector_claim = MultilinearPolynomial::from(selector).evaluate(
+            &self
+                .params
+                .normalize_opening_point(&sumcheck_challenges.into_opening())
+                .r,
+        );
+        input_claim * selector_claim
     }
 
     fn cache_openings(
@@ -417,25 +372,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReshapeSumc
             transcript,
             VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[0]),
             SumcheckId::NodeExecution(self.params.computation_node.idx),
-            opening_point.clone(),
-        );
-        accumulator.append_virtual(
-            transcript,
-            VirtualPolynomial::NodeOutput(self.params.computation_node.idx),
-            SumcheckId::NodeExecution(self.params.computation_node.idx),
             opening_point,
         );
     }
-}
-
-fn gamma_power<F: JoltField>(gamma: F, exponent: usize) -> F {
-    // TODO: This is a naive O(exponent) implementation. Replace with fast exponentiation
-    // (square-and-multiply) or incremental power caching when selector construction is optimized.
-    let mut acc = F::one();
-    for _ in 0..exponent {
-        acc *= gamma;
-    }
-    acc
 }
 
 #[cfg(test)]

--- a/jolt-atlas-core/src/onnx_proof/ops/slice.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/slice.rs
@@ -1,3 +1,4 @@
+use crate::utils::dims::{coord_to_linear, linear_to_coord};
 use atlas_onnx_tracer::{
     model::{
         trace::{LayerData, Trace},
@@ -29,6 +30,7 @@ use joltworks::{
     transcripts::Transcript,
     utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
 };
+use rayon::prelude::*;
 
 use crate::onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier};
 
@@ -168,20 +170,17 @@ pub struct SliceSumcheckProver<F: JoltField> {
 impl<F: JoltField> SliceSumcheckProver<F> {
     /// Initialize the slice sumcheck prover from trace data and prepared parameters.
     pub fn initialize(trace: &Trace, params: SliceSumcheckParams<F>) -> Self {
-        let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
+        let LayerData { operands, .. } = Trace::layer_data(trace, &params.computation_node);
         let [input] = operands[..] else {
             panic!("Slice expects exactly one operand")
         };
 
         let input_mle = MultilinearPolynomial::from(input.padded_next_power_of_two());
-        let _output_mle: MultilinearPolynomial<F> =
-            MultilinearPolynomial::from(output.padded_next_power_of_two());
         let selector = build_slice_selector(
             &params.input_raw_dims,
             &params.output_raw_dims,
             params.axis,
             params.start,
-            params.end,
             &params.r_output.r,
         );
         let selector_mle = MultilinearPolynomial::from(selector);
@@ -203,17 +202,21 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for SliceSumcheck
     fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
         const DEGREE_BOUND: usize = 2;
         let half_poly_len = self.input_mle.len() / 2;
-        let mut uni_poly_evals = [F::zero(); 2];
-        for i in 0..half_poly_len {
-            let input_evals =
-                self.input_mle
-                    .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-            let selector_evals =
-                self.selector_mle
-                    .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
-            uni_poly_evals[0] += input_evals[0] * selector_evals[0];
-            uni_poly_evals[1] += input_evals[1] * selector_evals[1];
-        }
+        let uni_poly_evals: [F; 2] = (0..half_poly_len)
+            .into_par_iter()
+            .map(|i| {
+                let input_evals =
+                    self.input_mle
+                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                let selector_evals =
+                    self.selector_mle
+                        .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+                [
+                    input_evals[0] * selector_evals[0],
+                    input_evals[1] * selector_evals[1],
+                ]
+            })
+            .reduce(|| [F::zero(); 2], |a, b| [a[0] + b[0], a[1] + b[1]]);
         UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
     }
 
@@ -279,7 +282,6 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for SliceSumche
             &self.params.output_raw_dims,
             self.params.axis,
             self.params.start,
-            self.params.end,
             &self.params.r_output.r,
         );
         let selector_claim = MultilinearPolynomial::from(selector).evaluate(
@@ -314,7 +316,6 @@ fn build_slice_selector<F: JoltField>(
     output_raw_dims: &[usize],
     axis: usize,
     start: usize,
-    end: usize,
     r_output: &[F],
 ) -> Vec<F> {
     let input_raw_len: usize = input_raw_dims.iter().product();
@@ -351,27 +352,7 @@ fn build_slice_selector<F: JoltField>(
         input_raw_len >= output_raw_dims.iter().product(),
         "Slice output raw length exceeds input raw length"
     );
-    let _ = end;
     selector
-}
-
-fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
-    let mut coord = vec![0; dims.len()];
-    for axis in (0..dims.len()).rev() {
-        coord[axis] = index % dims[axis];
-        index /= dims[axis];
-    }
-    coord
-}
-
-fn coord_to_linear(coord: &[usize], dims: &[usize]) -> usize {
-    let mut index = 0usize;
-    let mut stride = 1usize;
-    for axis in (0..dims.len()).rev() {
-        index += coord[axis] * stride;
-        stride *= dims[axis];
-    }
-    index
 }
 
 fn validate_slice_shapes(

--- a/jolt-atlas-core/src/onnx_proof/ops/slice.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/slice.rs
@@ -1,82 +1,56 @@
 use atlas_onnx_tracer::{
-    model::trace::{LayerData, Trace},
+    model::{
+        trace::{LayerData, Trace},
+        ComputationGraph,
+    },
     node::ComputationNode,
     ops::{Operator, Slice},
-    utils::dims::Pad,
 };
 use common::VirtualPolynomial;
 use joltworks::{
-    field::JoltField,
-    poly::opening_proof::{OpeningAccumulator, SumcheckId},
+    field::{IntoOpening, JoltField},
+    poly::{
+        eq_poly::EqPolynomial,
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
+        opening_proof::{
+            OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+            VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
+        },
+        unipoly::UniPoly,
+    },
     subprotocols::{
-        gamma_fold::{gamma_powers, GammaFoldProver, GammaFoldVerifier},
-        sumcheck::{BatchedSumcheck, SumcheckInstanceProof},
+        sumcheck::Sumcheck,
+        sumcheck::SumcheckInstanceProof,
         sumcheck_prover::SumcheckInstanceProver,
-        sumcheck_verifier::SumcheckInstanceVerifier,
+        sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::errors::ProofVerifyError,
+    utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
 };
 
-use crate::onnx_proof::{
-    ops::{eval_reduction::NodeEvalReduction, OperatorProofTrait, ReductionFlow},
-    ProofId, ProofType, Prover, Verifier,
-};
+use crate::onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier};
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Slice {
-    fn reduction_flow(&self) -> ReductionFlow {
-        ReductionFlow::Custom
-    }
-
     #[tracing::instrument(skip_all, name = "Slice::prove")]
     fn prove(
         &self,
         node: &ComputationNode,
         prover: &mut Prover<F, T>,
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
-        let Operator::Slice(slice_op) = &node.operator else {
-            panic!("Expected Slice operator")
-        };
-
-        let gamma: F = prover.transcript.challenge_scalar();
-
-        let input_dims = {
-            let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
-            let [input_tensor] = operands[..] else {
-                panic!("Slice expects exactly one operand")
-            };
-            input_tensor.dims().to_vec()
-        };
-
-        let ctx =
-            SliceGammaWeightsContext::new(&input_dims, &node.output_dims, slice_op.clone(), gamma);
-
-        let output_prover = initialize_output_prover(node, &ctx, prover);
-        let input_prover = initialize_input_prover(node, &ctx, prover);
-
-        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> =
-            vec![Box::new(output_prover), Box::new(input_prover)];
-
-        let (proof, _) = BatchedSumcheck::prove(
-            instances.iter_mut().map(|v| &mut **v as _).collect(),
+        let params = SliceSumcheckParams::new(
+            node.clone(),
+            &prover.accumulator,
+            &prover.preprocessing.model.graph,
+        );
+        let mut prover_sumcheck = SliceSumcheckProver::initialize(&prover.trace, params);
+        let (proof, _) = Sumcheck::prove(
+            &mut prover_sumcheck,
             &mut prover.accumulator,
             &mut prover.transcript,
         );
-
         vec![(ProofId(node.idx, ProofType::Execution), proof)]
-    }
-
-    fn prove_with_reduction(
-        &self,
-        node: &ComputationNode,
-        prover: &mut Prover<F, T>,
-    ) -> (
-        joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
-        Vec<(ProofId, SumcheckInstanceProof<F, T>)>,
-    ) {
-        let proofs = self.prove(node, prover);
-        let eval_reduction_proof = NodeEvalReduction::prove(prover, node);
-        (eval_reduction_proof, proofs)
     }
 
     #[tracing::instrument(skip_all, name = "Slice::verify")]
@@ -89,150 +63,332 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Slice {
             .proofs
             .get(&ProofId(node.idx, ProofType::Execution))
             .ok_or(ProofVerifyError::MissingProof(node.idx))?;
-
-        let Operator::Slice(slice_op) = &node.operator else {
-            panic!("Expected Slice operator")
-        };
-
-        let gamma: F = verifier.transcript.challenge_scalar();
-
-        let input_dims = {
-            let graph = &verifier.preprocessing.model.graph;
-            let input_nodes = graph.get_input_nodes(node);
-            let [input_node] = input_nodes[..] else {
-                panic!("Slice expects exactly one input node")
-            };
-            input_node.output_dims.clone()
-        };
-
-        let ctx =
-            SliceGammaWeightsContext::new(&input_dims, &node.output_dims, slice_op.clone(), gamma);
-
-        let verifiers: Vec<GammaFoldVerifier<F>> = vec![
-            initialize_output_verifier(node, &ctx, verifier),
-            initialize_input_verifier(node, &ctx, verifier),
-        ];
-        let instances: Vec<&dyn SumcheckInstanceVerifier<F, T>> = verifiers
-            .iter()
-            .map(|instance| instance as &dyn SumcheckInstanceVerifier<F, T>)
-            .collect();
-        BatchedSumcheck::verify(
+        let verifier_sumcheck = SliceSumcheckVerifier::new(
+            node.clone(),
+            &verifier.accumulator,
+            &verifier.preprocessing.model.graph,
+        );
+        Sumcheck::verify(
             proof,
-            instances,
+            &verifier_sumcheck,
             &mut verifier.accumulator,
             &mut verifier.transcript,
         )?;
-
-        let output_claim = verifier
-            .accumulator
-            .get_virtual_polynomial_opening(claim_poly_output(node), SumcheckId::RLC(node.idx))
-            .1;
-        let input_claim = verifier
-            .accumulator
-            .get_virtual_polynomial_opening(claim_poly_input(node), SumcheckId::RLC(node.idx))
-            .1;
-        if output_claim != input_claim {
-            return Err(ProofVerifyError::InvalidOpeningProof(
-                "Slice folded-claim relation failed".to_string(),
-            ));
-        }
-
         Ok(())
     }
+}
 
-    fn verify_with_reduction(
-        &self,
-        node: &ComputationNode,
-        verifier: &mut Verifier<'_, F, T>,
-        eval_reduction_proof: &joltworks::subprotocols::evaluation_reduction::EvalReductionProof<F>,
-    ) -> Result<(), ProofVerifyError> {
-        self.verify(node, verifier)?;
-        NodeEvalReduction::verify(verifier, node, eval_reduction_proof)
+/// Parameters for the slice selector sumcheck.
+#[derive(Clone)]
+pub struct SliceSumcheckParams<F: JoltField> {
+    /// Slice node being proven.
+    pub computation_node: ComputationNode,
+    /// Reduced opening point for the slice output.
+    pub r_output: OpeningPoint<BIG_ENDIAN, F>,
+    /// Raw input shape.
+    pub input_raw_dims: Vec<usize>,
+    /// Raw output shape.
+    pub output_raw_dims: Vec<usize>,
+    /// Slice axis.
+    pub axis: usize,
+    /// Slice start index on the axis.
+    pub start: usize,
+    /// Slice end index on the axis.
+    pub end: usize,
+}
+
+impl<F: JoltField> SliceSumcheckParams<F> {
+    /// Build slice sumcheck parameters from the graph metadata and reduced output opening.
+    pub fn new(
+        computation_node: ComputationNode,
+        accumulator: &dyn OpeningAccumulator<F>,
+        graph: &ComputationGraph,
+    ) -> Self {
+        let Operator::Slice(slice_op) = &computation_node.operator else {
+            panic!("Expected Slice operator")
+        };
+        let axis = slice_op.axis;
+        let start = slice_op.start;
+        let end = slice_op.end;
+        let r_output = accumulator.get_node_output_opening(computation_node.idx).0;
+        let input_raw_dims = graph
+            .nodes
+            .get(&computation_node.inputs[0])
+            .expect("Slice node should have one input")
+            .output_dims
+            .clone();
+        let output_raw_dims = computation_node.output_dims.clone();
+        validate_slice_shapes(&input_raw_dims, &output_raw_dims, axis, start, end);
+        Self {
+            computation_node,
+            r_output,
+            input_raw_dims,
+            output_raw_dims,
+            axis,
+            start,
+            end,
+        }
     }
 }
 
-fn initialize_output_prover<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
-    ctx: &SliceGammaWeightsContext<F>,
-    prover: &mut Prover<F, T>,
-) -> GammaFoldProver<F> {
-    let LayerData { output, .. } = Trace::layer_data(&prover.trace, node);
+impl<F: JoltField> SumcheckInstanceParams<F> for SliceSumcheckParams<F> {
+    fn degree(&self) -> usize {
+        2
+    }
 
-    GammaFoldProver::initialize(
-        node.idx,
-        claim_poly_output(node),
-        output,
-        ctx.output_gamma_weights(),
-        &mut prover.accumulator,
-        &mut prover.transcript,
-    )
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.input_raw_dims
+            .iter()
+            .map(|dim| dim.next_power_of_two())
+            .product::<usize>()
+            .log_2()
+    }
 }
 
-fn initialize_input_prover<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
-    ctx: &SliceGammaWeightsContext<F>,
-    prover: &mut Prover<F, T>,
-) -> GammaFoldProver<F> {
-    let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
-    let [input_tensor] = operands[..] else {
-        panic!("Slice expects exactly one operand")
-    };
-
-    GammaFoldProver::initialize(
-        node.idx,
-        claim_poly_input(node),
-        input_tensor,
-        ctx.input_gamma_weights(),
-        &mut prover.accumulator,
-        &mut prover.transcript,
-    )
+/// Prover state for the slice selector sumcheck.
+pub struct SliceSumcheckProver<F: JoltField> {
+    /// Static slice parameters shared across all rounds.
+    pub params: SliceSumcheckParams<F>,
+    /// Input polynomial over the padded input domain.
+    pub input_mle: MultilinearPolynomial<F>,
+    /// Selector polynomial mapping input coordinates to the output point.
+    pub selector_mle: MultilinearPolynomial<F>,
 }
 
-fn initialize_output_verifier<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
-    ctx: &SliceGammaWeightsContext<F>,
-    verifier: &mut Verifier<'_, F, T>,
-) -> GammaFoldVerifier<F> {
-    GammaFoldVerifier::initialize(
-        node.idx,
-        claim_poly_output(node),
-        node.pow2_padded_num_output_elements(),
-        ctx.output_gamma_weights(),
-        &mut verifier.accumulator,
-        &mut verifier.transcript,
-    )
+impl<F: JoltField> SliceSumcheckProver<F> {
+    /// Initialize the slice sumcheck prover from trace data and prepared parameters.
+    pub fn initialize(trace: &Trace, params: SliceSumcheckParams<F>) -> Self {
+        let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
+        let [input] = operands[..] else {
+            panic!("Slice expects exactly one operand")
+        };
+
+        let input_mle = MultilinearPolynomial::from(input.padded_next_power_of_two());
+        let _output_mle: MultilinearPolynomial<F> =
+            MultilinearPolynomial::from(output.padded_next_power_of_two());
+        let selector = build_slice_selector(
+            &params.input_raw_dims,
+            &params.output_raw_dims,
+            params.axis,
+            params.start,
+            params.end,
+            &params.r_output.r,
+        );
+        let selector_mle = MultilinearPolynomial::from(selector);
+        assert_eq!(input_mle.len(), selector_mle.len());
+
+        Self {
+            params,
+            input_mle,
+            selector_mle,
+        }
+    }
 }
 
-fn initialize_input_verifier<F: JoltField, T: Transcript>(
-    node: &ComputationNode,
-    ctx: &SliceGammaWeightsContext<F>,
-    verifier: &mut Verifier<'_, F, T>,
-) -> GammaFoldVerifier<F> {
-    let graph = &verifier.preprocessing.model.graph;
-    let input_nodes = graph.get_input_nodes(node);
-    let [input_node] = input_nodes[..] else {
-        panic!("Slice expects exactly one input node")
-    };
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for SliceSumcheckProver<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
 
-    GammaFoldVerifier::initialize(
-        node.idx,
-        claim_poly_input(node),
-        input_node.pow2_padded_num_output_elements(),
-        ctx.input_gamma_weights(),
-        &mut verifier.accumulator,
-        &mut verifier.transcript,
-    )
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        const DEGREE_BOUND: usize = 2;
+        let half_poly_len = self.input_mle.len() / 2;
+        let mut uni_poly_evals = [F::zero(); 2];
+        for i in 0..half_poly_len {
+            let input_evals =
+                self.input_mle
+                    .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+            let selector_evals =
+                self.selector_mle
+                    .sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
+            uni_poly_evals[0] += input_evals[0] * selector_evals[0];
+            uni_poly_evals[1] += input_evals[1] * selector_evals[1];
+        }
+        UniPoly::from_evals_and_hint(previous_claim, &uni_poly_evals)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        self.input_mle.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.selector_mle
+            .bind_parallel(r_j, BindingOrder::LowToHigh);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point,
+            self.input_mle.final_sumcheck_claim(),
+        );
+    }
 }
 
-fn validate_slice_shapes(input_dims: &[usize], output_dims: &[usize], op: &Slice) {
+/// Verifier state for the slice selector sumcheck.
+pub struct SliceSumcheckVerifier<F: JoltField> {
+    /// Static slice parameters shared across all rounds.
+    pub params: SliceSumcheckParams<F>,
+}
+
+impl<F: JoltField> SliceSumcheckVerifier<F> {
+    /// Build the slice verifier from the reduced output opening and graph metadata.
+    pub fn new(
+        computation_node: ComputationNode,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        graph: &ComputationGraph,
+    ) -> Self {
+        let params = SliceSumcheckParams::new(computation_node, accumulator, graph);
+        Self { params }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for SliceSumcheckVerifier<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(
+        &self,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) -> F {
+        let input_claim = accumulator.get_node_output_claim(
+            self.params.computation_node.inputs[0],
+            self.params.computation_node.idx,
+        );
+        let selector = build_slice_selector(
+            &self.params.input_raw_dims,
+            &self.params.output_raw_dims,
+            self.params.axis,
+            self.params.start,
+            self.params.end,
+            &self.params.r_output.r,
+        );
+        let selector_claim = MultilinearPolynomial::from(selector).evaluate(
+            &self
+                .params
+                .normalize_opening_point(&sumcheck_challenges.into_opening())
+                .r,
+        );
+        input_claim * selector_claim
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = self
+            .params
+            .normalize_opening_point(&sumcheck_challenges.into_opening());
+        accumulator.append_virtual(
+            transcript,
+            VirtualPolynomial::NodeOutput(self.params.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.params.computation_node.idx),
+            opening_point,
+        );
+    }
+}
+
+fn build_slice_selector<F: JoltField>(
+    input_raw_dims: &[usize],
+    output_raw_dims: &[usize],
+    axis: usize,
+    start: usize,
+    end: usize,
+    r_output: &[F],
+) -> Vec<F> {
+    let input_raw_len: usize = input_raw_dims.iter().product();
+    let input_padded_dims: Vec<usize> = input_raw_dims
+        .iter()
+        .map(|dim| dim.next_power_of_two())
+        .collect();
+    let output_padded_dims: Vec<usize> = output_raw_dims
+        .iter()
+        .map(|dim| dim.next_power_of_two())
+        .collect();
+    let input_domain_len: usize = input_padded_dims.iter().product();
+    let output_domain_len: usize = output_padded_dims.iter().product();
+    let output_num_vars = output_domain_len.log_2();
+    assert_eq!(
+        output_num_vars,
+        r_output.len(),
+        "Slice selector expects output challenge length to match output padded domain"
+    );
+
+    let mut selector = vec![F::zero(); input_domain_len];
+    for output_linear_idx in 0..output_raw_dims.iter().product() {
+        let output_coord = linear_to_coord(output_linear_idx, output_raw_dims);
+        let mut input_coord = output_coord.clone();
+        input_coord[axis] += start;
+
+        let input_index = coord_to_linear(&input_coord, &input_padded_dims);
+        let output_index = coord_to_linear(&output_coord, &output_padded_dims);
+        let output_bits = index_to_field_bitvector::<F>(output_index as u64, output_num_vars);
+        selector[input_index] = EqPolynomial::mle(&output_bits, r_output);
+    }
+
+    assert!(
+        input_raw_len >= output_raw_dims.iter().product(),
+        "Slice output raw length exceeds input raw length"
+    );
+    let _ = end;
+    selector
+}
+
+fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
+    let mut coord = vec![0; dims.len()];
+    for axis in (0..dims.len()).rev() {
+        coord[axis] = index % dims[axis];
+        index /= dims[axis];
+    }
+    coord
+}
+
+fn coord_to_linear(coord: &[usize], dims: &[usize]) -> usize {
+    let mut index = 0usize;
+    let mut stride = 1usize;
+    for axis in (0..dims.len()).rev() {
+        index += coord[axis] * stride;
+        stride *= dims[axis];
+    }
+    index
+}
+
+fn validate_slice_shapes(
+    input_dims: &[usize],
+    output_dims: &[usize],
+    axis: usize,
+    start: usize,
+    end: usize,
+) {
     assert_eq!(input_dims.len(), output_dims.len(), "Slice rank mismatch");
-    assert!(op.axis < input_dims.len(), "Slice axis out of range");
-    assert!(op.start <= op.end, "Slice start must be <= end");
-    assert!(op.end <= input_dims[op.axis], "Slice end out of bounds");
+    assert!(axis < input_dims.len(), "Slice axis out of range");
+    assert!(start <= end, "Slice start must be <= end");
+    assert!(end <= input_dims[axis], "Slice end out of bounds");
 
     for dim in 0..input_dims.len() {
-        let expected = if dim == op.axis {
-            op.end - op.start
+        let expected = if dim == axis {
+            end - start
         } else {
             input_dims[dim]
         };
@@ -243,94 +399,13 @@ fn validate_slice_shapes(input_dims: &[usize], output_dims: &[usize], op: &Slice
     }
 }
 
-struct SliceGammaWeightsContext<F: JoltField> {
-    input_dims: Vec<usize>,
-    output_dims: Vec<usize>,
-    op: Slice,
-    gamma_powers: Vec<F>,
-}
-
-impl<F: JoltField> SliceGammaWeightsContext<F> {
-    fn new(input_dims: &[usize], output_dims: &[usize], op: Slice, gamma: F) -> Self {
-        validate_slice_shapes(input_dims, output_dims, &op);
-
-        let output_len: usize = output_dims.iter().product();
-        Self {
-            input_dims: input_dims.to_vec(),
-            output_dims: output_dims.to_vec(),
-            op,
-            gamma_powers: gamma_powers(output_len, gamma),
-        }
-    }
-
-    fn output_gamma_weights(&self) -> Vec<F> {
-        self.gamma_powers.pad_next_power_of_two(&self.output_dims)
-    }
-
-    fn input_gamma_weights(&self) -> Vec<F> {
-        let rank = self.input_dims.len();
-        assert!(rank > 0, "Slice rank must be non-zero");
-
-        let raw_weights = self.build_input_weights_recursive(rank - 1, vec![F::one()]);
-        debug_assert_eq!(raw_weights.len(), self.input_dims.iter().product::<usize>());
-        raw_weights.pad_next_power_of_two(&self.input_dims)
-    }
-
-    /// Recursively expands gamma factors from inner to outer dimensions.
-    ///
-    /// This mirrors concat-style weight construction and keeps all indexing in
-    /// slice-native terms: at the sliced axis we only emit non-zero factors for
-    /// positions in `[start, start + output_axis_dim)` and zero otherwise.
-    fn build_input_weights_recursive(&self, dim: usize, current_slice: Vec<F>) -> Vec<F> {
-        let output_linear_factor: usize = self.output_dims.iter().skip(dim + 1).product();
-        let mut outer_slice = Vec::with_capacity(self.input_dims[dim] * current_slice.len());
-
-        if dim == self.op.axis {
-            outer_slice.extend((0..current_slice.len() * self.op.start).map(|_| F::zero()));
-        }
-
-        for i in 0..self.output_dims[dim] {
-            let exp = i * output_linear_factor;
-            let dim_factor = self.gamma_powers[exp];
-            outer_slice.extend(current_slice.iter().map(|w| *w * dim_factor));
-        }
-
-        if dim == self.op.axis {
-            outer_slice.resize(self.input_dims[dim] * current_slice.len(), F::zero());
-        }
-
-        if dim == 0 {
-            outer_slice
-        } else {
-            self.build_input_weights_recursive(dim - 1, outer_slice)
-        }
-    }
-}
-
-fn claim_poly_output(node: &ComputationNode) -> VirtualPolynomial {
-    VirtualPolynomial::NodeOutput(node.idx)
-}
-
-fn claim_poly_input(node: &ComputationNode) -> VirtualPolynomial {
-    let input_node_idx = *node
-        .inputs
-        .first()
-        .expect("Slice node should have one input");
-    VirtualPolynomial::NodeOutput(input_node_idx)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::onnx_proof::ops::test::unit_test_op;
-    use ark_bn254::Fr;
     use atlas_onnx_tracer::{
         model::{test::ModelBuilder, Model},
-        ops::Slice,
-        tensor::{ops::concat, Tensor},
-        utils::dims::Pad,
+        tensor::Tensor,
     };
-    use joltworks::field::JoltField;
     use rand::{rngs::StdRng, SeedableRng};
 
     fn slice_model(input_shape: Vec<usize>, axis: usize, start: usize, end: usize) -> Model {
@@ -339,86 +414,6 @@ mod tests {
         let out = b.slice(input, axis, start, end);
         b.mark_output(out);
         b.build()
-    }
-
-    fn gamma_pow<F: JoltField>(gamma: F, power: usize) -> F {
-        (0..power).fold(F::one(), |acc, _| acc * gamma)
-    }
-
-    fn weights_from_exponents<F: JoltField>(gamma: F, exponents: &[usize]) -> Vec<F> {
-        exponents.iter().map(|exp| gamma_pow(gamma, *exp)).collect()
-    }
-
-    fn exponents_tensor_to_weights(gamma: Fr, exponents: &Tensor<i32>) -> Vec<Fr> {
-        exponents
-            .data()
-            .iter()
-            .map(|exp| {
-                if *exp < 0 {
-                    Fr::from(0u64)
-                } else {
-                    gamma_pow(gamma, *exp as usize)
-                }
-            })
-            .collect()
-    }
-
-    fn output_exponents_2d(dims: &[usize; 2]) -> Tensor<i32> {
-        let len = dims[0] * dims[1];
-        let data: Vec<i32> = (0..len as i32).collect();
-        Tensor::construct(data, vec![dims[0], dims[1]])
-    }
-
-    /// Builds expected 2D input-weight exponents using concat of:
-    /// zero block(s) + active output exponents block + zero block(s).
-    ///
-    /// Sentinel `-1` means zero weight.
-    fn expected_input_exponents_with_concat_2d(input_dims: &[usize; 2], op: &Slice) -> Tensor<i32> {
-        let output_dims = [input_dims[0], input_dims[1]];
-        let output_dims = if op.axis == 0 {
-            [op.end - op.start, output_dims[1]]
-        } else {
-            [output_dims[0], op.end - op.start]
-        };
-        let active = output_exponents_2d(&output_dims);
-
-        if op.axis == 1 {
-            let mut blocks: Vec<Tensor<i32>> = Vec::new();
-            if op.start > 0 {
-                blocks.push(Tensor::construct(
-                    vec![-1; input_dims[0] * op.start],
-                    vec![input_dims[0], op.start],
-                ));
-            }
-            blocks.push(active);
-            let right = input_dims[1] - op.end;
-            if right > 0 {
-                blocks.push(Tensor::construct(
-                    vec![-1; input_dims[0] * right],
-                    vec![input_dims[0], right],
-                ));
-            }
-            let block_refs: Vec<&Tensor<i32>> = blocks.iter().collect();
-            concat(&block_refs, 1).expect("concat on axis 1 should build expected exponents")
-        } else {
-            let mut blocks: Vec<Tensor<i32>> = Vec::new();
-            if op.start > 0 {
-                blocks.push(Tensor::construct(
-                    vec![-1; op.start * input_dims[1]],
-                    vec![op.start, input_dims[1]],
-                ));
-            }
-            blocks.push(active);
-            let bottom = input_dims[0] - op.end;
-            if bottom > 0 {
-                blocks.push(Tensor::construct(
-                    vec![-1; bottom * input_dims[1]],
-                    vec![bottom, input_dims[1]],
-                ));
-            }
-            let block_refs: Vec<&Tensor<i32>> = blocks.iter().collect();
-            concat(&block_refs, 0).expect("concat on axis 0 should build expected exponents")
-        }
     }
 
     #[test]
@@ -437,69 +432,6 @@ mod tests {
             let input = Tensor::<i32>::random_small(&mut rng, &shape);
             let model = slice_model(shape, axis, start, end);
             unit_test_op(model, &[input]);
-        }
-    }
-
-    #[test]
-    fn test_slice_gamma_weights_layout_rank2_axis1() {
-        let gamma = Fr::from(7u64);
-        let cases = vec![
-            (
-                [2, 5],
-                Slice {
-                    axis: 1,
-                    start: 1,
-                    end: 4,
-                },
-            ),
-            (
-                [3, 6],
-                Slice {
-                    axis: 1,
-                    start: 2,
-                    end: 5,
-                },
-            ),
-            (
-                [5, 4],
-                Slice {
-                    axis: 0,
-                    start: 1,
-                    end: 4,
-                },
-            ),
-            (
-                [6, 3],
-                Slice {
-                    axis: 0,
-                    start: 0,
-                    end: 2,
-                },
-            ),
-        ];
-
-        for (input_dims, op) in cases {
-            let output_dims = if op.axis == 0 {
-                vec![op.end - op.start, input_dims[1]]
-            } else {
-                vec![input_dims[0], op.end - op.start]
-            };
-
-            let ctx = SliceGammaWeightsContext::new(&input_dims, &output_dims, op.clone(), gamma);
-            let output_weights = ctx.output_gamma_weights();
-            let input_weights = ctx.input_gamma_weights();
-
-            let output_len = output_dims.iter().product::<usize>();
-            let expected_output =
-                weights_from_exponents(gamma, &(0..output_len).collect::<Vec<_>>())
-                    .pad_next_power_of_two(&output_dims);
-            assert_eq!(output_weights, expected_output);
-
-            let expected_input_exponents =
-                expected_input_exponents_with_concat_2d(&input_dims, &op);
-            let expected_input = exponents_tensor_to_weights(gamma, &expected_input_exponents)
-                .pad_next_power_of_two(&input_dims);
-            assert_eq!(input_weights, expected_input);
         }
     }
 }

--- a/jolt-atlas-core/src/utils/dims.rs
+++ b/jolt-atlas-core/src/utils/dims.rs
@@ -14,6 +14,27 @@ use atlas_onnx_tracer::{model::Model, node::ComputationNode, ops::Operator};
 use joltworks::{field::JoltField, utils::thread::unsafe_allocate_zero_vec};
 use rayon::prelude::*;
 
+/// Convert a row-major linear index into coordinates for the given dimensions.
+pub fn linear_to_coord(mut index: usize, dims: &[usize]) -> Vec<usize> {
+    let mut coord = vec![0; dims.len()];
+    for axis in (0..dims.len()).rev() {
+        coord[axis] = index % dims[axis];
+        index /= dims[axis];
+    }
+    coord
+}
+
+/// Convert row-major coordinates into a linear index for the given dimensions.
+pub fn coord_to_linear(coord: &[usize], dims: &[usize]) -> usize {
+    let mut index = 0usize;
+    let mut stride = 1usize;
+    for axis in (0..dims.len()).rev() {
+        index += coord[axis] * stride;
+        stride *= dims[axis];
+    }
+    index
+}
+
 /// Function type for extracting dimension information from a computation node.
 pub type DimExtractor = fn(&ComputationNode, &Model) -> EinsumDims;
 


### PR DESCRIPTION
This PR rewrites `reshape`, `concat`, and `slice` from the old gamma-fold style into an eq-selector style.

The main idea is to express reordering without adding a new commitment. At a high level, we build a selector MLE like `[eq(r, 2), eq(r, 0), eq(r, 1), ...]`, which represents an index permutation such as `0 -> 2`, `1 -> 0`, `2 -> 1`. We then use sumcheck to compute the weighted sum of the input MLE under this selector. That sum should match `out(r)`.

Because the verifier already knows the input and output shapes, it can build the same selector MLE directly and evaluate it on its own. This makes the proof flow simpler and keeps these reordering ops commitment-free.

Close #207 