### PR TITLE
feat: abs lookup

### DIFF
--- a/joltworks/src/field/mod.rs
+++ b/joltworks/src/field/mod.rs
@@ -34,7 +34,6 @@ pub trait ChallengeFieldOps<F>:
     + for<'a> Sub<&'a Self, Output = F>
     + Mul<Self, Output = F>
     + for<'a> Mul<&'a Self, Output = F>
-    + Debug
 {
 }
 
@@ -87,7 +86,6 @@ impl<F, C> ChallengeFieldOps<F> for C where
         + for<'a> Sub<&'a C, Output = F>
         + Mul<C, Output = F>
         + for<'a> Mul<&'a C, Output = F>
-        + Debug
 {
 }
 

--- a/joltworks/src/field/mod.rs
+++ b/joltworks/src/field/mod.rs
@@ -34,6 +34,7 @@ pub trait ChallengeFieldOps<F>:
     + for<'a> Sub<&'a Self, Output = F>
     + Mul<Self, Output = F>
     + for<'a> Mul<&'a Self, Output = F>
+    + Debug
 {
 }
 
@@ -86,6 +87,7 @@ impl<F, C> ChallengeFieldOps<F> for C where
         + for<'a> Sub<&'a C, Output = F>
         + Mul<C, Output = F>
         + for<'a> Mul<&'a C, Output = F>
+        + Debug
 {
 }
 

--- a/joltworks/src/lookup_tables/mod.rs
+++ b/joltworks/src/lookup_tables/mod.rs
@@ -105,10 +105,22 @@ pub mod suffixes;
 
 /// Bitwise AND lookup table.
 pub mod and;
+/// Negated ReLU lookup table: `f(x) = max(−x, 0)`.
+///
+/// Returns the magnitude of `x` when negative, and `0` otherwise.
+pub mod neg_relu;
 /// Bitwise OR lookup table.
 pub mod or;
 /// ReLU (Rectified Linear Unit) activation lookup table.
 pub mod relu;
+/// Unsigned absolute value lookup table.
+///
+/// Computes `abs(x)` by interpreting the input as a signed integer and returning
+/// its unsigned magnitude. For the edge case where `x = i8::MIN` (−128), the
+/// two's complement absolute value would overflow in hardware, but since we
+/// operate over a prime field, we simply return `128` (i.e., −(−128) = 128
+/// in the canonical field representation).
+pub mod unsigned_abs;
 /// Unsigned less-than comparison lookup table.
 pub mod unsigned_less_than;
 /// Bitwise XOR lookup table.

--- a/joltworks/src/lookup_tables/neg_relu.rs
+++ b/joltworks/src/lookup_tables/neg_relu.rs
@@ -62,6 +62,11 @@ impl<const X_LEN: usize> PrefixSuffixDecompositionTrait<X_LEN> for NegReluTable<
         suffixes: &[SuffixEval<F>],
     ) -> F {
         let [one, suffix_neg_relu] = suffixes.try_into().unwrap();
+        // Safe to multiply prefix[MSB] * prefix[NotLowerWord]:
+        //   - prefix[NotLowerWord] is degree-0 in the MSB variable
+        //   - prefix[MSB] is degree-1 in the MSB variable and degree-0 in the lower bits
+        // so their product remains degree ≤ 1 in every variable,
+        // preserving the multilinear property.
         prefixes[Prefixes::Msb] * prefixes[Prefixes::NotLowerWord] * one
             + prefixes[Prefixes::Msb] * suffix_neg_relu
     }

