### PR TITLE
chore: gate malicious prover

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/malicious_prover.rs
+++ b/jolt-atlas-core/src/onnx_proof/malicious_prover.rs
@@ -23,9 +23,6 @@ use joltworks::{
     transcripts::{AppendToTranscript, Transcript},
 };
 
-pub use ark_bn254::{Bn254, Fr};
-pub use joltworks::{poly::commitment::hyperkzg::HyperKZG, transcripts::Blake2bTranscript};
-
 use crate::onnx_proof::{
     ops::{malicious_sub::malicious_sub_prove, OperatorProver},
     AtlasProverPreprocessing, ONNXProof, ProofId, Prover, ProverDebugInfo,

--- a/jolt-atlas-core/src/onnx_proof/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/mod.rs
@@ -32,7 +32,8 @@ pub mod proof_serialization;
 pub mod range_checking;
 pub mod witness;
 
-pub mod malicious_prover;
+#[cfg(test)]
+mod malicious_prover;
 mod preprocessing;
 mod prover;
 mod types;

--- a/jolt-atlas-core/src/onnx_proof/ops/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mod.rs
@@ -68,6 +68,7 @@ pub mod iff;
 pub mod input;
 /// Check for NaN values.
 pub mod is_nan;
+#[cfg(test)]
 /// Experimental malicious variant of Sub proof logic.
 pub mod malicious_sub;
 /// Reorder tensor axes.


### PR DESCRIPTION
removed it from public API and gated behind `cfg(test)`