### PR TITLE
Feat: optimize commit witness polynomials

### DIFF
--- a/atlas-onnx-tracer/src/ops/einsum.rs
+++ b/atlas-onnx-tracer/src/ops/einsum.rs
@@ -2,6 +2,7 @@ use crate::{
     ops::{Einsum, Op},
     tensor::{Tensor, TensorError},
 };
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use tract_onnx::prelude::tract_itertools::Itertools;
@@ -169,6 +170,7 @@ pub fn einsum_i32_with_i64_rebase(
 
     let output: Vec<i32> = cartesian_coord
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|out_coord| {
             let out_partials: Vec<usize> = (0..inputs.len())
                 .map(|inp_idx| {

--- a/atlas-onnx-tracer/src/ops/mul.rs
+++ b/atlas-onnx-tracer/src/ops/mul.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 
 use crate::{
@@ -44,6 +45,7 @@ pub fn mult_i32_with_i64_rebase(
         output
             .par_iter_mut()
             .zip(rhs_expanded.data().par_iter())
+            .with_min_len(par_enabled())
             .for_each(|(o, r)| {
                 let prod: i64 = (*o as i64) * (*r as i64);
 

--- a/atlas-onnx-tracer/src/tensor/mod.rs
+++ b/atlas-onnx-tracer/src/tensor/mod.rs
@@ -5,10 +5,11 @@ use crate::utils::parallel_utils::IndexedParallelIterator;
 use crate::utils::{
     self,
     dims::copy_strided,
-    parallel_utils::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelSliceMut},
+    parallel_utils::{
+        IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator, ParallelSliceMut,
+    },
     quantize,
 };
-use maybe_rayon::iter::ParallelIterator;
 use rand::{Rng, RngCore, distributions::Uniform, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/atlas-onnx-tracer/src/tensor/ops.rs
+++ b/atlas-onnx-tracer/src/tensor/ops.rs
@@ -5,6 +5,7 @@ use crate::{
     tensor::{Tensor, TensorType},
     utils::parallel_utils::{IntoParallelRefIterator, IntoParallelRefMutIterator},
 };
+use common::parallel::par_enabled;
 use maybe_rayon::iter::ParallelIterator;
 use std::collections::{HashMap, HashSet};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -53,6 +54,7 @@ pub fn iff<
     // assert is boolean
     if !mask
         .par_iter()
+        .with_min_len(par_enabled())
         .all(|x| *x == T::one().unwrap() || *x == T::zero().unwrap())
     {
         return Err(TensorError::WrongMethod);
@@ -134,6 +136,7 @@ pub fn or<
 ) -> Result<Tensor<T>, TensorError> {
     if !b
         .par_iter()
+        .with_min_len(par_enabled())
         .all(|x| *x == T::one().unwrap() || *x == T::zero().unwrap())
     {
         return Err(TensorError::WrongMethod);
@@ -214,6 +217,7 @@ pub fn and<
     // assert is boolean
     if !b
         .par_iter()
+        .with_min_len(par_enabled())
         .all(|x| *x == T::one().unwrap() || *x == T::zero().unwrap())
     {
         return Err(TensorError::WrongMethod);
@@ -222,6 +226,7 @@ pub fn and<
     // assert is boolean
     if !a
         .par_iter()
+        .with_min_len(par_enabled())
         .all(|x| *x == T::one().unwrap() || *x == T::zero().unwrap())
     {
         return Err(TensorError::WrongMethod);
@@ -267,6 +272,7 @@ pub fn and2<
     let result: Vec<T> = tensor1
         .par_iter()
         .zip(tensor2.par_iter())
+        .with_min_len(par_enabled())
         .map(|(a, b)| *a & *b)
         .collect();
 
@@ -877,6 +883,7 @@ pub fn einsum<
 
     let output: Vec<T> = cartesian_coord
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|out_coord| {
             // Precompute partial flat index for each input from output coordinates
             let out_partials: Vec<usize> = (0..inputs.len())
@@ -1101,11 +1108,15 @@ pub fn rescale<T: TensorType + Add<Output = T> + std::marker::Send + std::marker
 ) -> Result<Tensor<T>, TensorError> {
     // calculate value of output
     let mut output: Tensor<T> = a.clone();
-    output.par_iter_mut().enumerate().for_each(|(i, a_i)| {
-        for _ in 1..mult {
-            *a_i = a_i.clone() + a[i].clone();
-        }
-    });
+    output
+        .par_iter_mut()
+        .with_min_len(par_enabled())
+        .enumerate()
+        .for_each(|(i, a_i)| {
+            for _ in 1..mult {
+                *a_i = a_i.clone() + a[i].clone();
+            }
+        });
     Ok(output)
 }
 
@@ -1683,7 +1694,15 @@ pub fn min_axes<T: TensorType + Add<Output = T> + std::cmp::Ord + Send + Sync>(
     // calculate value of output
 
     let min_fn = |a: &Tensor<T>| -> Result<Tensor<T>, TensorError> {
-        Ok(vec![a.par_iter().min().unwrap().clone()].into_iter().into())
+        Ok(vec![
+            a.par_iter()
+                .with_min_len(par_enabled())
+                .min()
+                .unwrap()
+                .clone(),
+        ]
+        .into_iter()
+        .into())
     };
 
     axes_op(a, axes, min_fn)
@@ -1744,7 +1763,15 @@ pub fn max_axes<T: TensorType + Add<Output = T> + std::cmp::Ord + Send + Sync>(
     // calculate value of output
 
     let max_fn = |a: &Tensor<T>| -> Result<Tensor<T>, TensorError> {
-        Ok(vec![a.par_iter().max().unwrap().clone()].into_iter().into())
+        Ok(vec![
+            a.par_iter()
+                .with_min_len(par_enabled())
+                .max()
+                .unwrap()
+                .clone(),
+        ]
+        .into_iter()
+        .into())
     };
 
     axes_op(a, axes, max_fn)
@@ -2001,44 +2028,48 @@ pub fn conv<
     .multi_cartesian_product()
     .collect::<Vec<_>>();
 
-    output.par_iter_mut().enumerate().for_each(|(i, o)| {
-        let cartesian_coord_per_group = &cartesian_coord[i];
-        let (batch, group, i, j, k) = (
-            cartesian_coord_per_group[0],
-            cartesian_coord_per_group[1],
-            cartesian_coord_per_group[2],
-            cartesian_coord_per_group[3],
-            cartesian_coord_per_group[4],
-        );
-        let rs = j * stride.0;
-        let cs = k * stride.1;
+    output
+        .par_iter_mut()
+        .with_min_len(par_enabled())
+        .enumerate()
+        .for_each(|(i, o)| {
+            let cartesian_coord_per_group = &cartesian_coord[i];
+            let (batch, group, i, j, k) = (
+                cartesian_coord_per_group[0],
+                cartesian_coord_per_group[1],
+                cartesian_coord_per_group[2],
+                cartesian_coord_per_group[3],
+                cartesian_coord_per_group[4],
+            );
+            let rs = j * stride.0;
+            let cs = k * stride.1;
 
-        let start_channel = group * input_channels_per_group;
-        let end_channel = start_channel + input_channels_per_group;
+            let start_channel = group * input_channels_per_group;
+            let end_channel = start_channel + input_channels_per_group;
 
-        let local_image = padded_image
-            .get_slice(&[
-                batch..batch + 1,
-                start_channel..end_channel,
-                rs..(rs + kernel_height),
-                cs..(cs + kernel_width),
-            ])
-            .unwrap();
+            let local_image = padded_image
+                .get_slice(&[
+                    batch..batch + 1,
+                    start_channel..end_channel,
+                    rs..(rs + kernel_height),
+                    cs..(cs + kernel_width),
+                ])
+                .unwrap();
 
-        let start_kernel_index = group * output_channels_per_group + i;
-        let end_kernel_index = start_kernel_index + 1;
-        #[allow(clippy::single_range_in_vec_init)]
-        let local_kernel = kernel
-            .get_slice(&[start_kernel_index..end_kernel_index])
-            .unwrap();
+            let start_kernel_index = group * output_channels_per_group + i;
+            let end_kernel_index = start_kernel_index + 1;
+            #[allow(clippy::single_range_in_vec_init)]
+            let local_kernel = kernel
+                .get_slice(&[start_kernel_index..end_kernel_index])
+                .unwrap();
 
-        let res = dot(&[local_image, local_kernel]).unwrap()[0].clone();
-        if has_bias {
-            *o = res + inputs[2][start_kernel_index].clone();
-        } else {
-            *o = res;
-        }
-    });
+            let res = dot(&[local_image, local_kernel]).unwrap()[0].clone();
+            if has_bias {
+                *o = res + inputs[2][start_kernel_index].clone();
+            } else {
+                *o = res;
+            }
+        });
 
     // remove dummy batch dimension if we added one
     if og_image_dims.len() == 3 && vert_slides == 1 {
@@ -2517,6 +2548,7 @@ pub fn max_pool2d<T: TensorType + std::marker::Sync + std::marker::Send + std::c
 
     output
         .par_iter_mut()
+        .with_min_len(par_enabled())
         .enumerate()
         .for_each(|(flat_index, o)| {
             let coord = &cartesian_coord[flat_index];
@@ -2572,6 +2604,7 @@ pub fn dot<T: TensorType + Mul<Output = T> + Add<Output = T> + Send + Sync + std
     let res: Vec<T> = a
         .par_iter()
         .zip(b.par_iter())
+        .with_min_len(par_enabled())
         .fold(
             || T::zero().unwrap(),
             |acc, (k, i)| acc + k.clone() * i.clone(),

--- a/atlas-onnx-tracer/src/tensor/ops.rs
+++ b/atlas-onnx-tracer/src/tensor/ops.rs
@@ -3,10 +3,9 @@ use super::TensorError;
 use crate::utils::parallel_utils::IndexedParallelIterator;
 use crate::{
     tensor::{Tensor, TensorType},
-    utils::parallel_utils::{IntoParallelRefIterator, IntoParallelRefMutIterator},
+    utils::parallel_utils::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
 };
 use common::parallel::par_enabled;
-use maybe_rayon::iter::ParallelIterator;
 use std::collections::{HashMap, HashSet};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use std::iter::Iterator;

--- a/atlas-onnx-tracer/src/tensor/ops.rs
+++ b/atlas-onnx-tracer/src/tensor/ops.rs
@@ -3,7 +3,9 @@ use super::TensorError;
 use crate::utils::parallel_utils::IndexedParallelIterator;
 use crate::{
     tensor::{Tensor, TensorType},
-    utils::parallel_utils::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
+    utils::parallel_utils::{
+        IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
+    },
 };
 use common::parallel::par_enabled;
 use std::collections::{HashMap, HashSet};

--- a/atlas-onnx-tracer/src/utils/parallel_utils.rs
+++ b/atlas-onnx-tracer/src/utils/parallel_utils.rs
@@ -104,8 +104,10 @@ impl<T> ParallelSliceMut<T> for [T] {
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub trait ParallelIterator: Iterator {
-    // Removed custom collect implementation to avoid conflicts
+pub trait ParallelIterator: Iterator + Sized {
+    fn with_min_len(self, _min: usize) -> Self {
+        self
+    }
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/atlas-onnx-tracer/src/utils/parser.rs
+++ b/atlas-onnx-tracer/src/utils/parser.rs
@@ -34,6 +34,8 @@
 //! Internal Computation Graph
 //! ```
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+use crate::utils::parallel_utils::IndexedParallelIterator;
 use crate::{
     model::RunArgs,
     node::{
@@ -43,6 +45,7 @@ use crate::{
     ops::Operator,
     tensor::Tensor,
 };
+use common::parallel::par_enabled;
 
 use std::{collections::BTreeMap, sync::Arc};
 use tract_onnx::{
@@ -695,7 +698,11 @@ pub fn extract_tensor_value(
     match dt {
         DatumType::F16 => {
             let vec = input.as_slice::<tract_onnx::prelude::f16>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| (*x).into()).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| (*x).into())
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::F32 => {
@@ -704,61 +711,101 @@ pub fn extract_tensor_value(
         }
         DatumType::F64 => {
             let vec = input.as_slice::<f64>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::I64 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<i64>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::I32 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<i32>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::I16 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<i16>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::I8 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<i8>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::U8 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<u8>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::U16 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<u16>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::U32 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<u32>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::U64 => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<u64>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::Bool => {
             // Generally a shape or hyperparam
             let vec = input.as_slice::<bool>()?.to_vec();
-            let cast: Vec<f32> = vec.par_iter().map(|x| *x as usize as f32).collect();
+            let cast: Vec<f32> = vec
+                .par_iter()
+                .with_min_len(par_enabled())
+                .map(|x| *x as usize as f32)
+                .collect();
             const_value = Tensor::<f32>::new(Some(&cast), &dims)?;
         }
         DatumType::TDim => {
@@ -767,6 +814,7 @@ pub fn extract_tensor_value(
 
             let cast: Result<Vec<f32>, &str> = vec
                 .par_iter()
+                .with_min_len(par_enabled())
                 .map(|x| match x.to_i64() {
                     Ok(v) => Ok(v as f32),
                     Err(_) => match x.to_i64() {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,7 @@
 use allocative::Allocative;
 
 pub mod consts;
+pub mod parallel;
 pub mod utils;
 
 // ---------------------------------------------------------------------------

--- a/common/src/parallel.rs
+++ b/common/src/parallel.rs
@@ -40,6 +40,18 @@ pub fn par_enabled() -> usize {
     }
 }
 
+/// Returns the effective minimum parallel chunk length for the given enabled case.
+///
+/// When parallel execution is enabled, this returns `enabled_min_len`. When disabled,
+/// this returns `usize::MAX`, which prevents further splitting for indexed iterators.
+pub fn par_enabled_with(enabled_min_len: usize) -> usize {
+    if PAR_ENABLED.load(Ordering::Relaxed) {
+        enabled_min_len
+    } else {
+        usize::MAX
+    }
+}
+
 /// Sets whether shared parallel execution is enabled.
 pub fn set_par_enabled(enabled: bool) {
     PAR_ENABLED.store(enabled, Ordering::Relaxed);
@@ -52,7 +64,9 @@ pub fn swap_par_enabled(enabled: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{ParallelFlagGuard, par_enabled, set_par_enabled, swap_par_enabled};
+    use super::{
+        ParallelFlagGuard, par_enabled, par_enabled_with, set_par_enabled, swap_par_enabled,
+    };
 
     #[test]
     fn parallel_flag_round_trips() {
@@ -60,9 +74,11 @@ mod tests {
 
         set_par_enabled(false);
         assert_eq!(par_enabled(), usize::MAX);
+        assert_eq!(par_enabled_with(4096), usize::MAX);
 
         assert!(!swap_par_enabled(true));
         assert_eq!(par_enabled(), 1);
+        assert_eq!(par_enabled_with(4096), 4096);
 
         set_par_enabled(original);
     }

--- a/common/src/parallel.rs
+++ b/common/src/parallel.rs
@@ -1,29 +1,22 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-static PAR_ENABLED: AtomicBool = AtomicBool::new(true);
+static PAR_DISABLE_DEPTH: AtomicUsize = AtomicUsize::new(0);
 
-/// RAII guard that restores the shared parallel execution flag on drop.
-pub struct ParallelFlagGuard {
-    previous: bool,
-}
+/// RAII guard that disables shared parallel execution for the current scope.
+pub struct ParallelFlagGuard;
 
 impl ParallelFlagGuard {
-    /// Sets the shared parallel execution flag for the current scope.
-    pub fn set(enabled: bool) -> Self {
-        Self {
-            previous: swap_par_enabled(enabled),
-        }
-    }
-
     /// Disables shared parallel execution for the current scope.
     pub fn disabled() -> Self {
-        Self::set(false)
+        PAR_DISABLE_DEPTH.fetch_add(1, Ordering::SeqCst);
+        Self
     }
 }
 
 impl Drop for ParallelFlagGuard {
     fn drop(&mut self) {
-        swap_par_enabled(self.previous);
+        let previous = PAR_DISABLE_DEPTH.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(previous > 0, "parallel disable depth underflow");
     }
 }
 
@@ -33,7 +26,7 @@ impl Drop for ParallelFlagGuard {
 /// Rayon default behavior. When disabled, this returns `usize::MAX`, which
 /// prevents further splitting for indexed iterators.
 pub fn par_enabled() -> usize {
-    if PAR_ENABLED.load(Ordering::Relaxed) {
+    if PAR_DISABLE_DEPTH.load(Ordering::SeqCst) == 0 {
         1
     } else {
         usize::MAX
@@ -45,48 +38,46 @@ pub fn par_enabled() -> usize {
 /// When parallel execution is enabled, this returns `enabled_min_len`. When disabled,
 /// this returns `usize::MAX`, which prevents further splitting for indexed iterators.
 pub fn par_enabled_with(enabled_min_len: usize) -> usize {
-    if PAR_ENABLED.load(Ordering::Relaxed) {
+    if PAR_DISABLE_DEPTH.load(Ordering::SeqCst) == 0 {
         enabled_min_len
     } else {
         usize::MAX
     }
 }
 
-/// Sets whether shared parallel execution is enabled.
-pub fn set_par_enabled(enabled: bool) {
-    PAR_ENABLED.store(enabled, Ordering::Relaxed);
-}
-
-/// Swaps the shared parallel execution flag and returns the previous value.
-pub fn swap_par_enabled(enabled: bool) -> bool {
-    PAR_ENABLED.swap(enabled, Ordering::Relaxed)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        ParallelFlagGuard, par_enabled, par_enabled_with, set_par_enabled, swap_par_enabled,
-    };
+    use super::{PAR_DISABLE_DEPTH, ParallelFlagGuard, par_enabled, par_enabled_with};
+    use std::sync::atomic::Ordering;
+    use std::sync::{Mutex, MutexGuard};
+
+    static PARALLEL_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn test_lock() -> MutexGuard<'static, ()> {
+        PARALLEL_TEST_MUTEX.lock().unwrap()
+    }
+
+    fn reset_depth() {
+        PAR_DISABLE_DEPTH.store(0, Ordering::SeqCst);
+    }
 
     #[test]
-    fn parallel_flag_round_trips() {
-        let original = swap_par_enabled(true);
+    fn parallel_flag_guard_disables_and_restores() {
+        let _lock = test_lock();
+        reset_depth();
 
-        set_par_enabled(false);
-        assert_eq!(par_enabled(), usize::MAX);
-        assert_eq!(par_enabled_with(4096), usize::MAX);
-
-        assert!(!swap_par_enabled(true));
         assert_eq!(par_enabled(), 1);
         assert_eq!(par_enabled_with(4096), 4096);
 
-        set_par_enabled(original);
+        let _guard = ParallelFlagGuard::disabled();
+        assert_eq!(par_enabled(), usize::MAX);
+        assert_eq!(par_enabled_with(4096), usize::MAX);
     }
 
     #[test]
     fn parallel_flag_guard_restores_previous_value() {
-        let original = swap_par_enabled(true);
-        set_par_enabled(true);
+        let _lock = test_lock();
+        reset_depth();
 
         {
             let _guard = ParallelFlagGuard::disabled();
@@ -94,6 +85,24 @@ mod tests {
         }
 
         assert_eq!(par_enabled(), 1);
-        set_par_enabled(original);
+        assert_eq!(par_enabled_with(4096), 4096);
+    }
+
+    #[test]
+    fn parallel_flag_guard_is_reference_counted() {
+        let _lock = test_lock();
+        reset_depth();
+
+        let outer = ParallelFlagGuard::disabled();
+        assert_eq!(par_enabled(), usize::MAX);
+
+        {
+            let _inner = ParallelFlagGuard::disabled();
+            assert_eq!(par_enabled(), usize::MAX);
+        }
+
+        assert_eq!(par_enabled(), usize::MAX);
+        drop(outer);
+        assert_eq!(par_enabled(), 1);
     }
 }

--- a/common/src/parallel.rs
+++ b/common/src/parallel.rs
@@ -1,0 +1,83 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static PAR_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// RAII guard that restores the shared parallel execution flag on drop.
+pub struct ParallelFlagGuard {
+    previous: bool,
+}
+
+impl ParallelFlagGuard {
+    /// Sets the shared parallel execution flag for the current scope.
+    pub fn set(enabled: bool) -> Self {
+        Self {
+            previous: swap_par_enabled(enabled),
+        }
+    }
+
+    /// Disables shared parallel execution for the current scope.
+    pub fn disabled() -> Self {
+        Self::set(false)
+    }
+}
+
+impl Drop for ParallelFlagGuard {
+    fn drop(&mut self) {
+        swap_par_enabled(self.previous);
+    }
+}
+
+/// Returns the shared minimum parallel chunk length.
+///
+/// When parallel execution is enabled, this returns `1`, which is effectively
+/// Rayon default behavior. When disabled, this returns `usize::MAX`, which
+/// prevents further splitting for indexed iterators.
+pub fn par_enabled() -> usize {
+    if PAR_ENABLED.load(Ordering::Relaxed) {
+        1
+    } else {
+        usize::MAX
+    }
+}
+
+/// Sets whether shared parallel execution is enabled.
+pub fn set_par_enabled(enabled: bool) {
+    PAR_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Swaps the shared parallel execution flag and returns the previous value.
+pub fn swap_par_enabled(enabled: bool) -> bool {
+    PAR_ENABLED.swap(enabled, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ParallelFlagGuard, par_enabled, set_par_enabled, swap_par_enabled};
+
+    #[test]
+    fn parallel_flag_round_trips() {
+        let original = swap_par_enabled(true);
+
+        set_par_enabled(false);
+        assert_eq!(par_enabled(), usize::MAX);
+
+        assert!(!swap_par_enabled(true));
+        assert_eq!(par_enabled(), 1);
+
+        set_par_enabled(original);
+    }
+
+    #[test]
+    fn parallel_flag_guard_restores_previous_value() {
+        let original = swap_par_enabled(true);
+        set_par_enabled(true);
+
+        {
+            let _guard = ParallelFlagGuard::disabled();
+            assert_eq!(par_enabled(), usize::MAX);
+        }
+
+        assert_eq!(par_enabled(), 1);
+        set_par_enabled(original);
+    }
+}

--- a/jolt-atlas-core/examples/qwen.rs
+++ b/jolt-atlas-core/examples/qwen.rs
@@ -6,8 +6,14 @@
 /// # Terminal output with timing
 /// cargo run --release --package jolt-atlas-core --example qwen -- --trace-terminal
 ///
+/// # Override sequence length (default: 16)
+/// cargo run --release --package jolt-atlas-core --example qwen -- --seq-len 32
+///
 /// # Reuse cached shared preprocessing (builds and saves it on first use)
 /// cargo run --release --package jolt-atlas-core --example qwen -- --use-cache
+///
+/// # Disable pre-rebase nonlinear decomposition
+/// cargo run --release --package jolt-atlas-core --example qwen -- --no-pre-rebase-nonlinear
 /// ```
 ///
 /// Requires the Qwen ONNX model to be present first.
@@ -26,6 +32,19 @@ use std::{env, fs, path::Path};
 
 const MODEL_PATH: &str = "atlas-onnx-tracer/models/qwen/network.onnx";
 const SHARED_PP_CACHE_PATH: &str = "atlas-onnx-tracer/models/qwen/shared_preprocessing.bin";
+
+fn parse_seq_len_arg(args: &[String]) -> usize {
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if arg == "--seq-len" {
+            let value = args.next().expect("--seq-len requires a value");
+            return value
+                .parse::<usize>()
+                .expect("--seq-len must be a positive integer");
+        }
+    }
+    16
+}
 
 fn load_or_build_shared_preprocessing(
     run_args: &RunArgs,
@@ -57,15 +76,17 @@ fn load_or_build_shared_preprocessing(
 
 fn main() {
     let (_guard, _tracing_enabled) = setup_tracing("Qwen ONNX Proof");
-    let use_cache = env::args().any(|arg| arg == "--use-cache");
+    let args: Vec<String> = env::args().collect();
+    let use_cache = args.iter().any(|arg| arg == "--use-cache");
+    let pre_rebase_nonlinear = !args.iter().any(|arg| arg == "--no-pre-rebase-nonlinear");
+    let seq_len = parse_seq_len_arg(&args);
 
-    let seq_len: usize = 16;
     let run_args = RunArgs::new([
         ("batch_size", 1),
         ("sequence_length", seq_len),
         ("past_sequence_length", 0),
     ])
-    .with_pre_rebase_nonlinear(true);
+    .with_pre_rebase_nonlinear(pre_rebase_nonlinear);
 
     let mut rng = StdRng::seed_from_u64(44);
     let vocab_size: i32 = 151936;

--- a/jolt-atlas-core/src/onnx_proof/neural_teleport/utils.rs
+++ b/jolt-atlas-core/src/onnx_proof/neural_teleport/utils.rs
@@ -4,6 +4,7 @@
 
 use super::{n_bits_to_usize, usize_to_n_bits, SCALE};
 use atlas_onnx_tracer::tensor::Tensor;
+use common::parallel::par_enabled;
 use joltworks::{
     field::{FieldChallengeOps, JoltField},
     poly::eq_poly::EqPolynomial,
@@ -28,6 +29,7 @@ where
 {
     let indexes_usize = indexes
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|&x| x as usize)
         .collect::<Vec<usize>>();
     compute_ra_evals_from_usize_indices(r, &indexes_usize, table_size)
@@ -49,6 +51,7 @@ where
     let table_size = 1 << log_table_size;
     let input_usize = input
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|&x| n_bits_to_usize(x, log_table_size))
         .collect::<Vec<usize>>();
 
@@ -152,6 +155,7 @@ where
     for partial in partial_results {
         ra.par_iter_mut()
             .zip(partial.par_iter())
+            .with_min_len(par_enabled())
             .for_each(|(dest, &src)| *dest += src);
     }
     ra

--- a/jolt-atlas-core/src/onnx_proof/ops/concat.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/concat.rs
@@ -7,6 +7,7 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::{Concat, Operator},
 };
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use joltworks::{
     field::{IntoOpening, JoltField},
@@ -241,6 +242,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ConcatSumchec
             .unwrap_or(0);
         let uni_poly_evals: [F; 2] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let mut evals = [F::zero(); 2];
                 for term in &self.input_terms {

--- a/jolt-atlas-core/src/onnx_proof/ops/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cos.rs
@@ -22,6 +22,7 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Cos,
 };
+use common::parallel::par_enabled;
 use common::{consts::XLEN, CommittedPolynomial, VirtualPolynomial};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
@@ -47,7 +48,9 @@ use joltworks::{
     transcripts::Transcript,
     utils::errors::ProofVerifyError,
 };
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
     fn reduction_flow(&self) -> ReductionFlow {
@@ -230,6 +233,7 @@ fn prove_range_and_onehot<F: JoltField, T: Transcript>(
     let (_, remainder) = compute_division(input, FOUR_PI_APPROX);
     let cos_lookup_indices = remainder
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|&x| x as usize)
         .collect::<Vec<usize>>();
 
@@ -510,6 +514,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for CosProver<F> 
 
         let univariate_poly_evals: [F; 2] = (0..input_onehot.len() / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let ra_evals =
                     input_onehot.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::array;
 
 use atlas_onnx_tracer::{
@@ -155,6 +156,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BmkBknMbnProv
         let half_poly_len = right_operand.len() / 2;
         let uni_poly_evals: [F; DEGREE_BOUND] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|jh| {
                 let left_evals =
                     left_operand.sumcheck_evals_array::<DEGREE_BOUND>(jh, BindingOrder::HighToLow);

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::array;
 
 use atlas_onnx_tracer::{
@@ -154,6 +155,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BmkKbnMbnProv
         let half_poly_len = right_operand.len() / 2;
         let uni_poly_evals: [F; DEGREE_BOUND] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|jh| {
                 let left_evals =
                     left_operand.sumcheck_evals_array::<DEGREE_BOUND>(jh, BindingOrder::HighToLow);

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
@@ -2,6 +2,7 @@ use atlas_onnx_tracer::{
     model::trace::{LayerData, Trace},
     node::ComputationNode,
 };
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use joltworks::{
     field::{IntoOpening, JoltField},
@@ -100,6 +101,7 @@ impl<F: JoltField> KNkNProver<F> {
         let eq_r_node_output = EqPolynomial::evals(&params.r_node_output.r);
         let right_operand: Vec<F> = (0..k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|j| {
                 (0..n)
                     .map(|h| F::from_i32(right_operand[h * k + j]) * eq_r_node_output[h])
@@ -130,6 +132,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for KNkNProver<F>
         let half_poly_len = left_operand.len() / 2;
         let uni_poly_evals: [F; 2] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let l_evals = left_operand.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::HighToLow);
                 let r_evals =

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::array;
 
 use atlas_onnx_tracer::{
@@ -155,6 +156,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for MbkBnkBmnProv
         let half_poly_len = right_operand.len() / 2;
         let uni_poly_evals: [F; DEGREE_BOUND] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hj| {
                 let l_evals =
                     left_operand.sumcheck_evals_array::<DEGREE_BOUND>(hj, BindingOrder::HighToLow);

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::array;
 
 use atlas_onnx_tracer::{
@@ -158,6 +159,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for MbkNbkBmnProv
         let half_poly_len = right_operand.len() / 2;
         let uni_poly_evals: [F; DEGREE_BOUND] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hj| {
                 let l_evals =
                     left_operand.sumcheck_evals_array::<DEGREE_BOUND>(hj, BindingOrder::HighToLow);

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::array;
 
 use atlas_onnx_tracer::{
@@ -106,6 +107,7 @@ impl<F: JoltField> MkKnMnProver<F> {
         let (eq_r_m, eq_r_n) = (EqPolynomial::evals(&r_m.r), EqPolynomial::evals(&r_n.r));
         let left_operand: Vec<F> = (0..k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|j| {
                 (0..m)
                     .map(|i| F::from_i32(left_operand[i * k + j]) * eq_r_m[i])
@@ -114,6 +116,7 @@ impl<F: JoltField> MkKnMnProver<F> {
             .collect();
         let right_operand: Vec<F> = (0..k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|j| {
                 (0..n)
                     .map(|h| F::from_i32(right_operand[j * n + h]) * eq_r_n[h])
@@ -144,6 +147,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for MkKnMnProver<
         let half_poly_len = left_operand.len() / 2;
         let uni_poly_evals: [F; 2] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let l_evals = left_operand.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::HighToLow);
                 let r_evals =

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/rbmk_rbnk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/rbmk_rbnk_bmn.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::array;
 
 use atlas_onnx_tracer::{
@@ -247,6 +248,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
         let batch = a * b;
         let left: Vec<F> = (0..batch * k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hj| {
                 let h = hj / k;
                 let j = hj % k;
@@ -260,6 +262,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
             .collect();
         let right: Vec<F> = (0..batch * k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hj| {
                 let h = hj / k;
                 let j = hj % k;
@@ -303,6 +306,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
         let cb = c * b;
         let left: Vec<F> = (0..cb * a * k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hak| {
                 let h = hak / (a * k);
                 let rem = hak % (a * k);
@@ -320,6 +324,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
             .collect();
         let right_base: Vec<F> = (0..c * k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|ck| {
                 let c_idx = ck / k;
                 let k_idx = ck % k;
@@ -333,6 +338,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
             .collect();
         let right: Vec<F> = (0..cb * a * k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hak| {
                 let h = hak / (a * k);
                 let rem = hak % (a * k);
@@ -367,6 +373,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
 
         let left: Vec<F> = (0..cb * k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hk| {
                 let h = hk / k;
                 let k_idx = hk % k;
@@ -380,6 +387,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
             .collect();
         let right: Vec<F> = (0..cb * k)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|hk| {
                 let h = hk / k;
                 let k_idx = hk % k;
@@ -524,6 +532,7 @@ impl<F: JoltField> RbmkRbnkBmnProver<F> {
         let half_poly_len = self.left_operand.len() / 2;
         let uni_poly_evals: [F; DEGREE_BOUND_EQ] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|idx| {
                 let l_evals = self
                     .left_operand
@@ -576,6 +585,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for RbmkRbnkBmnPr
                 let half_poly_len = self.left_operand.len() / 2;
                 let uni_poly_evals: [F; DEGREE_BOUND_DOT] = (0..half_poly_len)
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|idx| {
                         let l_evals = self.left_operand.sumcheck_evals(
                             idx,

--- a/jolt-atlas-core/src/onnx_proof/ops/erf.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/erf.rs
@@ -21,6 +21,7 @@ use atlas_onnx_tracer::{
     node::{handlers::activation::NEURAL_TELEPORT_LOG_TABLE_SIZE, ComputationNode},
     ops::Erf,
 };
+use common::parallel::par_enabled;
 use common::{consts::XLEN, CommittedPolynomial, VirtualPolynomial};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
@@ -47,7 +48,9 @@ use joltworks::{
     transcripts::Transcript,
     utils::errors::ProofVerifyError,
 };
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Erf {
     fn prove(
@@ -95,6 +98,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Erf {
         let (quotient, _remainder) = compute_division(input, self.tau);
         let lookup_indices = quotient
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&x| n_bits_to_usize(x, self.log_table))
             .collect::<Vec<usize>>();
 
@@ -426,6 +430,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ErfProver<F> 
 
         let univariate_poly_evals: [F; 2] = (0..input_onehot.len() / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let ra_evals =
                     input_onehot.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);

--- a/jolt-atlas-core/src/onnx_proof/ops/gather/large.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/gather/large.rs
@@ -1,5 +1,6 @@
 use super::*;
 use atlas_onnx_tracer::ops::GatherLarge;
+use common::parallel::par_enabled;
 use common::CommittedPolynomial;
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
@@ -170,6 +171,7 @@ pub(crate) fn gather_lookup_indices(
         .padded_next_power_of_two()
         .data()
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|&x| x as usize)
         .collect()
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/gather/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/gather/mod.rs
@@ -8,6 +8,7 @@ use atlas_onnx_tracer::{
     ops::Operator,
     tensor::Tensor,
 };
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use joltworks::{
     field::{IntoOpening, JoltField},
@@ -207,6 +208,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for GatherProver<
 
         let univariate_poly_evals: [F; 2] = (0..index_onehot.len() / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let ra_evals =
                     index_onehot.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
@@ -370,6 +372,7 @@ where
 
     let indexes_usize = indexes
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|&x| x as usize)
         .collect::<Vec<usize>>();
 
@@ -390,6 +393,7 @@ where
     for partial in partial_results {
         ra.par_iter_mut()
             .zip(partial.par_iter())
+            .with_min_len(par_enabled())
             .for_each(|(dest, &src)| *dest += src);
     }
     ra

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -17,6 +17,7 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Reshape,
 };
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use joltworks::{
     field::{ChallengeFieldOps, IntoOpening, JoltField},
@@ -244,6 +245,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReshapeSumche
         let half_poly_len = input_mle.len() / 2;
         let uni_poly_evals: [F; 2] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let a_evals = input_mle.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);
                 let selector_evals =

--- a/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
@@ -22,6 +22,7 @@ use atlas_onnx_tracer::{
     node::{handlers::activation::NEURAL_TELEPORT_LOG_TABLE_SIZE, ComputationNode},
     ops::Sigmoid,
 };
+use common::parallel::par_enabled;
 use common::{consts::XLEN, CommittedPolynomial, VirtualPolynomial};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
@@ -47,7 +48,9 @@ use joltworks::{
     transcripts::Transcript,
     utils::errors::ProofVerifyError,
 };
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sigmoid {
     fn prove(
@@ -95,6 +98,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sigmoid {
         let (quotient, _remainder) = compute_division(input, self.tau);
         let lookup_indices = quotient
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&x| n_bits_to_usize(x, self.log_table))
             .collect::<Vec<usize>>();
 
@@ -426,6 +430,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for SigmoidProver
 
         let univariate_poly_evals: [F; 2] = (0..input_onehot.len() / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let ra_evals =
                     input_onehot.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);

--- a/jolt-atlas-core/src/onnx_proof/ops/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sin.rs
@@ -22,6 +22,7 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Sin,
 };
+use common::parallel::par_enabled;
 use common::{consts::XLEN, CommittedPolynomial, VirtualPolynomial};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
@@ -47,7 +48,9 @@ use joltworks::{
     transcripts::Transcript,
     utils::errors::ProofVerifyError,
 };
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
     fn reduction_flow(&self) -> ReductionFlow {
@@ -231,6 +234,7 @@ fn prove_post_reduction_checks<F: JoltField, T: Transcript>(
     let (_, remainder) = compute_division(input, FOUR_PI_APPROX);
     let sin_lookup_indices = remainder
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|&x| x as usize)
         .collect::<Vec<usize>>();
 
@@ -511,6 +515,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for SinProver<F> 
 
         let univariate_poly_evals: [F; 2] = (0..input_onehot.len() / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let ra_evals =
                     input_onehot.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);

--- a/jolt-atlas-core/src/onnx_proof/ops/slice.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/slice.rs
@@ -7,6 +7,7 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::{Operator, Slice},
 };
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use joltworks::{
     field::{IntoOpening, JoltField},
@@ -204,6 +205,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for SliceSumcheck
         let half_poly_len = self.input_mle.len() / 2;
         let uni_poly_evals: [F; 2] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let input_evals =
                     self.input_mle

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/exp_sum.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/exp_sum.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use joltworks::{
     field::{IntoOpening, JoltField},
@@ -115,6 +116,7 @@ impl<F: JoltField> ExpSumProver<F> {
         let half_poly_len = exp_q.len() / 2;
         let eval_0 = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|kj| {
                 let k = kj >> (self.params.log_N() - m);
                 exp_q.get_bound_coeff(2 * kj) * eq_r0_k[k]

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/max.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/max.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::array;
 
 use common::VirtualPolynomial;
@@ -145,6 +146,7 @@ impl<F: JoltField> MaxIndicatorProver<F> {
         let half_poly_len = X.len() / 2;
         let evals: [F; DEGREE_BOUND] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|kj| {
                 let k = kj >> (self.params.log_N() - m);
                 let eq_val = eq[k];

--- a/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
@@ -2,6 +2,7 @@ use atlas_onnx_tracer::{
     model::trace::{LayerData, Trace},
     node::ComputationNode,
 };
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use joltworks::{
     field::{IntoOpening, JoltField},
@@ -106,6 +107,7 @@ impl<F: JoltField> SumAxisProver<F> {
                 let eq_r_node_output = EqPolynomial::evals(&params.r_node_output.r);
                 (0..m)
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|h| {
                         (0..n)
                             .map(|j| F::from_i32(operand[h * n + j]) * eq_r_node_output[j])
@@ -118,6 +120,7 @@ impl<F: JoltField> SumAxisProver<F> {
                 let eq_r_node_output = EqPolynomial::evals(&params.r_node_output.r);
                 (0..n)
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|j| {
                         (0..m)
                             .map(|h| F::from_i32(operand[h * n + j]) * eq_r_node_output[h])
@@ -132,6 +135,7 @@ impl<F: JoltField> SumAxisProver<F> {
         {
             let claim = (0..operand.len())
                 .into_par_iter()
+                .with_min_len(par_enabled())
                 .map(|i| operand.get_bound_coeff(i))
                 .sum::<F>();
             assert_eq!(claim, params.input_claim(_accumulator));
@@ -149,6 +153,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for SumAxisProver
         let half_poly_len = self.operand.len() / 2;
         let eval_0 = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| self.operand.get_bound_coeff(i))
             .sum();
         UniPoly::from_evals_and_hint(previous_claim, &[eval_0])

--- a/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
@@ -22,6 +22,7 @@ use atlas_onnx_tracer::{
     node::{handlers::activation::NEURAL_TELEPORT_LOG_TABLE_SIZE, ComputationNode},
     ops::{Operator, Tanh},
 };
+use common::parallel::par_enabled;
 use common::{consts::XLEN, CommittedPolynomial, VirtualPolynomial};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
@@ -47,7 +48,9 @@ use joltworks::{
     transcripts::Transcript,
     utils::errors::ProofVerifyError,
 };
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Tanh {
     #[tracing::instrument(skip_all, name = "Tanh::prove")]
@@ -105,6 +108,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Tanh {
         let (quotient, _remainder) = compute_division(input, tanh_op.tau);
         let lookup_indices = quotient
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&x| n_bits_to_usize(x, tanh_op.log_table))
             .collect::<Vec<usize>>();
 
@@ -456,6 +460,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for TanhProver<F>
 
         let univariate_poly_evals: [F; 2] = (0..input_onehot.len() / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let ra_evals =
                     input_onehot.sumcheck_evals(i, DEGREE_BOUND, BindingOrder::LowToHigh);

--- a/jolt-atlas-core/src/onnx_proof/prover.rs
+++ b/jolt-atlas-core/src/onnx_proof/prover.rs
@@ -19,7 +19,7 @@ use atlas_onnx_tracer::{
     },
     node::ComputationNode,
 };
-use common::{CommittedPolynomial, VirtualPolynomial};
+use common::{CommittedPolynomial, VirtualPolynomial, parallel::ParallelFlagGuard};
 use joltworks::{
     field::JoltField,
     poly::{
@@ -32,6 +32,7 @@ use joltworks::{
     transcripts::Transcript,
     utils::math::Math,
 };
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::collections::BTreeMap;
 
 // ---------------------------------------------------------------------------
@@ -208,10 +209,15 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
         model: &Model,
         trace: &Trace,
     ) -> BTreeMap<CommittedPolynomial, MultilinearPolynomial<F>> {
+        // Rayon jobs were overly fragmented, and the resulting context switching degraded performance,
+        // so the parallelism granularity is now limited to the polynomial level.
+        let _guard = ParallelFlagGuard::disabled();
         model
             .graph
             .nodes
             .values()
+            .collect::<Vec<_>>()
+            .par_iter()
             .flat_map(|node| NodeCommittedPolynomials::get_committed_polynomials::<F, T>(node))
             .map(|committed_poly| {
                 let witness = committed_poly.generate_witness(model, trace);
@@ -225,8 +231,13 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
         poly_map: &BTreeMap<CommittedPolynomial, MultilinearPolynomial<F>>,
         pcs: &PCS::ProverSetup,
     ) -> Vec<PCS::Commitment> {
+        // Rayon jobs were overly fragmented, and the resulting context switching degraded performance,
+        // so the parallelism granularity is now limited to the polynomial level.
+        let _guard = ParallelFlagGuard::disabled();
         poly_map
             .values()
+            .collect::<Vec<_>>()
+            .par_iter()
             .map(|poly| PCS::commit(poly, pcs).0)
             .collect()
     }

--- a/jolt-atlas-core/src/onnx_proof/prover.rs
+++ b/jolt-atlas-core/src/onnx_proof/prover.rs
@@ -19,7 +19,7 @@ use atlas_onnx_tracer::{
     },
     node::ComputationNode,
 };
-use common::{CommittedPolynomial, VirtualPolynomial, parallel::ParallelFlagGuard};
+use common::{parallel::ParallelFlagGuard, CommittedPolynomial, VirtualPolynomial};
 use joltworks::{
     field::JoltField,
     poly::{

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -36,6 +36,7 @@ use atlas_onnx_tracer::{
     },
     tensor::Tensor,
 };
+use common::parallel::par_enabled;
 use common::CommittedPolynomial;
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
@@ -75,6 +76,7 @@ fn build_one_hot_rad_witness<F: JoltField>(
     let one_hot_params = OneHotParams::new(lookup_indices.len().log_2());
     let addresses: Vec<_> = lookup_indices
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|lookup_index| Some(one_hot_params.lookup_index_chunk(lookup_index.into(), d) as u16))
         .collect();
     MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
@@ -97,6 +99,7 @@ fn build_teleport_activation_rad_witness<F: JoltField>(
     let (quotient, _remainder) = compute_division(input, tau);
     let lookup_indices: Vec<usize> = quotient
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|&x| n_bits_to_usize(x, log_table))
         .collect();
     let one_hot_params = OneHotParams::from_config_and_log_K(&OneHotConfig::default(), log_table);
@@ -105,6 +108,7 @@ fn build_teleport_activation_rad_witness<F: JoltField>(
     MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
         h_indices[d]
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&h| h.map(|h| h as u16))
             .collect(),
         one_hot_params.k_chunk,
@@ -261,6 +265,7 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 let non_zero_addresses: Vec<_> = indexes
                     .data()
                     .par_iter()
+                    .with_min_len(par_enabled())
                     .map(|&index| Some(index as u16))
                     .collect();
                 let input_dict = &model.graph.nodes.get(&computation_node.inputs[0]).unwrap();
@@ -277,8 +282,12 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 };
                 let layer_data = Trace::layer_data(trace, computation_node);
                 let indexes = layer_data.operands[1].padded_next_power_of_two();
-                let lookup_indices: Vec<usize> =
-                    indexes.data().par_iter().map(|&x| x as usize).collect();
+                let lookup_indices: Vec<usize> = indexes
+                    .data()
+                    .par_iter()
+                    .with_min_len(par_enabled())
+                    .map(|&x| x as usize)
+                    .collect();
                 let num_words = gather_op.dict_len.next_power_of_two();
                 let one_hot_params = OneHotParams::from_config_and_log_K(
                     &OneHotConfig::default(),
@@ -291,6 +300,7 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
                     h_indices[*d_idx]
                         .par_iter()
+                        .with_min_len(par_enabled())
                         .map(|&h| h.map(|h| h as u16))
                         .collect(),
                     one_hot_params.k_chunk,
@@ -344,8 +354,11 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 let input = &layer_data.operands[0];
 
                 let (_quotient, remainder) = compute_division(input, FOUR_PI_APPROX);
-                let lookup_indices: Vec<usize> =
-                    remainder.par_iter().map(|&x| x as usize).collect();
+                let lookup_indices: Vec<usize> = remainder
+                    .par_iter()
+                    .with_min_len(par_enabled())
+                    .map(|&x| x as usize)
+                    .collect();
                 let one_hot_params = OneHotParams::from_config_and_log_K(
                     &OneHotConfig::default(),
                     COS_LOG_TABLE_SIZE,
@@ -357,6 +370,7 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPolynomial {
                 MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
                     h_indices[*d_idx]
                         .par_iter()
+                        .with_min_len(par_enabled())
                         .map(|&h| h.map(|h| h as u16))
                         .collect(),
                     one_hot_params.k_chunk,
@@ -450,6 +464,7 @@ fn build_onehot_witness<F: JoltField>(
     MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(
         h_indices[d]
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&h| h.map(|h| h as u16))
             .collect(),
         one_hot_params.k_chunk,

--- a/jolt-atlas-core/src/utils/mod.rs
+++ b/jolt-atlas-core/src/utils/mod.rs
@@ -2,6 +2,7 @@
 
 use atlas_onnx_tracer::tensor::Tensor;
 use common::consts::XLEN;
+use common::parallel::par_enabled;
 use joltworks::utils::{interleave_bits, lookup_bits::LookupBits};
 use rayon::prelude::*;
 
@@ -80,6 +81,7 @@ pub fn compute_lookup_indices_from_operands(
             .data()
             .par_iter()
             .zip(right_operand.data().par_iter())
+            .with_min_len(par_enabled())
             .map(|(&left_val, &right_val)| {
                 // Cast to u64 for interleaving
                 let left_bits = left_val as u32;
@@ -109,6 +111,7 @@ pub fn compute_lookup_indices_from_operands(
         operand
             .data()
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&value| {
                 // Cast to u64 for consistent bit representation
                 let index = value as u32 as u64;

--- a/joltworks/src/field/ark.rs
+++ b/joltworks/src/field/ark.rs
@@ -6,6 +6,7 @@ use crate::{
     utils::thread::unsafe_allocate_zero_vec,
 };
 use ark_ff::{prelude::*, BigInt, PrimeField, UniformRand};
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 
 impl FieldOps for ark_bn254::Fr {}
@@ -51,9 +52,10 @@ impl JoltField for ark_bn254::Fr {
         for i in 0..2 {
             let bitshift = 16 * i;
             let unit = <Self as JoltField>::from_u64(1 << bitshift);
-            lookup_tables[i] = (0..(1 << 16))
+            lookup_tables[i] = (0usize..(1 << 16))
                 .into_par_iter()
-                .map(|j| unit * <Self as JoltField>::from_u64(j))
+                .with_min_len(par_enabled())
+                .map(|j| unit * <Self as JoltField>::from_u64(j as u64))
                 .collect();
         }
 

--- a/joltworks/src/lookup_tables/prefixes/mod.rs
+++ b/joltworks/src/lookup_tables/prefixes/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     lookup_tables::prefixes::{msb::MsbPrefix, nlw::NotLowerWordPrefix},
     utils::lookup_bits::LookupBits,
 };
+use common::parallel::par_enabled;
 use num::FromPrimitive;
 use num_derive::FromPrimitive;
 use rayon::prelude::*;
@@ -225,6 +226,7 @@ impl Prefixes {
         let previous_checkpoints = checkpoints.to_vec();
         checkpoints
             .par_iter_mut()
+            .with_min_len(par_enabled())
             .enumerate()
             .for_each(|(index, new_checkpoint)| {
                 let prefix: Self = FromPrimitive::from_u8(index as u8).unwrap();

--- a/joltworks/src/msm/mod.rs
+++ b/joltworks/src/msm/mod.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::borrow::Borrow;
 
 use crate::{
@@ -38,10 +39,22 @@ where
             MultilinearPolynomial::U8Scalars(poly) => (bases.len() == poly.coeffs.len())
                 .then(|| {
                     let scalars = &poly.coeffs;
-                    if scalars.par_iter().all(|&s| s == 0) {
+                    if scalars
+                        .par_iter()
+                        .with_min_len(par_enabled())
+                        .all(|&s| s == 0)
+                    {
                         Self::zero()
-                    } else if scalars.par_iter().all(|&s| s <= 1) {
-                        let bool_scalars: Vec<bool> = scalars.par_iter().map(|&s| s == 1).collect();
+                    } else if scalars
+                        .par_iter()
+                        .with_min_len(par_enabled())
+                        .all(|&s| s <= 1)
+                    {
+                        let bool_scalars: Vec<bool> = scalars
+                            .par_iter()
+                            .with_min_len(par_enabled())
+                            .map(|&s| s == 1)
+                            .collect();
                         msm_binary::<Self>(bases, &bool_scalars, false)
                     } else {
                         msm_u8::<Self>(bases, scalars, false)
@@ -89,6 +102,7 @@ where
                 ) = bases
                     .par_iter()
                     .zip(scalars.par_iter())
+                    .with_min_len(par_enabled())
                     .fold(
                         || (vec![], vec![], vec![], vec![]),
                         |(mut pos_s, mut pos_b, mut neg_s, mut neg_b), (base, &scalar)| {
@@ -134,6 +148,7 @@ where
                 ) = bases
                     .par_iter()
                     .zip(scalars.par_iter())
+                    .with_min_len(par_enabled())
                     .fold(
                         || (vec![], vec![], vec![], vec![]),
                         |(mut pos_s, mut pos_b, mut neg_s, mut neg_b), (base, &scalar)| {
@@ -178,8 +193,16 @@ where
     fn msm_u8(bases: &[Self::MulBase], scalars: &[u8]) -> Result<Self, ProofVerifyError> {
         (bases.len() == scalars.len())
             .then(|| {
-                if scalars.par_iter().all(|&s| s <= 1) {
-                    let bool_scalars: Vec<bool> = scalars.par_iter().map(|&s| s == 1).collect();
+                if scalars
+                    .par_iter()
+                    .with_min_len(par_enabled())
+                    .all(|&s| s <= 1)
+                {
+                    let bool_scalars: Vec<bool> = scalars
+                        .par_iter()
+                        .with_min_len(par_enabled())
+                        .map(|&s| s == 1)
+                        .collect();
                     msm_binary::<Self>(bases, &bool_scalars, true)
                 } else {
                     msm_u8::<Self>(bases, scalars, true)
@@ -226,6 +249,7 @@ where
             bases
                 .par_iter()
                 .zip(scalars.par_iter())
+                .with_min_len(par_enabled())
                 .fold(
                     || (vec![], vec![], vec![], vec![]),
                     |(mut pos_s, mut pos_b, mut neg_s, mut neg_b), (base, &scalar)| {
@@ -288,6 +312,7 @@ where
     {
         polys
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|poly| VariableBaseMSM::msm(&bases[..poly.borrow().len()], poly).unwrap())
             .collect()
     }
@@ -298,6 +323,7 @@ where
     ) -> Vec<Self> {
         polys
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|poly| {
                 VariableBaseMSM::msm_field_elements(&bases[..poly.coeffs.len()], &poly.coeffs)
                     .unwrap()

--- a/joltworks/src/poly/commitment/hyperkzg/commitment_scheme.rs
+++ b/joltworks/src/poly/commitment/hyperkzg/commitment_scheme.rs
@@ -14,6 +14,7 @@ use crate::{
     utils::errors::ProofVerifyError,
 };
 use ark_ec::CurveGroup;
+use common::parallel::par_enabled;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
@@ -82,6 +83,7 @@ impl CommitmentScheme for HyperKZG<ark_bn254::Bn254> {
         UnivariateKZG::commit_batch(&gens.kzg_pk, polys)
             .unwrap()
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|c| (HyperKZGCommitment(c), ()))
             .collect()
     }

--- a/joltworks/src/poly/commitment/hyperkzg/kzg.rs
+++ b/joltworks/src/poly/commitment/hyperkzg/kzg.rs
@@ -8,6 +8,7 @@ use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{One, UniformRand, Zero};
+use common::parallel::par_enabled;
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use std::borrow::Borrow;
@@ -72,7 +73,10 @@ impl<P: Pairing> SRS<P> {
         // Precompute a commitment to each power-of-two length vector of ones, which is just the sum of each power-of-two length prefix of the SRS
         let num_powers = (g1_powers.len() as f64).log2().floor() as usize + 1;
         let all_ones_coeffs: Vec<u8> = vec![1; num_g1_powers + 1];
-        let powers_of_2 = (0..num_powers).into_par_iter().map(|i| 1usize << i);
+        let powers_of_2 = (0..num_powers)
+            .into_par_iter()
+            .with_min_len(par_enabled())
+            .map(|i| 1usize << i);
         let g_products = powers_of_2
             .map(|power| {
                 <P::G1 as VariableBaseMSM>::msm_u8(&g1_powers[..power], &all_ones_coeffs[..power])
@@ -200,6 +204,7 @@ where
         // batch commit requires all batches to have the same length
         assert!(polys
             .par_iter()
+            .with_min_len(par_enabled())
             .all(|s| s.borrow().len() == polys[0].borrow().len()));
 
         if let Some(invalid) = polys

--- a/joltworks/src/poly/commitment/hyperkzg/mod.rs
+++ b/joltworks/src/poly/commitment/hyperkzg/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{One, Zero};
+use common::parallel::par_enabled;
 use kzg::{KZGProverKey, KZGVerifierKey, UnivariateKZG, SRS};
 use rand_core::{CryptoRng, RngCore};
 use rayon::iter::{
@@ -155,6 +156,7 @@ where
     let f: &DensePolynomial<P::ScalarField> = f.try_into().unwrap();
     let h = u
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|ui| {
             let h = compute_witness_polynomial::<P>(&f.evals(), *ui);
             MultilinearPolynomial::from(h)
@@ -197,13 +199,16 @@ where
     // The verifier needs f_i(u_j), so we compute them here
     // (V will compute B(u_j) itself)
     let mut v = vec![vec!(P::ScalarField::zero(); k); t];
-    v.par_iter_mut().enumerate().for_each(|(i, v_i)| {
-        // for each point u
-        v_i.par_iter_mut().zip_eq(f).for_each(|(v_ij, f)| {
-            // for each poly f
-            *v_ij = UniPoly::eval_as_univariate(f, &u[i]);
+    v.par_iter_mut()
+        .with_min_len(par_enabled())
+        .enumerate()
+        .for_each(|(i, v_i)| {
+            // for each point u
+            v_i.par_iter_mut().zip_eq(f).for_each(|(v_ij, f)| {
+                // for each poly f
+                *v_ij = UniPoly::eval_as_univariate(f, &u[i]);
+            });
         });
-    });
 
     // TODO(moodlezoup): Avoid cloned()
     let scalars = v.iter().flatten().collect::<Vec<&P::ScalarField>>();
@@ -277,6 +282,7 @@ where
 
     let q_powers_multiplied: Vec<P::ScalarField> = q_powers
         .par_iter()
+        .with_min_len(par_enabled())
         .map(|q_power| *q_power * q_power_multiplier)
         .collect();
 
@@ -284,9 +290,11 @@ where
     // compute B(u_i) = v[i][0] + q*v[i][1] + ... + q^(t-1) * v[i][t-1]
     let B_u = v
         .into_par_iter()
+        .with_min_len(par_enabled())
         .map(|v_i| {
             v_i.into_par_iter()
                 .zip(q_powers.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| *a * *b)
                 .sum()
         })
@@ -364,10 +372,13 @@ where
             let previous_poly: &DensePolynomial<P::ScalarField> = (&polys[i]).try_into().unwrap();
             let Pi_len = previous_poly.len() / 2;
             let mut Pi = vec![P::ScalarField::zero(); Pi_len];
-            Pi.par_iter_mut().enumerate().for_each(|(j, Pi_j)| {
-                *Pi_j = point[ell - i - 1] * (previous_poly[2 * j + 1] - previous_poly[2 * j])
-                    + previous_poly[2 * j];
-            });
+            Pi.par_iter_mut()
+                .with_min_len(par_enabled())
+                .enumerate()
+                .for_each(|(j, Pi_j)| {
+                    *Pi_j = point[ell - i - 1] * (previous_poly[2 * j + 1] - previous_poly[2 * j])
+                        + previous_poly[2 * j];
+                });
 
             polys.push(MultilinearPolynomial::from(Pi));
         }

--- a/joltworks/src/poly/compact_polynomial.rs
+++ b/joltworks/src/poly/compact_polynomial.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 use std::{cmp::Ordering, ops::Index};
 
@@ -56,7 +57,11 @@ impl<T: SmallScalar, F: JoltField> CompactPolynomial<T, F> {
     }
 
     pub fn coeffs_as_field_elements(&self) -> Vec<F> {
-        self.coeffs.par_iter().map(|x| x.to_field()).collect()
+        self.coeffs
+            .par_iter()
+            .with_min_len(par_enabled())
+            .map(|x| x.to_field())
+            .collect()
     }
 
     pub fn split_eq_evaluate(&self, r_len: usize, eq_one: &[F], eq_two: &[F]) -> F {
@@ -71,9 +76,11 @@ impl<T: SmallScalar, F: JoltField> CompactPolynomial<T, F> {
     fn evaluate_split_eq_parallel(&self, eq_one: &[F], eq_two: &[F]) -> F {
         let eval: F = (0..eq_one.len())
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|x1| {
                 let partial_sum = (0..eq_two.len())
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|x2| {
                         let idx = x1 * eq_two.len() + x2;
                         // field_mul now already checks for 0 and 1 optimisation
@@ -145,7 +152,12 @@ impl<T: SmallScalar, F: JoltField> CompactPolynomial<T, F> {
     }
 
     fn inside_out_parallel(&self, r: &[F]) -> F {
-        let mut current: Vec<F> = self.coeffs.par_iter().map(|&c| c.to_field()).collect();
+        let mut current: Vec<F> = self
+            .coeffs
+            .par_iter()
+            .with_min_len(par_enabled())
+            .map(|&c| c.to_field())
+            .collect();
         let m = r.len();
         for i in (0..m).rev() {
             let stride = 1 << i;
@@ -156,6 +168,7 @@ impl<T: SmallScalar, F: JoltField> CompactPolynomial<T, F> {
             evals_left
                 .par_iter_mut()
                 .zip(evals_right.par_iter())
+                .with_min_len(par_enabled())
                 .for_each(|(x, y)| {
                     //*x = *x + r_val * (*y - *x);
                     let slope = *y - *x;
@@ -267,6 +280,7 @@ impl<T: SmallScalar, F: JoltField> PolynomialBinding<F> for CompactPolynomial<T,
                         self.bound_coeffs.par_chunks_exact(2),
                     )
                         .into_par_iter()
+                        .with_min_len(par_enabled())
                         .with_min_len(512)
                         .for_each(|(bound_coeff, coeffs)| {
                             bound_coeff.write(if coeffs[1] == coeffs[0] {
@@ -282,6 +296,7 @@ impl<T: SmallScalar, F: JoltField> PolynomialBinding<F> for CompactPolynomial<T,
                     let (left, right) = self.bound_coeffs.split_at_mut(n);
                     left.par_iter_mut()
                         .zip(right.par_iter())
+                        .with_min_len(par_enabled())
                         .with_min_len(4096)
                         .filter(|(a, b)| a != b)
                         .for_each(|(a, b)| {
@@ -294,6 +309,7 @@ impl<T: SmallScalar, F: JoltField> PolynomialBinding<F> for CompactPolynomial<T,
                 BindingOrder::LowToHigh => {
                     self.bound_coeffs = (0..n)
                         .into_par_iter()
+                        .with_min_len(par_enabled())
                         .map(|i| {
                             let a = self.coeffs[2 * i];
                             let b = self.coeffs[2 * i + 1];
@@ -316,6 +332,7 @@ impl<T: SmallScalar, F: JoltField> PolynomialBinding<F> for CompactPolynomial<T,
                     self.bound_coeffs = left
                         .par_iter()
                         .zip(right.par_iter())
+                        .with_min_len(par_enabled())
                         .map(|(&a, &b)| {
                             match a.cmp(&b) {
                                 Ordering::Equal => a.to_field(),

--- a/joltworks/src/poly/compact_polynomial.rs
+++ b/joltworks/src/poly/compact_polynomial.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use common::parallel::par_enabled;
+use common::parallel::{par_enabled, par_enabled_with};
 use rayon::prelude::*;
 use std::{cmp::Ordering, ops::Index};
 
@@ -280,8 +280,7 @@ impl<T: SmallScalar, F: JoltField> PolynomialBinding<F> for CompactPolynomial<T,
                         self.bound_coeffs.par_chunks_exact(2),
                     )
                         .into_par_iter()
-                        .with_min_len(par_enabled())
-                        .with_min_len(512)
+                        .with_min_len(par_enabled_with(512))
                         .for_each(|(bound_coeff, coeffs)| {
                             bound_coeff.write(if coeffs[1] == coeffs[0] {
                                 coeffs[0]
@@ -296,8 +295,7 @@ impl<T: SmallScalar, F: JoltField> PolynomialBinding<F> for CompactPolynomial<T,
                     let (left, right) = self.bound_coeffs.split_at_mut(n);
                     left.par_iter_mut()
                         .zip(right.par_iter())
-                        .with_min_len(par_enabled())
-                        .with_min_len(4096)
+                        .with_min_len(par_enabled_with(4096))
                         .filter(|(a, b)| a != b)
                         .for_each(|(a, b)| {
                             *a += r * (*b - *a);

--- a/joltworks/src/poly/dense_mlpoly.rs
+++ b/joltworks/src/poly/dense_mlpoly.rs
@@ -7,6 +7,7 @@ use crate::{
         compute_dotproduct, compute_dotproduct_low_optimized, thread::unsafe_allocate_zero_vec,
     },
 };
+use common::parallel::par_enabled;
 
 use crate::{
     field::{FieldChallengeOps, JoltField, OptimizedMul},
@@ -129,6 +130,7 @@ impl<F: JoltField> DensePolynomial<F> {
 
         left.par_iter_mut()
             .zip(right.par_iter())
+            .with_min_len(par_enabled())
             .with_min_len(4096)
             .filter(|(&mut a, &b)| a != b)
             .for_each(|(a, b)| {
@@ -220,6 +222,7 @@ impl<F: JoltField> DensePolynomial<F> {
         let mut bound_Z = Vec::with_capacity(n);
         (bound_Z.spare_capacity_mut(), self.Z.par_chunks_exact(2))
             .into_par_iter()
+            .with_min_len(par_enabled())
             .with_min_len(512)
             .for_each(|(bound_coeff, coeffs)| {
                 let m = coeffs[1] - coeffs[0];
@@ -272,9 +275,11 @@ impl<F: JoltField> DensePolynomial<F> {
     fn evaluate_split_eq_parallel(&self, eq_one: &[F], eq_two: &[F]) -> F {
         let eval: F = (0..eq_one.len())
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|x1| {
                 let partial_sum = (0..eq_two.len())
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|x2| {
                         let idx = x1 * eq_two.len() + x2;
                         OptimizedMul::mul_01_optimized(eq_two[x2], self.Z[idx])
@@ -364,7 +369,12 @@ impl<F: JoltField> DensePolynomial<F> {
         C: Copy + Send + Sync + Into<F> + ChallengeFieldOps<F>,
         F: FieldChallengeOps<C>,
     {
-        let mut current: Vec<_> = self.Z.par_iter().cloned().collect();
+        let mut current: Vec<_> = self
+            .Z
+            .par_iter()
+            .with_min_len(par_enabled())
+            .cloned()
+            .collect();
         let m = r.len();
         // Invoking the same parallelisation structure
         // currently in evaluating in Lagrange bases.
@@ -378,6 +388,7 @@ impl<F: JoltField> DensePolynomial<F> {
             evals_left
                 .par_iter_mut()
                 .zip(evals_right.par_iter())
+                .with_min_len(par_enabled())
                 .for_each(|(x, y)| {
                     let slope = *y - *x;
                     if slope.is_zero() {
@@ -446,6 +457,7 @@ impl<F: JoltField> DensePolynomial<F> {
 
         let result: Vec<F> = (0..max_length)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let mut acc = F::zero();
                 for (coeff, poly) in coefficients.iter().zip(polynomials.iter()) {
@@ -533,10 +545,12 @@ impl<F: JoltField> PolynomialEvaluation<F> for DensePolynomial<F> {
 
         let evals = (0..eq_one.len())
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|x1| {
                 let eq1_val = eq_one[x1];
                 let inner_sums = (0..eq_two.len())
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .filter_map(|x2| {
                         let eq2_val = eq_two[x2];
                         let idx = x1 * eq_two.len() + x2;

--- a/joltworks/src/poly/dense_mlpoly.rs
+++ b/joltworks/src/poly/dense_mlpoly.rs
@@ -7,7 +7,7 @@ use crate::{
         compute_dotproduct, compute_dotproduct_low_optimized, thread::unsafe_allocate_zero_vec,
     },
 };
-use common::parallel::par_enabled;
+use common::parallel::{par_enabled, par_enabled_with};
 
 use crate::{
     field::{FieldChallengeOps, JoltField, OptimizedMul},
@@ -130,8 +130,7 @@ impl<F: JoltField> DensePolynomial<F> {
 
         left.par_iter_mut()
             .zip(right.par_iter())
-            .with_min_len(par_enabled())
-            .with_min_len(4096)
+            .with_min_len(par_enabled_with(4096))
             .filter(|(&mut a, &b)| a != b)
             .for_each(|(a, b)| {
                 *a += *r * (*b - *a);
@@ -222,8 +221,7 @@ impl<F: JoltField> DensePolynomial<F> {
         let mut bound_Z = Vec::with_capacity(n);
         (bound_Z.spare_capacity_mut(), self.Z.par_chunks_exact(2))
             .into_par_iter()
-            .with_min_len(par_enabled())
-            .with_min_len(512)
+            .with_min_len(par_enabled_with(512))
             .for_each(|(bound_coeff, coeffs)| {
                 let m = coeffs[1] - coeffs[0];
                 bound_coeff.write(if m.is_zero() {

--- a/joltworks/src/poly/eq_plus_one_poly.rs
+++ b/joltworks/src/poly/eq_plus_one_poly.rs
@@ -1,4 +1,5 @@
 use allocative::Allocative;
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 
 use crate::field::{FieldChallengeOps, JoltField};
@@ -43,6 +44,7 @@ impl<F: JoltField> EqPlusOnePolynomial<F> {
         */
         (0..l)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|k| {
                 let lower_bits_product = (0..k)
                     .map(|i| x[l - 1 - i] * (F::one() - y[l - 1 - i]))
@@ -74,7 +76,11 @@ impl<F: JoltField> EqPlusOnePolynomial<F> {
             debug_assert!(i != 0);
             let step = 1 << (ell - i); // step = (full / size)/2
 
-            let mut selected: Vec<_> = eq_evals.par_iter_mut().step_by(step).collect();
+            let mut selected: Vec<_> = eq_evals
+                .par_iter_mut()
+                .with_min_len(par_enabled())
+                .step_by(step)
+                .collect();
 
             selected.par_chunks_mut(2).for_each(|chunk| {
                 *chunk[1] = *chunk[0] * r[i - 1];
@@ -94,6 +100,7 @@ impl<F: JoltField> EqPlusOnePolynomial<F> {
 
             eq_plus_one_evals
                 .par_iter_mut()
+                .with_min_len(par_enabled())
                 .enumerate()
                 .skip(half_step)
                 .step_by(step)

--- a/joltworks/src/poly/eq_poly.rs
+++ b/joltworks/src/poly/eq_poly.rs
@@ -1,6 +1,7 @@
 use crate::field::JoltField;
 use crate::poly::opening_proof::{Endianness, OpeningPoint};
 use crate::utils::{math::Math, thread::unsafe_allocate_zero_vec};
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 use std::{
     marker::PhantomData,
@@ -29,6 +30,7 @@ impl<F: JoltField> EqPolynomial<F> {
         assert_eq!(x.len(), y.len());
         x.par_iter()
             .zip(y.par_iter())
+            .with_min_len(par_enabled())
             .map(|(x_i, y_i)| *x_i * *y_i + (F::one() - *x_i) * (F::one() - *y_i))
             .product()
     }
@@ -45,11 +47,13 @@ impl<F: JoltField> EqPolynomial<F> {
         if E1 == E2 {
             x.r.par_iter()
                 .zip(y.r.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(x_i, y_i)| *x_i * y_i + (F::one() - x_i) * (F::one() - y_i))
                 .product()
         } else {
             x.r.par_iter()
                 .zip(y.r.par_iter().rev())
+                .with_min_len(par_enabled())
                 .map(|(x_i, y_i)| *x_i * y_i + (F::one() - x_i) * (F::one() - y_i))
                 .product()
         }
@@ -235,6 +239,7 @@ impl<F: JoltField> EqPolynomial<F> {
             evals_left
                 .par_iter_mut()
                 .zip(evals_right.par_iter_mut())
+                .with_min_len(par_enabled())
                 .for_each(|(x, y)| {
                     *y = *x * *r;
                     *x -= *y;

--- a/joltworks/src/poly/multilinear_polynomial.rs
+++ b/joltworks/src/poly/multilinear_polynomial.rs
@@ -7,6 +7,7 @@ use allocative::Allocative;
 use ark_ff::biginteger::S128;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use atlas_onnx_tracer::tensor::Tensor;
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 use strum_macros::EnumIter;
 
@@ -343,60 +344,70 @@ impl<F: JoltField> MultilinearPolynomial<F> {
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::U8Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::U16Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::U32Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::U64Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::I32Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::I64Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::I128Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::U128Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             MultilinearPolynomial::S128Scalars(poly) => poly
                 .coeffs
                 .par_iter()
                 .zip_eq(other.par_iter())
+                .with_min_len(par_enabled())
                 .map(|(a, b)| a.field_mul(*b))
                 .sum(),
             _ => unimplemented!("Unexpected MultilinearPolynomial variant"),

--- a/joltworks/src/poly/multiquadratic_poly.rs
+++ b/joltworks/src/poly/multiquadratic_poly.rs
@@ -1,4 +1,5 @@
 use allocative::Allocative;
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 
 use crate::field::JoltField;
@@ -331,6 +332,7 @@ impl<F: JoltField> MultiquadraticPolynomial<F> {
 
         E_active
             .par_iter()
+            .with_min_len(par_enabled())
             .enumerate()
             .map(|(eq_active_idx, eq_active_val)| {
                 let mut index = offset;

--- a/joltworks/src/poly/one_hot_polynomial.rs
+++ b/joltworks/src/poly/one_hot_polynomial.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     poly::{
@@ -10,6 +8,7 @@ use crate::{
     utils::math::Math,
 };
 use allocative::Allocative;
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 use std::sync::{Arc, RwLock};
 
@@ -87,6 +86,7 @@ impl<F: JoltField> OneHotPolynomial<F> {
         let poly = MultilinearPolynomial::from(
             self.nonzero_indices
                 .par_iter()
+                .with_min_len(par_enabled())
                 .map(|instruction| match instruction {
                     Some(index) => eq_r_address[*index as usize],
                     None => F::zero(),
@@ -118,6 +118,7 @@ impl<F: JoltField> OneHotPolynomial<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::poly::dense_mlpoly::DensePolynomial;
     use crate::{
         poly::{multilinear_polynomial::BindingOrder, unipoly::UniPoly},
         subprotocols::opening_reduction::{

--- a/joltworks/src/poly/one_hot_polynomial.rs
+++ b/joltworks/src/poly/one_hot_polynomial.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     poly::{
@@ -118,7 +120,6 @@ impl<F: JoltField> OneHotPolynomial<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::poly::dense_mlpoly::DensePolynomial;
     use crate::{
         poly::{multilinear_polynomial::BindingOrder, unipoly::UniPoly},
         subprotocols::opening_reduction::{

--- a/joltworks/src/poly/prefix_suffix.rs
+++ b/joltworks/src/poly/prefix_suffix.rs
@@ -9,6 +9,7 @@ use crate::{
     utils::{lookup_bits::LookupBits, math::Math, thread::unsafe_allocate_zero_vec},
 };
 use allocative::Allocative;
+use common::parallel::par_enabled;
 use num_traits::Zero;
 use rayon::prelude::*;
 use std::{
@@ -441,6 +442,7 @@ impl<F: JoltField, const ORDER: usize> PrefixSuffixDecomposition<F, ORDER> {
             .P
             .par_iter()
             .zip(self.Q.par_iter())
+            .with_min_len(par_enabled())
             .map(|(p, q)| {
                 let p_evals = if let Some(p) = p {
                     // one for registry and one for self
@@ -479,15 +481,18 @@ impl<F: JoltField, const ORDER: usize> PrefixSuffixDecomposition<F, ORDER> {
     }
 
     pub fn bind(&mut self, r: F::Challenge) {
-        self.P.par_iter().for_each(|p| {
+        self.P.par_iter().with_min_len(par_enabled()).for_each(|p| {
             if let Some(p) = p {
                 let mut p = p.write().unwrap();
                 p.bind_parallel(r, BindingOrder::HighToLow);
             }
         });
-        self.Q.par_iter_mut().for_each(|poly| {
-            poly.bind_parallel(r, BindingOrder::HighToLow);
-        });
+        self.Q
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|poly| {
+                poly.bind_parallel(r, BindingOrder::HighToLow);
+            });
         self.next_round();
     }
 
@@ -495,6 +500,7 @@ impl<F: JoltField, const ORDER: usize> PrefixSuffixDecomposition<F, ORDER> {
         self.P
             .par_iter()
             .zip(self.poly.suffixes().par_iter())
+            .with_min_len(par_enabled())
             .map(|(p, suffix)| {
                 let suff = suffix.suffix_mle(LookupBits::new(0, 0));
                 if suff == 0 {
@@ -511,7 +517,7 @@ impl<F: JoltField, const ORDER: usize> PrefixSuffixDecomposition<F, ORDER> {
     }
 
     fn next_round(&mut self) {
-        self.P.par_iter().for_each(|p| {
+        self.P.par_iter().with_min_len(par_enabled()).for_each(|p| {
             if let Some(p) = p {
                 // one for registry and one for self
                 let use_cache = Arc::strong_count(p) > 2;

--- a/joltworks/src/poly/ra_poly.rs
+++ b/joltworks/src/poly/ra_poly.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 use std::{fmt::Debug, iter::zip, mem, sync::Arc};
 
@@ -218,10 +219,18 @@ impl<I: Into<usize> + Copy + Default + Send + Sync + 'static, F: JoltField>
         let mut F_10: Vec<F> = self.F_1.clone();
         let mut F_11: Vec<F> = self.F_1;
 
-        F_00.par_iter_mut().for_each(|f| *f *= eq_0_r1);
-        F_01.par_iter_mut().for_each(|f| *f *= eq_1_r1);
-        F_10.par_iter_mut().for_each(|f| *f *= eq_0_r1);
-        F_11.par_iter_mut().for_each(|f| *f *= eq_1_r1);
+        F_00.par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_0_r1);
+        F_01.par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_1_r1);
+        F_10.par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_0_r1);
+        F_11.par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_1_r1);
 
         RaPolynomialRound3 {
             F_00,
@@ -296,14 +305,38 @@ impl<I: Into<usize> + Copy + Default + Send + Sync + 'static, F: JoltField>
         let mut F_110: Vec<F> = self.F_11.clone();
         let mut F_111: Vec<F> = self.F_11;
 
-        F_000.par_iter_mut().for_each(|f| *f *= eq_0_r2);
-        F_010.par_iter_mut().for_each(|f| *f *= eq_0_r2);
-        F_100.par_iter_mut().for_each(|f| *f *= eq_0_r2);
-        F_110.par_iter_mut().for_each(|f| *f *= eq_0_r2);
-        F_001.par_iter_mut().for_each(|f| *f *= eq_1_r2);
-        F_011.par_iter_mut().for_each(|f| *f *= eq_1_r2);
-        F_101.par_iter_mut().for_each(|f| *f *= eq_1_r2);
-        F_111.par_iter_mut().for_each(|f| *f *= eq_1_r2);
+        F_000
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_0_r2);
+        F_010
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_0_r2);
+        F_100
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_0_r2);
+        F_110
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_0_r2);
+        F_001
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_1_r2);
+        F_011
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_1_r2);
+        F_101
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_1_r2);
+        F_111
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|f| *f *= eq_1_r2);
 
         let lookup_indices = &self.lookup_indices;
         let n = lookup_indices.len() / 8;

--- a/joltworks/src/poly/rlc_polynomial.rs
+++ b/joltworks/src/poly/rlc_polynomial.rs
@@ -2,6 +2,7 @@ use crate::{
     field::JoltField,
     poly::{dense_mlpoly::DensePolynomial, multilinear_polynomial::MultilinearPolynomial},
 };
+use common::parallel::par_enabled;
 use common::CommittedPolynomial;
 use rayon::prelude::*;
 use std::collections::BTreeMap;
@@ -41,6 +42,7 @@ pub fn build_materialized_rlc<F: JoltField>(
     // Homomorphically combine dense polynomials: joint[i] = Σ coeff_j * poly_j[i]
     let mut joint_coeffs: Vec<F> = (0..joint_len)
         .into_par_iter()
+        .with_min_len(par_enabled())
         .map(|i| {
             dense
                 .iter()

--- a/joltworks/src/poly/split_eq_poly.rs
+++ b/joltworks/src/poly/split_eq_poly.rs
@@ -1,6 +1,7 @@
 //! Implements the Dao-Thaler + Gruen optimization for EQ polynomial evaluations
 //! https://eprint.iacr.org/2024/1210.pdf
 
+use common::parallel::par_enabled;
 use std::ops::Mul;
 
 use allocative::Allocative;
@@ -543,6 +544,7 @@ impl<F: JoltField> GruenSplitEqPolynomial<F> {
 
         (0..out_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|x_out| {
                 let mut inner_acc = make_inner();
 

--- a/joltworks/src/poly/unipoly.rs
+++ b/joltworks/src/poly/unipoly.rs
@@ -1,4 +1,5 @@
 use crate::field::{ChallengeFieldOps, FieldChallengeOps, JoltField};
+use common::parallel::par_enabled;
 use std::cmp::Ordering;
 use std::iter::zip;
 use std::ops::{Add, AddAssign, Index, IndexMut, Mul, MulAssign, Sub};
@@ -291,7 +292,10 @@ impl<F: JoltField> UniPoly<F> {
     }
 
     pub fn shift_coefficients(&mut self, rhs: &F) {
-        self.coeffs.par_iter_mut().for_each(|c| *c += *rhs);
+        self.coeffs
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|c| *c += *rhs);
     }
 
     /// This function computes a cubic polynomial s(X), given the following conditions:
@@ -400,7 +404,7 @@ impl<F: JoltField> Mul<F> for UniPoly<F> {
     type Output = Self;
 
     fn mul(self, rhs: F) -> Self {
-        let iter = self.coeffs.into_par_iter();
+        let iter = self.coeffs.into_par_iter().with_min_len(par_enabled());
         Self::from_coeff(iter.map(|c| c * rhs).collect::<Vec<_>>())
     }
 }
@@ -409,7 +413,7 @@ impl<F: JoltField> Mul<&F> for UniPoly<F> {
     type Output = Self;
 
     fn mul(self, rhs: &F) -> Self {
-        let iter = self.coeffs.into_par_iter();
+        let iter = self.coeffs.into_par_iter().with_min_len(par_enabled());
         Self::from_coeff(iter.map(|c| c * *rhs).collect::<Vec<_>>())
     }
 }
@@ -453,7 +457,10 @@ impl<F: JoltField> IndexMut<usize> for UniPoly<F> {
 
 impl<F: JoltField> MulAssign<&F> for UniPoly<F> {
     fn mul_assign(&mut self, rhs: &F) {
-        self.coeffs.par_iter_mut().for_each(|c| *c *= *rhs);
+        self.coeffs
+            .par_iter_mut()
+            .with_min_len(par_enabled())
+            .for_each(|c| *c *= *rhs);
     }
 }
 

--- a/joltworks/src/subprotocols/booleanity.rs
+++ b/joltworks/src/subprotocols/booleanity.rs
@@ -2,6 +2,7 @@ use allocative::Allocative;
 #[cfg(feature = "allocative")]
 use allocative::FlameGraphBuilder;
 use ark_std::Zero;
+use common::parallel::par_enabled;
 use common::CommittedPolynomial;
 use rayon::prelude::*;
 use std::{fmt::Debug, iter::zip, sync::Arc};
@@ -136,10 +137,12 @@ impl<F: JoltField, I: Into<usize> + Copy + Default + Send + Sync + 'static>
             .par_fold_out_in_unreduced::<9, { DEGREE_BOUND - 1 }>(&|k_prime| {
                 let coeffs = (0..self.params.d)
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|i| {
                         let G_i = &self.G[i];
                         let inner_sum = G_i[k_prime << m..(k_prime + 1) << m]
                             .par_iter()
+                            .with_min_len(par_enabled())
                             .enumerate()
                             .map(|(k, &G_k)| {
                                 let k_m = k >> (m - 1);
@@ -277,6 +280,7 @@ impl<
             self.D.bind(r_j);
             self.H
                 .par_iter_mut()
+                .with_min_len(par_enabled())
                 .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
         }
     }

--- a/joltworks/src/subprotocols/gamma_fold.rs
+++ b/joltworks/src/subprotocols/gamma_fold.rs
@@ -1,6 +1,7 @@
 use atlas_onnx_tracer::tensor::Tensor;
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 use crate::{
     field::{IntoOpening, JoltField},
@@ -132,6 +133,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for GammaFoldProv
     fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
         let univariate_poly_evals: [F; DEGREE_BOUND] = (0..self.tensor.len() / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let tensor_evals =
                     self.tensor

--- a/joltworks/src/subprotocols/hamming_booleanity.rs
+++ b/joltworks/src/subprotocols/hamming_booleanity.rs
@@ -1,6 +1,7 @@
 use allocative::Allocative;
 #[cfg(feature = "allocative")]
 use allocative::FlameGraphBuilder;
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use rayon::prelude::*;
 use std::iter::zip;
@@ -85,6 +86,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         let [q_constant, q_quadratic] = hw
             .par_iter()
             .zip(self.params.gamma_powers.par_iter())
+            .with_min_len(par_enabled())
             .map(|(hw_d, &gamma)| {
                 let [qd_c, qd_q] = eq_r.par_fold_out_in_unreduced::<9, 2>(&|g| {
                     let hw0 = hw_d.get_bound_coeff(2 * g);
@@ -109,6 +111,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
     fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
         self.hw
             .par_iter_mut()
+            .with_min_len(par_enabled())
             .for_each(|ra| ra.bind_parallel(r_j, BindingOrder::LowToHigh));
         self.eq_r.bind(r_j);
     }

--- a/joltworks/src/subprotocols/hamming_weight.rs
+++ b/joltworks/src/subprotocols/hamming_weight.rs
@@ -2,6 +2,7 @@ use allocative::Allocative;
 #[cfg(feature = "allocative")]
 use allocative::FlameGraphBuilder;
 use ark_std::Zero;
+use common::parallel::par_enabled;
 use common::{CommittedPolynomial, VirtualPolynomial};
 use rayon::prelude::*;
 use std::iter::zip;
@@ -85,10 +86,16 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for HammingWeight
         let prover_msg = self
             .ra
             .par_iter()
-            .zip(self.params.gamma_powers.par_iter())
+            .zip(
+                self.params
+                    .gamma_powers
+                    .par_iter()
+                    .with_min_len(par_enabled()),
+            )
             .map(|(ra, gamma)| {
                 let ra_sum = (0..ra.len() / 2)
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|i| ra.get_bound_coeff(2 * i))
                     .fold_with(F::Unreduced::<5>::zero(), |running, new| {
                         running + new.as_unreduced_ref()
@@ -106,6 +113,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for HammingWeight
     fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
         self.ra
             .par_iter_mut()
+            .with_min_len(par_enabled())
             .for_each(|ra| ra.bind_parallel(r_j, BindingOrder::LowToHigh));
     }
 

--- a/joltworks/src/subprotocols/hamming_weight.rs
+++ b/joltworks/src/subprotocols/hamming_weight.rs
@@ -86,12 +86,8 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for HammingWeight
         let prover_msg = self
             .ra
             .par_iter()
-            .zip(
-                self.params
-                    .gamma_powers
-                    .par_iter()
-                    .with_min_len(par_enabled()),
-            )
+            .zip(self.params.gamma_powers.par_iter())
+            .with_min_len(par_enabled())
             .map(|(ra, gamma)| {
                 let ra_sum = (0..ra.len() / 2)
                     .into_par_iter()

--- a/joltworks/src/subprotocols/identity_range_check.rs
+++ b/joltworks/src/subprotocols/identity_range_check.rs
@@ -25,6 +25,7 @@ use crate::{
     },
 };
 use ark_std::Zero;
+use common::parallel::par_enabled;
 use common::VirtualPolynomial;
 use itertools::Itertools;
 use rayon::prelude::*;
@@ -233,6 +234,7 @@ where
         let len = self.identity_ps.Q_len();
         (0..len / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|b| {
                 let (i0, i2) = self.identity_ps.sumcheck_evals(b);
                 [i0, i2]
@@ -264,6 +266,7 @@ where
             let _guard = span.enter();
             self.lookup_indices
                 .par_iter()
+                .with_min_len(par_enabled())
                 .map(|k| {
                     (0..self.phases)
                         .map(|phase| {

--- a/joltworks/src/subprotocols/opening_reduction.rs
+++ b/joltworks/src/subprotocols/opening_reduction.rs
@@ -32,6 +32,7 @@ use allocative::Allocative;
 #[cfg(feature = "allocative")]
 use allocative::FlameGraphBuilder;
 use ark_std::Zero;
+use common::parallel::par_enabled;
 use common::CommittedPolynomial;
 use rayon::prelude::*;
 use std::{
@@ -309,6 +310,7 @@ impl<F: JoltField> DensePolynomialProverOpening<F> {
             // E_in is fully bound
             let unreduced_q_0 = (0..mle_half)
                 .into_par_iter()
+                .with_min_len(par_enabled())
                 .map(|j| {
                     let eq_eval = gruen_eq.E_out_current()[j];
                     // TODO(quang): special case depending on the polynomial type?
@@ -326,9 +328,11 @@ impl<F: JoltField> DensePolynomialProverOpening<F> {
 
             (0..num_x_in)
                 .into_par_iter()
+                .with_min_len(par_enabled())
                 .map(|x_in| {
                     let unreduced_inner_sum = (0..num_x_out)
                         .into_par_iter()
+                        .with_min_len(par_enabled())
                         .map(|x_out| {
                             let j = (x_in << num_x_out_bits) | x_out;
                             let poly_eval = polynomial.get_bound_coeff(j);
@@ -501,6 +505,7 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
                     running
                         .par_iter_mut()
                         .zip(new.into_par_iter())
+                        .with_min_len(par_enabled())
                         .for_each(|(x, y)| *x += y);
                     running
                 },
@@ -525,10 +530,12 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
 
             let unreduced_univariate_poly_evals = (0..B.len() / 2)
                 .into_par_iter()
+                .with_min_len(par_enabled())
                 .map(|k_prime| {
                     let B_evals = B.sumcheck_evals_array::<2>(k_prime, BindingOrder::HighToLow);
                     let inner_sum = G
                         .par_iter()
+                        .with_min_len(par_enabled())
                         .enumerate()
                         .skip(k_prime)
                         .step_by(B.len() / 2)
@@ -576,6 +583,7 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
             let gruen_eval_0 = if d_gruen.E_in_current_len() == 1 {
                 let unreduced_gruen_eval_0 = (0..d_gruen.len() / 2)
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|j| d_gruen.E_out_current()[j].mul_unreduced::<9>(H.get_bound_coeff(j)))
                     .reduce(F::Unreduced::<9>::zero, |running, new| running + new);
                 F::from_montgomery_reduce(unreduced_gruen_eval_0)
@@ -588,9 +596,11 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
 
                 (0..num_x_in)
                     .into_par_iter()
+                    .with_min_len(par_enabled())
                     .map(|x_in| {
                         let unreduced_inner_sum = (0..num_x_out)
                             .into_par_iter()
+                            .with_min_len(par_enabled())
                             .map(|x_out| {
                                 let j = (x_in << num_x_out_bits) | x_out;
                                 d_e_out[x_out].mul_unreduced::<9>(H.get_bound_coeff(j))

--- a/joltworks/src/subprotocols/ps_shout.rs
+++ b/joltworks/src/subprotocols/ps_shout.rs
@@ -32,6 +32,7 @@ use crate::{
     },
 };
 use ark_std::Zero;
+use common::parallel::par_enabled;
 use common::{
     consts::{LOG_K, XLEN},
     VirtualPolynomial,
@@ -221,6 +222,7 @@ where
             .iter()
             .collect::<Vec<_>>()
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|_| DensePolynomial::default())
             .collect();
         let is_interleaved_operands = params.is_interleaved_operands;
@@ -336,6 +338,7 @@ where
             .table
             .suffixes()
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|s| {
                 let mut Q = unsafe_allocate_zero_vec(m);
                 self.lookup_indices.iter().enumerate().for_each(|(j, &k)| {
@@ -391,6 +394,7 @@ where
         let half_poly_len = self.suffix_polys[0].len() / 2;
         let [eval_0, eval_2_low, eval_2_high] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let b = LookupBits::new(i as u64, half_poly_len.log_2());
                 let prefix_evals_0 = self
@@ -456,6 +460,7 @@ where
         let len = self.identity_ps.Q_len();
         let [left_0, left_2, right_0, right_2] = (0..len / 2)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|b| {
                 let (i0, i2) = self.identity_ps.sumcheck_evals(b);
                 let (r0, r2) = self.right_operand_ps.sumcheck_evals(b);
@@ -519,6 +524,7 @@ where
             let _guard = span.enter();
             self.lookup_indices
                 .par_iter()
+                .with_min_len(par_enabled())
                 .map(|k| {
                     (0..self.phases)
                         .map(|phase| {
@@ -598,6 +604,7 @@ where
                 s.spawn(|_| {
                     self.suffix_polys
                         .par_iter_mut()
+                        .with_min_len(par_enabled())
                         .for_each(|s| s.bind(r_j, BindingOrder::HighToLow));
                 });
                 s.spawn(|_| self.identity_ps.bind(r_j));

--- a/joltworks/src/subprotocols/ra_virtual.rs
+++ b/joltworks/src/subprotocols/ra_virtual.rs
@@ -1,3 +1,4 @@
+use common::parallel::par_enabled;
 use std::sync::Arc;
 
 use crate::{
@@ -76,6 +77,7 @@ impl<F: JoltField> RaSumcheckProver<F> {
 
         let ra_i_polys = H_indices
             .into_par_iter()
+            .with_min_len(par_enabled())
             .enumerate()
             .map(|(i, lookup_indices)| {
                 let eq_evals = EqPolynomial::evals(&r_address_chunks[i]);
@@ -236,6 +238,7 @@ mod tests {
         let poly = MultilinearPolynomial::from(
             indices
                 .par_iter()
+                .with_min_len(par_enabled())
                 .map(|index| {
                     let bit_vec: Vec<F> = index_to_field_bitvector(*index as u64, r_address.len());
                     EqPolynomial::mle(r_address, &bit_vec)
@@ -283,6 +286,7 @@ mod tests {
             .map(|i| {
                 lookup_indices
                     .par_iter()
+                    .with_min_len(par_enabled())
                     .map(|lookup_index| {
                         Some(one_hot_params.lookup_index_chunk(*lookup_index as u64, i))
                     })

--- a/joltworks/src/subprotocols/shout.rs
+++ b/joltworks/src/subprotocols/shout.rs
@@ -19,6 +19,7 @@ use crate::{
     transcripts::Transcript,
     utils::thread::unsafe_allocate_zero_vec,
 };
+use common::parallel::par_enabled;
 use common::{CommittedPolynomial, VirtualPolynomial};
 use rayon::prelude::*;
 use std::array;
@@ -150,6 +151,7 @@ impl<F: JoltField> ReadRafProver<F> {
         let E = EqPolynomial::evals(&params.r);
         let G = lookup_indices
             .par_iter()
+            .with_min_len(par_enabled())
             .enumerate()
             .fold(
                 || unsafe_allocate_zero_vec::<F>(table_size),
@@ -188,6 +190,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReadRafProver
         let half_poly_len = val.len() / 2;
         let uni_poly_evals: [F; 2] = (0..half_poly_len)
             .into_par_iter()
+            .with_min_len(par_enabled())
             .map(|i| {
                 let val_evals =
                     val.sumcheck_evals(i, READ_RAF_DEGREE_BOUND, BindingOrder::HighToLow);
@@ -494,6 +497,7 @@ pub fn compute_instruction_h_indices(
         .map(|i| {
             trace
                 .par_iter()
+                .with_min_len(par_enabled())
                 .map(|lookup_index| {
                     Some(one_hot_params.lookup_index_chunk(*lookup_index as u64, i))
                 })
@@ -545,6 +549,7 @@ where
                 running.iter_mut().zip(new.into_iter()).for_each(|(x, y)| {
                     x.par_iter_mut()
                         .zip(y.into_par_iter())
+                        .with_min_len(par_enabled())
                         .for_each(|(x, y)| *x += y)
                 });
                 running

--- a/joltworks/src/utils/expanding_table.rs
+++ b/joltworks/src/utils/expanding_table.rs
@@ -1,4 +1,5 @@
 use allocative::Allocative;
+use common::parallel::par_enabled;
 use rayon::prelude::*;
 use std::ops::Index;
 
@@ -65,6 +66,7 @@ impl<F: JoltField> ExpandingTable<F> {
                 values_left
                     .par_iter_mut()
                     .zip(values_right.par_iter_mut())
+                    .with_min_len(par_enabled())
                     .for_each(|(x, y)| {
                         *y = *x * r_j;
                         *x -= *y;

--- a/joltworks/src/utils/mod.rs
+++ b/joltworks/src/utils/mod.rs
@@ -1,4 +1,5 @@
 use crate::field::{ChallengeFieldOps, JoltField};
+use common::parallel::par_enabled;
 
 use rayon::prelude::*;
 
@@ -52,6 +53,7 @@ pub fn index_to_field_bitvector<F: JoltField + ChallengeFieldOps<F>>(
 pub fn compute_dotproduct<F: JoltField>(a: &[F], b: &[F]) -> F {
     a.par_iter()
         .zip_eq(b.par_iter())
+        .with_min_len(par_enabled())
         .map(|(a_i, b_i)| *a_i * *b_i)
         .sum()
 }
@@ -61,6 +63,7 @@ pub fn compute_dotproduct<F: JoltField>(a: &[F], b: &[F]) -> F {
 pub fn compute_dotproduct_low_optimized<F: JoltField>(a: &[F], b: &[F]) -> F {
     a.par_iter()
         .zip_eq(b.par_iter())
+        .with_min_len(par_enabled())
         .map(|(a_i, b_i)| mul_0_1_optimized(a_i, b_i))
         .sum()
 }


### PR DESCRIPTION
## Summary

This PR improves the performance of `commit_witness_polynomials`.

After profiling the commitment phase, I found that most of the CPU time was being spent in **kernel time**, while **user time accounted for only about 8%**. This suggested that the main bottleneck was not the computation itself, but excessive **thread context switching** caused by overly fragmented Rayon jobs.

To address this, I changed the parallelization strategy so that the two main components called inside `commit_witness_polynomials`:

- `polynomial_map`
- `commit_to_polynomials`

are parallelized **only at the polynomial / commitment level**, while disabling parallelism inside their internal subroutines.

As a result, the commitment phase became significantly faster.

## Performance

Overall, this change yields a multi-fold speedup in the commitment phase.

As one concrete example, when running Qwen, the commitment time improved from:

- **38.6s -> 8.7s** (**77.5% reduction**, or about **4.4x faster**)

## Motivation

The previous implementation used `par_iter` in multiple layers within the commitment phase. In practice, this caused Rayon jobs to become too fine-grained, which led to substantial scheduling overhead and frequent thread context switching.

Profiling showed that kernel time dominated the execution, which strongly suggests that the system was spending much more time managing threads than performing useful user-space computation.

## Implementation

The implementation introduces a mechanism to suppress `par_iter`-based parallelism in the code paths related to `commit_witness_polynomials`.

In other words:

- `polynomial_map` itself is still parallelized at the polynomial level
- `commit_to_polynomials` itself is still parallelized at the commitment level
- lower-level internal routines called inside these phases no longer introduce additional nested parallelism

~~This is admittedly a somewhat ad hoc solution, but at the moment I was not able to find a better alternative that works within the current structure. If there is a cleaner or more principled solution, I would be very happy to adopt it.~~

The implementation now takes a different form.

Instead of relying on `maybe-rayon`, this PR introduces a new crate, `perhaps-rayon`, and switches the relevant code in:

- `jolt-atlas-core`
- `atlas-onnx-tracer`
- `joltworks`

to use it while keeping the diff against the original implementations as small as possible.

The main idea is to preserve a Rayon-compatible API while allowing the caller to choose, at runtime, whether a given operation should execute in parallel or sequentially.

In particular, `perhaps-rayon` provides APIs such as:

- `par_iter(bool)`
- `par_iter_mut(bool)`
- `into_par_iter(bool)`

where the boolean determines whether the operation uses parallel execution or falls back to sequential execution.

This differs from `maybe-rayon`, where that choice is effectively made only at compile time.

Using this runtime-selectable facade makes it possible to suppress nested parallelism in the hot paths related to `commit_witness_polynomials` without requiring larger structural changes across the workspace.

## Documentation

To help review the relevant execution structure, I added:

- `docs/commit_witness_polynomials_call_graph.md`

Please refer to that document as well when reviewing this PR.

I also created a new `docs/` directory because there was previously no obvious place to put this kind of internal implementation/performance note. If there is a better location for this type of document, I would appreciate suggestions.

## Notes

This PR focuses specifically on improving the commitment phase by reducing nested and fragmented parallelism. It does not attempt to provide a general-purpose scheduling or parallelism framework; it is a targeted fix for the current bottleneck.