--- a/joltworks/src/lookup_tables/neg_relu.rs
+++ b/joltworks/src/lookup_tables/neg_relu.rs
@@ -1,0 +1,102 @@
+use super::{
+    prefixes::{PrefixEval, Prefixes},
+    suffixes::{SuffixEval, Suffixes},
+    JoltLookupTable, PrefixSuffixDecompositionTrait,
+};
+use crate::{
+    field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
+    utils::math::Math,
+};
+use serde::{Deserialize, Serialize};
+
+/// Negated ReLU lookup table: `f(x) = max(−x, 0)`.
+///
+/// Returns the magnitude of `x` when negative, and `0` otherwise.
+/// Used in the decomposition `abs(x) = relu(x) + neg_relu(x)`.
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct NegReluTable<const X_LEN: usize>;
+
+impl<const X_LEN: usize> JoltLookupTable for NegReluTable<X_LEN> {
+    fn materialize_entry(&self, index: u64) -> u64 {
+        let is_negative = ((index >> (X_LEN - 1)) & 1) == 1;
+        if is_negative {
+            // Two's complement negation: |x| = (!x % 2^X_LEN) + 1
+            (!index % (1 << X_LEN)) + 1
+        } else {
+            0
+        }
+    }
+
+    fn evaluate_mle<F, C>(&self, r: &[C]) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: JoltField + FieldChallengeOps<C>,
+    {
+        // Initialize to 1 to account for the +1 in two's complement
+        // negation: -x = (!x) + 1. The loop below accumulates the (!x) part
+        // as sum of (1 - r_i) * 2^i, and this starting value provides the +1.
+        let mut res = F::one();
+        r.iter()
+            .skip(X_LEN  /* skip high bits */ + 1 /* skip sign bit */)
+            .rev()
+            .enumerate()
+            .for_each(|(i, &r_i)| res += (F::one() - r_i) * F::from_u64(i.pow2() as u64));
+        let sign_bit = r[X_LEN];
+        res * sign_bit
+    }
+}
+
+impl<const X_LEN: usize> PrefixSuffixDecompositionTrait<X_LEN> for NegReluTable<X_LEN> {
+    fn suffixes(&self) -> Vec<Suffixes> {
+        vec![Suffixes::One, Suffixes::NegRelu]
+    }
+
+    fn prefixes(&self) -> Vec<Prefixes> {
+        vec![Prefixes::Msb, Prefixes::NotLowerWord]
+    }
+
+    #[cfg(test)]
+    fn combine_test<F: JoltField>(
+        &self,
+        prefixes: &[PrefixEval<F>],
+        suffixes: &[SuffixEval<F>],
+    ) -> F {
+        let [one, nlw] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::Msb] * prefixes[Prefixes::NotLowerWord] * one
+            + prefixes[Prefixes::Msb] * nlw
+    }
+
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        let [suffix_one, suffix_nlw] = suffixes.try_into().unwrap();
+        let [prefix_msb, prefix_nlw] = prefixes.try_into().unwrap();
+        prefix_msb * prefix_nlw * suffix_one + prefix_msb * suffix_nlw
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::lookup_tables::{
+        neg_relu::NegReluTable,
+        test::{
+            lookup_table_mle_full_hypercube_test, lookup_table_mle_random_test, prefix_suffix_test,
+        },
+    };
+    use ark_bn254::Fr;
+    use common::consts::XLEN;
+
+    #[test]
+    fn prefix_suffix() {
+        prefix_suffix_test::<XLEN, Fr, NegReluTable<XLEN>>();
+    }
+
+    #[test]
+    fn mle_full_hypercube() {
+        lookup_table_mle_full_hypercube_test::<Fr, NegReluTable<8>>();
+    }
+
+    #[test]
+    fn mle_random() {
+        lookup_table_mle_random_test::<Fr, NegReluTable<XLEN>>();
+    }
+}

--- a/joltworks/src/lookup_tables/neg_relu.rs
+++ b/joltworks/src/lookup_tables/neg_relu.rs
@@ -61,9 +61,9 @@ impl<const X_LEN: usize> PrefixSuffixDecompositionTrait<X_LEN> for NegReluTable<
         prefixes: &[PrefixEval<F>],
         suffixes: &[SuffixEval<F>],
     ) -> F {
-        let [one, nlw] = suffixes.try_into().unwrap();
+        let [one, suffix_neg_relu] = suffixes.try_into().unwrap();
         prefixes[Prefixes::Msb] * prefixes[Prefixes::NotLowerWord] * one
-            + prefixes[Prefixes::Msb] * nlw
+            + prefixes[Prefixes::Msb] * suffix_neg_relu
     }
 
     fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {

--- a/joltworks/src/lookup_tables/prefixes/mod.rs
+++ b/joltworks/src/lookup_tables/prefixes/mod.rs
@@ -11,6 +11,7 @@ use self::{
 };
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
+    lookup_tables::prefixes::{msb::MsbPrefix, nlw::NotLowerWordPrefix},
     utils::lookup_bits::LookupBits,
 };
 use num::FromPrimitive;
@@ -28,6 +29,10 @@ pub mod eq;
 pub mod less_than;
 /// Lower word (without MSB) prefix implementation.
 pub mod lower_word_no_msb;
+/// MSB (most significant bit) prefix implementation.
+pub mod msb;
+/// Two's complement negation prefix: `(!lower_word) + 1`, used in `neg_relu` decomposition.
+pub mod nlw;
 /// Not-MSB (most significant bit) prefix implementation.
 pub mod not_msb;
 /// Bitwise OR prefix implementation.
@@ -101,6 +106,10 @@ pub enum Prefixes {
     Or,
     /// Bitwise XOR prefix
     Xor,
+    /// MSB (sign bit) prefix
+    Msb,
+    /// Two's complement negation prefix: `(!lower_word) + 1`
+    NotLowerWord,
 }
 
 #[derive(Clone, Copy)]
