### PR TITLE
Feat: Optimize selector construction for reshape, concat, and slice

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/ops/concat.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/concat.rs
@@ -28,7 +28,7 @@ use joltworks::{
         sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
+    utils::{errors::ProofVerifyError, math::Math},
 };
 use rayon::prelude::*;
 
@@ -419,6 +419,7 @@ fn build_concat_selector<F: JoltField>(
     let max_domain_len = 1usize << max_input_num_vars;
     let axis_offset = axis_offset(raw_input_dims, input_idx, axis);
     let mut selector = vec![F::zero(); max_domain_len];
+    let eq_evals = EqPolynomial::evals(r_output);
 
     for linear_idx in 0..input_raw_len {
         let input_coord = linear_to_coord(linear_idx, input_raw_dims);
@@ -427,9 +428,8 @@ fn build_concat_selector<F: JoltField>(
 
         let input_index = coord_to_linear(&input_coord, &input_padded_dims);
         let output_index = coord_to_linear(&output_coord, &output_padded_dims);
-        let output_bits = index_to_field_bitvector::<F>(output_index as u64, output_num_vars);
         let full_index = input_index << (max_input_num_vars - input_num_vars);
-        selector[full_index] = EqPolynomial::mle(&output_bits, r_output);
+        selector[full_index] = eq_evals[output_index];
     }
 
     selector

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -38,7 +38,7 @@ use joltworks::{
         sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
+    utils::{errors::ProofVerifyError, math::Math},
 };
 use rayon::prelude::*;
 
@@ -126,14 +126,14 @@ pub(crate) fn build_reshape_selectors<F: JoltField + ChallengeFieldOps<F>>(
 
     // Selector values are zero on padding cells by default.
     let mut selector = vec![F::zero(); input_padded_len];
+    let eq_evals = EqPolynomial::evals(r_output);
 
     for t in 0..input_raw_len {
         let input_coord = linear_to_coord(t, input_raw_dims);
         let output_coord = linear_to_coord(t, output_raw_dims);
         let input_padded_index = coord_to_linear(&input_coord, &input_padded_dims);
         let output_padded_index = coord_to_linear(&output_coord, &output_padded_dims);
-        let output_bits = index_to_field_bitvector::<F>(output_padded_index as u64, r_output.len());
-        selector[input_padded_index] = EqPolynomial::mle(&output_bits, r_output);
+        selector[input_padded_index] = eq_evals[output_padded_index];
     }
 
     selector

--- a/jolt-atlas-core/src/onnx_proof/ops/slice.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/slice.rs
@@ -28,7 +28,7 @@ use joltworks::{
         sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::{errors::ProofVerifyError, index_to_field_bitvector, math::Math},
+    utils::{errors::ProofVerifyError, math::Math},
 };
 use rayon::prelude::*;
 
@@ -337,6 +337,7 @@ fn build_slice_selector<F: JoltField>(
     );
 
     let mut selector = vec![F::zero(); input_domain_len];
+    let eq_evals = EqPolynomial::evals(r_output);
     for output_linear_idx in 0..output_raw_dims.iter().product() {
         let output_coord = linear_to_coord(output_linear_idx, output_raw_dims);
         let mut input_coord = output_coord.clone();
@@ -344,14 +345,14 @@ fn build_slice_selector<F: JoltField>(
 
         let input_index = coord_to_linear(&input_coord, &input_padded_dims);
         let output_index = coord_to_linear(&output_coord, &output_padded_dims);
-        let output_bits = index_to_field_bitvector::<F>(output_index as u64, output_num_vars);
-        selector[input_index] = EqPolynomial::mle(&output_bits, r_output);
+        selector[input_index] = eq_evals[output_index];
     }
 
     assert!(
         input_raw_len >= output_raw_dims.iter().product(),
         "Slice output raw length exceeds input raw length"
     );
+
     selector
 }
 


### PR DESCRIPTION
This PR removes redundant work in `build_*_selector()` for `reshape`, `concat`, and `slice`.

Previously, these selector builders recomputed `EqPolynomial::mle(...)` for each mapped output index. Since the output challenge point is fixed for a given proof, this repeated the same `eq(r, ·)` work many times.

This change precomputes `EqPolynomial::evals(r_output)` once and then reuses it by direct indexing when building the selector MLE. The result is the same selector, but with much less repeated work.

This significantly reduced the cost of selector construction and improved end-to-end proving and verifying time.