@@ -189,6 +198,10 @@ impl Prefixes {
             Prefixes::NotMsb => NotMsbPrefix::<XLEN>::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::Or => OrPrefix::<XLEN>::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::Xor => XorPrefix::<XLEN>::prefix_mle(checkpoints, r_x, c, b, j),
+            Prefixes::Msb => MsbPrefix::<XLEN>::prefix_mle(checkpoints, r_x, c, b, j),
+            Prefixes::NotLowerWord => {
+                NotLowerWordPrefix::<XLEN>::prefix_mle(checkpoints, r_x, c, b, j)
+            }
         };
         PrefixEval(eval)
     }
@@ -269,6 +282,16 @@ impl Prefixes {
             Prefixes::Xor => {
                 XorPrefix::<XLEN>::update_prefix_checkpoint(checkpoints, r_x, r_y, j, suffix_len)
             }
+            Prefixes::Msb => {
+                MsbPrefix::<XLEN>::update_prefix_checkpoint(checkpoints, r_x, r_y, j, suffix_len)
+            }
+            Prefixes::NotLowerWord => NotLowerWordPrefix::<XLEN>::update_prefix_checkpoint(
+                checkpoints,
+                r_x,
+                r_y,
+                j,
+                suffix_len,
+            ),
         }
     }
 }

--- a/joltworks/src/lookup_tables/prefixes/msb.rs
+++ b/joltworks/src/lookup_tables/prefixes/msb.rs
@@ -1,0 +1,52 @@
+use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use crate::{
+    field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
+    utils::lookup_bits::LookupBits,
+};
+
+/// Prefix component for MSB (most significant bit) lookup table decomposition.
+pub enum MsbPrefix<const XLEN: usize> {}
+
+impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for MsbPrefix<XLEN> {
+    fn prefix_mle<C>(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<C>,
+        c: u32,
+        mut _b: LookupBits,
+        j: usize,
+    ) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        match j {
+            // suffix will handle
+            j if j < XLEN => F::one(),
+            // sign bit in c
+            j if j == XLEN => F::from_u32(c),
+            // sign bit in r_x
+            j if j == XLEN + 1 => r_x.unwrap().into(),
+            // sign bit processed; use checkpoint.
+            _ => checkpoints[Prefixes::Msb].unwrap(),
+        }
+    }
+
+    fn update_prefix_checkpoint<C>(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: C,
+        _r_y: C,
+        j: usize,
+        _suffix_len: usize,
+    ) -> PrefixCheckpoint<F>
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        match j {
+            j if j < XLEN => None.into(),
+            // sign bit will be in r_x when j == XLEN + 1
+            j if j == XLEN + 1 => Some(r_x.into()).into(),
+            _ => checkpoints[Prefixes::Msb].into(),
+        }
+    }
+}

--- a/joltworks/src/lookup_tables/prefixes/nlw.rs
+++ b/joltworks/src/lookup_tables/prefixes/nlw.rs
@@ -42,12 +42,12 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for NotLowerWordPrefi
             (Some(r_x), _) => {
                 let x_shift = XLEN - jj;
                 let y_shift = x_shift - 1;
-                let r_x = if j == (XLEN + 1) {
+                let not_r_x = if j == (XLEN + 1) {
                     F::zero()
                 } else {
                     F::one() - r_x.into()
                 };
-                word += F::from_u64(1 << x_shift) * r_x;
+                word += F::from_u64(1 << x_shift) * not_r_x;
                 word += F::from_u64(1 << y_shift) * (F::one() - F::from_u32(c));
             }
         }
@@ -76,12 +76,12 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for NotLowerWordPrefi
         let jj = j - XLEN;
         let x_shift = XLEN - jj;
         let y_shift = x_shift - 1;
-        let r_x = if j == (XLEN + 1) {
+        let not_r_x = if j == (XLEN + 1) {
             F::zero()
         } else {
             F::one() - r_x.into()
         };
-        word += F::from_u64(1 << x_shift) * r_x + F::from_u64(1 << y_shift) * (F::one() - r_y);
+        word += F::from_u64(1 << x_shift) * not_r_x + F::from_u64(1 << y_shift) * (F::one() - r_y);
         Some(word).into()
     }
 }

--- a/joltworks/src/lookup_tables/prefixes/nlw.rs
+++ b/joltworks/src/lookup_tables/prefixes/nlw.rs
@@ -1,0 +1,87 @@
+use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use crate::{
+    field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
+    utils::lookup_bits::LookupBits,
+};
+
+/// Prefix component for two's complement negation: `(!lower_word) + 1`.
+///
+/// Accumulates the bitwise-NOT of the magnitude bits (lower word, excluding the sign bit)
+/// plus one, used in the `neg_relu` prefix-suffix decomposition.
+pub enum NotLowerWordPrefix<const XLEN: usize> {}
+
+impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for NotLowerWordPrefix<XLEN> {
+    fn prefix_mle<C>(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<C>,
+        c: u32,
+        mut b: LookupBits,
+        j: usize,
+    ) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        // ignore high order variables and sign bit
+        if j < XLEN {
+            return F::zero();
+        }
+        let jj = j - XLEN;
+        let mut word = checkpoints[Prefixes::NotLowerWord].unwrap_or(F::one());
+        let suffix_len = XLEN * 2 - j - b.len() - 1;
+        match (r_x, j) {
+            (None, jjj) if jjj == XLEN => {
+                // sign bit is in c
+            }
+            (None, _) => {
+                let x_shift = XLEN - jj - 1;
+                let y_shift = x_shift - 1;
+                word += F::from_u64(1 << x_shift) * (F::one() - F::from_u32(c));
+                word += F::from_u64(1 << y_shift) * (F::one() - F::from_u8(b.pop_msb()));
+            }
+            (Some(r_x), _) => {
+                let x_shift = XLEN - jj;
+                let y_shift = x_shift - 1;
+                let r_x = if j == (XLEN + 1) {
+                    F::zero()
+                } else {
+                    F::one() - r_x.into()
+                };
+                word += F::from_u64(1 << x_shift) * r_x;
+                word += F::from_u64(1 << y_shift) * (F::one() - F::from_u32(c));
+            }
+        }
+
+        word += F::from_u64((<LookupBits as Into<u64>>::into(!b)) << suffix_len);
+        word
+    }
+
+    fn update_prefix_checkpoint<C>(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: C,
+        r_y: C,
+        j: usize,
+        _suffix_len: usize,
+    ) -> PrefixCheckpoint<F>
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        // ignore high order variables
+        if j < XLEN {
+            return None.into();
+        }
+
+        let mut word = checkpoints[Prefixes::NotLowerWord].unwrap_or(F::one());
+        let jj = j - XLEN;
+        let x_shift = XLEN - jj;
+        let y_shift = x_shift - 1;
+        let r_x = if j == (XLEN + 1) {
+            F::zero()
+        } else {
+            F::one() - r_x.into()
+        };
+        word += F::from_u64(1 << x_shift) * r_x + F::from_u64(1 << y_shift) * (F::one() - r_y);
+        Some(word).into()
+    }
+}

--- a/joltworks/src/lookup_tables/suffixes/mod.rs
+++ b/joltworks/src/lookup_tables/suffixes/mod.rs
@@ -5,7 +5,10 @@
 //! protocol, suffix MLEs are evaluated and combined with prefix contributions to
 //! reconstruct the full lookup table evaluation without materializing the entire table.
 
-use crate::{field::JoltField, utils::lookup_bits::LookupBits};
+use crate::{
+    field::JoltField, lookup_tables::suffixes::neg_relu::NegReluSuffix,
+    utils::lookup_bits::LookupBits,
+};
 use num_derive::FromPrimitive;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
@@ -20,6 +23,8 @@ pub mod and;
 pub mod less_than;
 /// Lower word without MSB suffix implementation.
 pub mod lower_word_no_msb;
+/// Negated ReLU suffix (Relu(-x)): `neg_relu(x) = max(-x, 0)`.
+pub mod neg_relu;
 /// Constant one suffix implementation.
 pub mod one;
 /// Bitwise OR suffix implementation.
@@ -57,6 +62,8 @@ pub enum Suffixes {
     Relu,
     /// Bitwise XOR suffix
     Xor,
+    /// Suffix for Relu(-x) table
+    NegRelu,
 }
 
 /// Type alias for suffix evaluation results in the field.
@@ -74,6 +81,7 @@ impl Suffixes {
             Suffixes::LowerWordNoMSB => LowerWordNoMsbSuffix::<XLEN>::suffix_mle(b),
             Suffixes::Relu => ReluSuffix::<XLEN>::suffix_mle(b),
             Suffixes::Xor => XorSuffix::suffix_mle(b),
+            Suffixes::NegRelu => NegReluSuffix::<XLEN>::suffix_mle(b),
         }
     }
 }

--- a/joltworks/src/lookup_tables/suffixes/neg_relu.rs
+++ b/joltworks/src/lookup_tables/suffixes/neg_relu.rs
@@ -1,0 +1,23 @@
+use crate::utils::lookup_bits::LookupBits;
+
+use super::SparseDenseSuffix;
+
+/// Suffix component for Relu(-x) lookup table MLE decomposition.
+pub enum NegReluSuffix<const XLEN: usize> {}
+
+impl<const XLEN: usize> SparseDenseSuffix for NegReluSuffix<XLEN> {
+    fn suffix_mle(bits: LookupBits) -> u32 {
+        let b: u64 = bits.into();
+        let num_bits = bits.len();
+
+        if num_bits >= XLEN {
+            // Two's complement negation, gated by sign bit: neg_relu(x) = is_negative * |x|
+            let is_negative = (b >> (XLEN - 1)) & 1;
+            let abs_value = (!b % (1 << (XLEN - 1))) as u32 + 1;
+            abs_value * is_negative as u32
+        } else {
+            // Partial suffix: flip the available bits (!b truncated to num_bits).
+            (!b % (1 << num_bits)) as u32
+        }
+    }
+}

--- a/joltworks/src/lookup_tables/test.rs
+++ b/joltworks/src/lookup_tables/test.rs
@@ -112,7 +112,7 @@ pub fn prefix_suffix_test<
                 let combined = T::default().combine_test(&prefix_evals, &suffix_evals);
                 if combined != mle_eval {
                     println!("Lookup index: {lookup_index}");
-                    println!("{j} {prefix_bits} {suffix_bits}");
+                    println!("j: {j} {prefix_bits} {suffix_bits}");
                     for (i, x) in prefix_evals.iter().enumerate() {
                         println!("prefix_evals[{i}] = {x}");
                     }

--- a/joltworks/src/lookup_tables/unsigned_abs.rs
+++ b/joltworks/src/lookup_tables/unsigned_abs.rs
@@ -1,0 +1,180 @@
+use std::fmt::Debug;
+
+use super::{
+    prefixes::{PrefixEval, Prefixes},
+    suffixes::{SuffixEval, Suffixes},
+    JoltLookupTable, PrefixSuffixDecompositionTrait,
+};
+use crate::{
+    field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
+    lookup_tables::{neg_relu::NegReluTable, relu::ReluTable},
+    utils::math::Math,
+};
+use serde::{Deserialize, Serialize};
+
+/// Unsigned absolute value lookup table: `f(x) = |x| = relu(x) + relu(-x)`.
+///
+/// Decomposes into [`ReluTable`] and [`NegReluTable`] for prefix-suffix proving.
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct UnsignedAbsTable<const X_LEN: usize>;
+
+impl<const X_LEN: usize> JoltLookupTable for UnsignedAbsTable<X_LEN> {
+    fn materialize_entry(&self, index: u64) -> u64 {
+        let sign_bit: bool = ((index >> (X_LEN - 1)) & 1) == 1;
+        if sign_bit {
+            // Two's complement negation: -x = (!x) + 1
+            // We reduce modulo 2^(X_LEN-1) first to extract the lower magnitude bits
+            // from the 64-bit NOT, then add 1. This ordering is important: for i8::MIN
+            // (magnitude bits all zero), !L = 2^(X_LEN-1) - 1, so (!L % 2^(X_LEN-1)) + 1
+            // correctly yields 2^(X_LEN-1) (= 128 for X_LEN=8).
+            (!index) % (1 << (X_LEN - 1)) + 1
+        } else {
+            index % (1 << (X_LEN - 1))
+        }
+    }
+
+    fn evaluate_mle<F, C>(&self, r: &[C]) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: JoltField + FieldChallengeOps<C>,
+    {
+        debug_assert_eq!(r.len(), 2 * X_LEN);
+
+        let mut positive_case = F::zero();
+
+        // if x < 0, abs(x) = -x = (!x) + 1
+        let mut negative_case = F::one();
+
+        r.iter()
+            .skip(X_LEN  /* skip high bits */ + 1 /* skip sign bit */)
+            .rev()
+            .enumerate()
+            .for_each(|(i, &r_i)| {
+                positive_case += r_i * F::from_u64(i.pow2() as u64);
+                negative_case += (F::one() - r_i) * F::from_u64(i.pow2() as u64)
+            });
+
+        let sign_bit = r[X_LEN];
+        positive_case * (F::one() - sign_bit) + negative_case * sign_bit
+    }
+}
+
+impl<const X_LEN: usize> PrefixSuffixDecompositionTrait<X_LEN> for UnsignedAbsTable<X_LEN> {
+    fn suffixes(&self) -> Vec<Suffixes> {
+        vec![Suffixes::One, Suffixes::Relu, Suffixes::NegRelu]
+    }
+
+    fn prefixes(&self) -> Vec<Prefixes> {
+        vec![
+            Prefixes::NotMsb,
+            Prefixes::LowerWordNoMsb,
+            Prefixes::Msb,
+            Prefixes::NotLowerWord,
+        ]
+    }
+
+    #[cfg(test)]
+    fn combine_test<F: JoltField>(
+        &self,
+        prefixes: &[PrefixEval<F>],
+        suffixes: &[SuffixEval<F>],
+    ) -> F {
+        let [one, relu, neg_relu] = suffixes.try_into().unwrap();
+        let relu = ReluTable::<X_LEN>.combine_test(prefixes, &[one, relu]);
+        let neg_relu = NegReluTable::<X_LEN>.combine_test(prefixes, &[one, neg_relu]);
+        relu + neg_relu
+    }
+
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        let [suffix_one, suffix_relu, suffix_neg_relu] = suffixes.try_into().unwrap();
+        let [prefix_not_msb, prefix_lower_word_no_msb, prefix_msb, prefix_nlw] =
+            prefixes.try_into().unwrap();
+        let relu = ReluTable::<X_LEN>.combine(
+            &[prefix_not_msb, prefix_lower_word_no_msb],
+            &[suffix_one, suffix_relu],
+        );
+        let neg_relu = NegReluTable::<X_LEN>
+            .combine(&[prefix_msb, prefix_nlw], &[suffix_one, suffix_neg_relu]);
+        relu + neg_relu
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::lookup_tables::{
+        test::{
+            lookup_table_mle_full_hypercube_test, lookup_table_mle_random_test, prefix_suffix_test,
+        },
+        unsigned_abs::UnsignedAbsTable,
+        JoltLookupTable,
+    };
+    use ark_bn254::Fr;
+    use common::consts::XLEN;
+
+    fn unsigned_abs(x: i8) -> u8 {
+        x.unsigned_abs()
+    }
+
+    /// Verify the lookup table matches `i8::unsigned_abs()` for all 256 inputs.
+    ///
+    /// Key edge cases (two's complement, X_LEN=8):
+    ///
+    /// | Value | Binary      | Abs |
+    /// |-------|-------------|-----|
+    /// |   127 | `0111_1111` | 127 |
+    /// |  -128 | `1000_0000` | 128 |
+    /// |    -1 | `1111_1111` |   1 |
+    /// |     0 | `0000_0000` |   0 |
+    ///
+    /// See the `i8::MIN` assertion below for why this table returns 128
+    /// (not 0) and how that differs from ONNX semantics.
+    #[test]
+    fn test_unsigned_abs_table() {
+        let table = UnsignedAbsTable::<8>;
+        let materialized_table = table.materialize();
+
+        // Exhaustive check against Rust's `i8::unsigned_abs()`
+        for i in 0..256usize {
+            assert_eq!(unsigned_abs(i as i8), materialized_table[i] as u8);
+        }
+
+        // Explicit edge cases
+        assert_eq!(table.materialize_entry(0u64), 0, "abs(0) = 0");
+        assert_eq!(table.materialize_entry(127u64), 127, "abs(127) = 127");
+        assert_eq!(table.materialize_entry(0xFF), 1, "abs(-1) = 1");
+
+        // i8::MIN = -128 (0b1000_0000): the critical edge case.
+        //
+        // NOTE: Our table returns 128 (not 0), because this table is used for
+        // internal proof computations where outputs are unsigned integers
+        // where we want int::MIN to return its canonical abs value in the
+        // field, NOT for proving ONNX `Abs` directly. For ONNX compliance,
+        // 128 doesn't fit in i8 (or negate(i32::MIN) doesn't fit in i32 in
+        // the real impl), so MIN would need clamped output. One approach:
+        // replace `!x + 1` with `!x + (1 - eqz)` where `eqz` is 1 when the
+        // lower X_LEN-1 magnitude bits (i.e., everything except the sign bit)
+        // are all zero — which uniquely identifies MIN. This skips the +1
+        // only for MIN, clamping its abs to INT_MAX (127 for i8).
+        assert_eq!(
+            table.materialize_entry(0x80),
+            128,
+            "abs(i8::MIN) must be 128, not 0: field arithmetic avoids two's complement overflow"
+        );
+    }
+
+    #[test]
+    fn prefix_suffix() {
+        prefix_suffix_test::<XLEN, Fr, UnsignedAbsTable<XLEN>>();
+    }
+
+    #[test]
+    fn mle_full_hypercube() {
+        lookup_table_mle_full_hypercube_test::<Fr, UnsignedAbsTable<8>>();
+    }
+
+    #[test]
+    fn mle_random() {
+        lookup_table_mle_random_test::<Fr, UnsignedAbsTable<XLEN>>();
+    }
+}

--- a/joltworks/src/subprotocols/ps_shout.rs
+++ b/joltworks/src/subprotocols/ps_shout.rs
@@ -817,3 +817,264 @@ pub fn ps_read_raf_verifier<
     let params = ReadRafSumcheckParams::new(provider, accumulator, transcript);
     ReadRafSumcheckVerifier::new(params)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        lookup_tables::{
+            and::AndTable, or::OrTable, relu::ReluTable, unsigned_abs::UnsignedAbsTable,
+            unsigned_less_than::UnsignedLessThanTable, xor::XorTable, JoltLookupTable,
+            PrefixSuffixDecompositionTrait,
+        },
+        poly::{
+            multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
+            opening_proof::{
+                OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+                VerifierOpeningAccumulator, BIG_ENDIAN,
+            },
+        },
+        subprotocols::{
+            ps_shout::{
+                ps_read_raf_prover, ps_read_raf_verifier, PrefixSuffixShoutProvider, ReadRafClaims,
+            },
+            sumcheck::Sumcheck,
+        },
+        transcripts::{Blake2bTranscript, Transcript},
+        utils::{lookup_bits::LookupBits, uninterleave_bits},
+    };
+    use ark_bn254::Fr;
+    use ark_std::Zero;
+    use common::{
+        consts::{LOG_K, XLEN},
+        VirtualPolynomial,
+    };
+    use itertools::Itertools;
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use std::marker::PhantomData;
+
+    const LOG_NUM_LOOKUPS: usize = 10;
+    const NUM_LOOKUPS: usize = 1 << LOG_NUM_LOOKUPS;
+
+    #[test]
+    fn test_unsigned_abs() {
+        test_read_raf_sumcheck::<UnsignedAbsTable<XLEN>, false>();
+    }
+
+    #[test]
+    fn test_and() {
+        test_read_raf_sumcheck::<AndTable<XLEN>, true>();
+    }
+
+    #[test]
+    fn test_or() {
+        test_read_raf_sumcheck::<OrTable<XLEN>, true>();
+    }
+
+    #[test]
+    fn test_relu() {
+        test_read_raf_sumcheck::<ReluTable<XLEN>, false>();
+    }
+
+    #[test]
+    fn test_ltu() {
+        test_read_raf_sumcheck::<UnsignedLessThanTable<XLEN>, true>();
+    }
+
+    #[test]
+    fn test_xor() {
+        test_read_raf_sumcheck::<XorTable<XLEN>, true>();
+    }
+
+    fn test_read_raf_sumcheck<LUT, const INTERLEAVED: bool>()
+    where
+        LUT: JoltLookupTable + PrefixSuffixDecompositionTrait<XLEN> + Default,
+    {
+        let trace = generate_trace::<LUT>();
+
+        // --- Prover ---
+        let (mut prover_transcript, r_cycle) = new_test_transcript();
+        let mut prover_accumulator = ProverOpeningAccumulator::new();
+
+        let rv_claim = trace.rv.evaluate(&r_cycle);
+        let (left_operand_claim, right_operand_claim) =
+            compute_operand_claims::<INTERLEAVED>(&trace.lookup_indices, &r_cycle);
+
+        let provider = TestProvider::<LUT>::new(
+            rv_claim,
+            left_operand_claim,
+            right_operand_claim,
+            r_cycle,
+            INTERLEAVED,
+        );
+
+        let mut prover = ps_read_raf_prover(
+            &provider,
+            trace.lookup_bits,
+            &mut prover_accumulator,
+            &mut prover_transcript,
+        );
+        let (proof, prover_challenges) =
+            Sumcheck::prove(&mut prover, &mut prover_accumulator, &mut prover_transcript);
+
+        // --- Verifier ---
+        // Re-derive the same transcript state the prover started from
+        let (mut verifier_transcript, _) = new_test_transcript();
+        let mut verifier_accumulator = VerifierOpeningAccumulator::new();
+        transfer_openings(&prover_accumulator, &mut verifier_accumulator);
+
+        let verifier = ps_read_raf_verifier(
+            &provider,
+            &mut verifier_accumulator,
+            &mut verifier_transcript,
+        );
+        let verifier_challenges = Sumcheck::verify(
+            &proof,
+            &verifier,
+            &mut verifier_accumulator,
+            &mut verifier_transcript,
+        )
+        .unwrap();
+
+        assert_eq!(prover_challenges, verifier_challenges);
+    }
+
+    /// Computes operand polynomial claims at `r_cycle`, branching on interleaving mode.
+    ///
+    /// - Interleaved: uninterleaves bits into left/right operand indices and evaluates both.
+    /// - Non-interleaved: left claim is zero, right claim evaluates raw lookup indices.
+    fn compute_operand_claims<const INTERLEAVED: bool>(
+        lookup_indices: &[u64],
+        r_cycle: &[Fr],
+    ) -> (Fr, Fr) {
+        if INTERLEAVED {
+            let (left_indices, right_indices): (Vec<_>, Vec<_>) =
+                lookup_indices.iter().map(|&i| uninterleave_bits(i)).unzip();
+            (
+                MultilinearPolynomial::from(left_indices).evaluate(r_cycle),
+                MultilinearPolynomial::from(right_indices).evaluate(r_cycle),
+            )
+        } else {
+            (
+                Fr::zero(),
+                MultilinearPolynomial::from(lookup_indices.to_vec()).evaluate(r_cycle),
+            )
+        }
+    }
+
+    /// Copies opening claims from prover accumulator to verifier accumulator,
+    /// simulating the verifier receiving committed opening claims.
+    fn transfer_openings(
+        prover_acc: &ProverOpeningAccumulator<Fr>,
+        verifier_acc: &mut VerifierOpeningAccumulator<Fr>,
+    ) {
+        for (key, (_, claim)) in &prover_acc.openings {
+            verifier_acc
+                .openings
+                .insert(*key, (OpeningPoint::default(), *claim));
+        }
+    }
+
+    struct TestTrace {
+        lookup_indices: Vec<u64>,
+        lookup_bits: Vec<LookupBits>,
+        rv: MultilinearPolynomial<Fr>,
+    }
+
+    /// Generates a deterministic random lookup trace for testing.
+    fn generate_trace<LUT: JoltLookupTable + Default>() -> TestTrace {
+        let mut rng = StdRng::seed_from_u64(0x1109);
+        let table = LUT::default();
+        let lookup_indices: Vec<u64> = (0..NUM_LOOKUPS).map(|_| rng.gen()).collect();
+        let lookup_bits = lookup_indices
+            .iter()
+            .map(|&i| LookupBits::new(i, LOG_K))
+            .collect();
+        let rv = MultilinearPolynomial::from(
+            lookup_indices
+                .iter()
+                .map(|&i| table.materialize_entry(i))
+                .collect_vec(),
+        );
+        TestTrace {
+            lookup_indices,
+            lookup_bits,
+            rv,
+        }
+    }
+
+    /// Creates a fresh test transcript and draws the challenge vector for cycle variables.
+    fn new_test_transcript() -> (Blake2bTranscript, Vec<Fr>) {
+        let mut transcript = Blake2bTranscript::new(b"test");
+        let r_cycle: Vec<Fr> = transcript.challenge_vector(LOG_NUM_LOOKUPS);
+        (transcript, r_cycle)
+    }
+
+    struct TestProvider<LUT>
+    where
+        LUT: JoltLookupTable + PrefixSuffixDecompositionTrait<XLEN> + Default,
+    {
+        rv_claim: Fr,
+        left_operand_claim: Fr,
+        right_operand_claim: Fr,
+        r_cycle: Vec<Fr>,
+        is_interleaved_operands: bool,
+        _phantom: PhantomData<LUT>,
+    }
+
+    impl<LUT> TestProvider<LUT>
+    where
+        LUT: JoltLookupTable + PrefixSuffixDecompositionTrait<XLEN> + Default,
+    {
+        fn new(
+            rv_claim: Fr,
+            left_operand_claim: Fr,
+            right_operand_claim: Fr,
+            r_cycle: Vec<Fr>,
+            is_interleaved_operands: bool,
+        ) -> Self {
+            Self {
+                rv_claim,
+                left_operand_claim,
+                right_operand_claim,
+                r_cycle,
+                is_interleaved_operands,
+                _phantom: PhantomData,
+            }
+        }
+    }
+
+    impl<LUT> PrefixSuffixShoutProvider<Fr, LUT> for TestProvider<LUT>
+    where
+        LUT: JoltLookupTable + PrefixSuffixDecompositionTrait<XLEN> + Default,
+    {
+        fn read_raf_claims(&self, _accumulator: &dyn OpeningAccumulator<Fr>) -> ReadRafClaims<Fr> {
+            ReadRafClaims {
+                rv_claim: self.rv_claim,
+                left_operand_claim: self.left_operand_claim,
+                right_operand_claim: self.right_operand_claim,
+            }
+        }
+
+        fn is_interleaved_operands(&self) -> bool {
+            self.is_interleaved_operands
+        }
+
+        fn ra_poly(&self) -> (VirtualPolynomial, SumcheckId) {
+            (
+                VirtualPolynomial::NodeOutputRa(0),
+                SumcheckId::NodeExecution(0),
+            )
+        }
+
+        fn r_cycle(
+            &self,
+            _accumulator: &dyn OpeningAccumulator<Fr>,
+        ) -> OpeningPoint<BIG_ENDIAN, Fr> {
+            OpeningPoint::new(self.r_cycle.clone())
+        }
+
+        fn raf_claim_specs(&self) -> Vec<(VirtualPolynomial, SumcheckId)> {
+            unimplemented!()
+        }
+    }
+}

--- a/joltworks/src/utils/lookup_bits.rs
+++ b/joltworks/src/utils/lookup_bits.rs
@@ -112,7 +112,7 @@ impl std::ops::Not for LookupBits {
     type Output = Self;
 
     fn not(self) -> Self::Output {
-        Self::new(!(self.bits % (1 << self.len)), self.len)
+        Self::new(!self.bits, self.len)
     }
 }
 

--- a/joltworks/src/utils/lookup_bits.rs
+++ b/joltworks/src/utils/lookup_bits.rs
@@ -108,6 +108,14 @@ impl std::ops::Rem<usize> for &LookupBits {
     }
 }
 
+impl std::ops::Not for LookupBits {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self::new(!(self.bits % (1 << self.len)), self.len)
+    }
+}
+
 impl std::ops::Rem<usize> for LookupBits {
     type Output = usize;
 


### PR DESCRIPTION
Builds on Antoines' earlier work.

Required for #208 & #192.

See [here](https://github.com/ICME-Lab/jolt-atlas/blob/b9824b925e35c92724b87ef3717c530e3de38255/joltworks/src/lookup_tables/unsigned_abs.rs#L147-L158) for design choice around handling `int::MIN` edge case.

