### PR TITLE
Add zk implementation for single sumcheck stage ops

### DIFF
--- a/jolt-atlas-core/Cargo.toml
+++ b/jolt-atlas-core/Cargo.toml
@@ -3,6 +3,9 @@ name = "jolt-atlas-core"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+zk = ["joltworks/zk"]
+
 [dependencies]
 # Internal
 atlas-onnx-tracer.workspace = true

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -740,9 +740,12 @@ fn test_square_zk() {
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
 
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
 
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -766,8 +769,11 @@ fn test_add_zk() {
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
 
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -789,8 +795,11 @@ fn test_reshape_zk() {
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
 
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -812,8 +821,11 @@ fn test_slice_zk() {
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
 
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -832,8 +844,11 @@ fn test_neg_zk() {
     let pp = AtlasSharedPreprocessing::preprocess(model);
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -853,8 +868,11 @@ fn test_sub_zk() {
     let pp = AtlasSharedPreprocessing::preprocess(model);
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -874,8 +892,11 @@ fn test_mul_zk() {
     let pp = AtlasSharedPreprocessing::preprocess(model);
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -894,8 +915,11 @@ fn test_cube_zk() {
     let pp = AtlasSharedPreprocessing::preprocess(model);
     let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
 }
 
@@ -933,8 +957,12 @@ fn bench_square_zk_overhead() {
     let standard_prove = t0.elapsed();
 
     // ZK prove (single pass: setup + ZK sumcheck + BlindFold)
+    let bench_gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
     let t0 = Instant::now();
-    let (bundle, io_zk) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input.clone()]);
+    let (bundle, io_zk) =
+        crate::onnx_proof::zk::prove_zk(&prover_pp, &[input.clone()], &bench_gens);
     let zk_prove = t0.elapsed();
 
     // Standard verify
@@ -944,7 +972,7 @@ fn bench_square_zk_overhead() {
 
     // ZK verify (BlindFold only)
     let t0 = Instant::now();
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io_zk).unwrap();
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io_zk, &bench_gens).unwrap();
     let zk_verify = t0.elapsed();
 
     let prove_overhead = zk_prove.as_secs_f64() / standard_prove.as_secs_f64();

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -742,6 +742,62 @@ fn test_square_zk() {
 
     let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
 
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, None)
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
         .expect("ZK verification should succeed");
+}
+
+/// Benchmark: measures ZK overhead vs standard prove/verify for Square.
+/// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
+#[cfg(feature = "zk")]
+#[ignore = "benchmark, run manually with --release --nocapture"]
+#[test]
+fn bench_square_zk_overhead() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    use std::time::Instant;
+
+    let size = 1 << 16;
+    let mut rng = StdRng::seed_from_u64(0xBE01);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![size]);
+    let res = b.square(i);
+    b.mark_output(res);
+    let model = b.build();
+
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    // Warmup
+    let _ =
+        ONNXProof::<Fr, Blake2bTranscript, HyperKZG<Bn254>>::prove(&prover_pp, &[input.clone()]);
+
+    // Standard prove
+    let t0 = Instant::now();
+    let (proof, io, _) =
+        ONNXProof::<Fr, Blake2bTranscript, HyperKZG<Bn254>>::prove(&prover_pp, &[input.clone()]);
+    let standard_prove = t0.elapsed();
+
+    // ZK prove (single pass: setup + ZK sumcheck + BlindFold)
+    let t0 = Instant::now();
+    let (bundle, io_zk) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input.clone()]);
+    let zk_prove = t0.elapsed();
+
+    // Standard verify
+    let t0 = Instant::now();
+    proof.verify(&verifier_pp, &io, None).unwrap();
+    let standard_verify = t0.elapsed();
+
+    // ZK verify (BlindFold only)
+    let t0 = Instant::now();
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io_zk).unwrap();
+    let zk_verify = t0.elapsed();
+
+    let prove_overhead = zk_prove.as_secs_f64() / standard_prove.as_secs_f64();
+    let verify_overhead = zk_verify.as_secs_f64() / standard_verify.as_secs_f64();
+
+    println!("\n=== Square ZK Overhead (n={size}) ===");
+    println!("Prove:  standard={standard_prove:?}  zk={zk_prove:?}  overhead={prove_overhead:.2}x  delta={:?}", zk_prove.saturating_sub(standard_prove));
+    println!("Verify: standard={standard_verify:?}  zk={zk_verify:?}  overhead={verify_overhead:.2}x  delta={:?}", zk_verify.saturating_sub(standard_verify));
 }

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -717,3 +717,31 @@ fn test_mlp_square_4layer() {
         TestConfig::default(),
     );
 }
+
+/// End-to-end ZK test: proves a Square-only model through the ZK pipeline
+/// (Pedersen-committed sumcheck rounds + BlindFold), then verifies both the
+/// standard proof and the BlindFold proof.
+#[cfg(feature = "zk")]
+#[test]
+fn test_square_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF02);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![size]);
+    let res = b.square(i);
+    b.mark_output(res);
+    let model = b.build();
+
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, None)
+        .expect("ZK verification should succeed");
+}

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -746,6 +746,77 @@ fn test_square_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_add_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF03);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![size]);
+    let c = b.constant(Tensor::<i32>::random_small(&mut rng, &[size]));
+    let res = b.add(i, c);
+    b.mark_output(res);
+    let model = b.build();
+
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_reshape_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+
+    let mut rng = StdRng::seed_from_u64(0xBF04);
+    let input = Tensor::<i32>::random_small(&mut rng, &[4, 4]);
+
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![4, 4]);
+    let res = b.reshape(i, vec![16]);
+    b.mark_output(res);
+    let model = b.build();
+
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_slice_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+
+    let mut rng = StdRng::seed_from_u64(0xBF05);
+    let input = Tensor::<i32>::random_small(&mut rng, &[2, 8]);
+
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![2, 8]);
+    let res = b.slice(i, 1, 2, 6); // slice axis 1, range [2..6]
+    b.mark_output(res);
+    let model = b.build();
+
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+        .expect("ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -817,6 +817,88 @@ fn test_slice_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_neg_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF06);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![size]);
+    let res = b.neg(i);
+    b.mark_output(res);
+    let model = b.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_sub_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF07);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![size]);
+    let c = b.constant(Tensor::<i32>::random_small(&mut rng, &[size]));
+    let res = b.sub(i, c);
+    b.mark_output(res);
+    let model = b.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_mul_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF08);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![size]);
+    let c = b.constant(Tensor::<i32>::random_small(&mut rng, &[size]));
+    let res = b.mul(i, c);
+    b.mark_output(res);
+    let model = b.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_cube_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF09);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![size]);
+    let res = b.cube(i, 1);
+    b.mark_output(res);
+    let model = b.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input]);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io)
+        .expect("ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/mod.rs
@@ -38,6 +38,8 @@ mod preprocessing;
 mod prover;
 mod types;
 mod verifier;
+#[cfg(feature = "zk")]
+pub mod zk;
 
 #[cfg(test)]
 mod e2e_tests;

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_standard_params, impl_standard_sumcheck_proof_api,
+    impl_standard_sumcheck_proof_api,
     onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
@@ -30,7 +30,111 @@ use joltworks::{
 };
 
 impl_standard_sumcheck_proof_api!(Add, AddParams, AddProver, AddVerifier);
-impl_standard_params!(AddParams, 2);
+
+/// Shared parameter block for the element-wise addition sumcheck proof.
+#[derive(Clone)]
+pub struct AddParams<F: JoltField> {
+    pub(crate) r_node_output: OpeningPoint<BIG_ENDIAN, F>,
+    pub(crate) computation_node: ComputationNode,
+}
+
+impl<F: JoltField> AddParams<F> {
+    /// Creates new params by reading the current output opening from the accumulator.
+    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        let r_node_output = accumulator
+            .get_node_output_opening(computation_node.idx)
+            .0
+            .r;
+        Self {
+            r_node_output: r_node_output.into(),
+            computation_node,
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn left_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
+        joltworks::poly::opening_proof::OpeningId::Virtual(
+            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.computation_node.idx),
+        )
+    }
+
+    #[cfg(feature = "zk")]
+    fn right_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
+        joltworks::poly::opening_proof::OpeningId::Virtual(
+            VirtualPolynomial::NodeOutput(self.computation_node.inputs[1]),
+            SumcheckId::NodeExecution(self.computation_node.idx),
+        )
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for AddParams<F> {
+    fn degree(&self) -> usize {
+        2
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        use joltworks::utils::math::Math;
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (left + right) = eq_eval * left + eq_eval * right
+    // Two terms, each with Challenge(0) = eq_eval scaling one opening.
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let left_id = self.left_opening_id();
+        let right_id = self.right_opening_id();
+        let terms = vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(left_id)],
+            ),
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(right_id)],
+            ),
+        ];
+        Some(OutputClaimConstraint::sum_of_products(terms))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval]
+    }
+}
 
 /// Prover state for element-wise addition sumcheck protocol.
 ///

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -41,30 +41,12 @@ pub struct AddParams<F: JoltField> {
 impl<F: JoltField> AddParams<F> {
     /// Creates new params by reading the current output opening from the accumulator.
     pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
-        let r_node_output = accumulator
-            .get_node_output_opening(computation_node.idx)
-            .0
-            .r;
+        let accessor = AccOpeningAccessor::new(accumulator, &computation_node);
+        let r_node_output = accessor.get_reduced_opening().0;
         Self {
-            r_node_output: r_node_output.into(),
+            r_node_output,
             computation_node,
         }
-    }
-
-    #[cfg(feature = "zk")]
-    fn left_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
-        joltworks::poly::opening_proof::OpeningId::Virtual(
-            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
-            SumcheckId::NodeExecution(self.computation_node.idx),
-        )
-    }
-
-    #[cfg(feature = "zk")]
-    fn right_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
-        joltworks::poly::opening_proof::OpeningId::Virtual(
-            VirtualPolynomial::NodeOutput(self.computation_node.inputs[1]),
-            SumcheckId::NodeExecution(self.computation_node.idx),
-        )
     }
 }
 
@@ -111,8 +93,11 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AddParams<F> {
     ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
         use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
 
-        let left_id = self.left_opening_id();
-        let right_id = self.right_opening_id();
+        let op_builder =
+            crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node);
+        let left_id = op_builder.nodeio(Target::Input(0));
+        let right_id = op_builder.nodeio(Target::Input(1));
+
         let terms = vec![
             ProductTerm::scaled(
                 ValueSource::Challenge(0),

--- a/jolt-atlas-core/src/onnx_proof/ops/cube.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cube.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_standard_params, impl_standard_sumcheck_proof_api,
+    impl_standard_sumcheck_proof_api,
     onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
@@ -31,7 +31,91 @@ use joltworks::{
 };
 
 impl_standard_sumcheck_proof_api!(Cube, CubeParams, CubeProver, CubeVerifier);
-impl_standard_params!(CubeParams, 4);
+
+/// Shared parameter block for the element-wise cube sumcheck proof.
+#[derive(Clone)]
+pub struct CubeParams<F: JoltField> {
+    pub(crate) r_node_output: OpeningPoint<BIG_ENDIAN, F>,
+    pub(crate) computation_node: ComputationNode,
+}
+
+impl<F: JoltField> CubeParams<F> {
+    /// Creates new params by reading the current output opening from the accumulator.
+    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        let accessor = AccOpeningAccessor::new(accumulator, &computation_node);
+        let r_node_output = accessor.get_reduced_opening().0;
+        Self {
+            r_node_output,
+            computation_node,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for CubeParams<F> {
+    fn degree(&self) -> usize {
+        4
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        use joltworks::utils::math::Math;
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * operand * operand * operand
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let op_id = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
+            .nodeio(Target::Input(0));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(op_id),
+                    ValueSource::Opening(op_id),
+                    ValueSource::Opening(op_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval]
+    }
+}
 
 const DEGREE_BOUND: usize = 4;
 

--- a/jolt-atlas-core/src/onnx_proof/ops/mul.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mul.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_standard_params, impl_standard_sumcheck_proof_api,
+    impl_standard_sumcheck_proof_api,
     onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
@@ -30,7 +30,92 @@ use joltworks::{
 };
 
 impl_standard_sumcheck_proof_api!(Mul, MulParams, MulProver, MulVerifier);
-impl_standard_params!(MulParams, 3);
+
+/// Shared parameter block for the element-wise multiplication sumcheck proof.
+#[derive(Clone)]
+pub struct MulParams<F: JoltField> {
+    pub(crate) r_node_output: OpeningPoint<BIG_ENDIAN, F>,
+    pub(crate) computation_node: ComputationNode,
+}
+
+impl<F: JoltField> MulParams<F> {
+    /// Creates new params by reading the current output opening from the accumulator.
+    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        let accessor = AccOpeningAccessor::new(accumulator, &computation_node);
+        let r_node_output = accessor.get_reduced_opening().0;
+        Self {
+            r_node_output,
+            computation_node,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for MulParams<F> {
+    fn degree(&self) -> usize {
+        3
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        use joltworks::utils::math::Math;
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * left * right
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.clone().nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval]
+    }
+}
 
 /// Prover state for element-wise multiplication sumcheck protocol.
 ///

--- a/jolt-atlas-core/src/onnx_proof/ops/neg.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/neg.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_standard_params, impl_standard_sumcheck_proof_api,
+    impl_standard_sumcheck_proof_api,
     onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
@@ -30,7 +30,87 @@ use joltworks::{
 };
 
 impl_standard_sumcheck_proof_api!(Neg, NegParams, NegProver, NegVerifier);
-impl_standard_params!(NegParams, 2);
+
+/// Shared parameter block for the element-wise negation sumcheck proof.
+#[derive(Clone)]
+pub struct NegParams<F: JoltField> {
+    pub(crate) r_node_output: OpeningPoint<BIG_ENDIAN, F>,
+    pub(crate) computation_node: ComputationNode,
+}
+
+impl<F: JoltField> NegParams<F> {
+    /// Creates new params by reading the current output opening from the accumulator.
+    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        let accessor = AccOpeningAccessor::new(accumulator, &computation_node);
+        let r_node_output = accessor.get_reduced_opening().0;
+        Self {
+            r_node_output,
+            computation_node,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for NegParams<F> {
+    fn degree(&self) -> usize {
+        2
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        use joltworks::utils::math::Math;
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (-operand) = (-eq_eval) * operand
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let operand_id =
+            crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
+                .nodeio(Target::Input(0));
+        let term = ProductTerm::scaled(
+            ValueSource::Challenge(0),
+            vec![ValueSource::Opening(operand_id)],
+        );
+        Some(OutputClaimConstraint::sum_of_products(vec![term]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![-eq_eval]
+    }
+}
 
 /// Prover state for element-wise negation sumcheck protocol.
 ///

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -180,6 +180,16 @@ impl<F: JoltField> ReshapeSumcheckParams<F> {
     }
 }
 
+impl<F: JoltField> ReshapeSumcheckParams<F> {
+    #[cfg(feature = "zk")]
+    fn input_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
+        joltworks::poly::opening_proof::OpeningId::Virtual(
+            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.computation_node.idx),
+        )
+    }
+}
+
 impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
     fn degree(&self) -> usize {
         2
@@ -198,6 +208,51 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
         self.computation_node
             .pow2_padded_num_output_elements()
             .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = input_claim * selector_claim
+    // selector_claim is deterministic from public data (shapes + r_output), so Challenge(0).
+    // input_claim is an opening.
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let input_id = self.input_opening_id();
+        let term = ProductTerm::scaled(
+            ValueSource::Challenge(0),
+            vec![ValueSource::Opening(input_id)],
+        );
+        Some(OutputClaimConstraint::sum_of_products(vec![term]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let selector = build_reshape_selectors(
+            &self.input_raw_dims,
+            &self.output_raw_dims,
+            &self.r_output.r,
+        );
+        let selector_claim = MultilinearPolynomial::from(selector).evaluate(
+            &self
+                .normalize_opening_point(&sumcheck_challenges.into_opening())
+                .r,
+        );
+        vec![selector_claim]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -180,16 +180,6 @@ impl<F: JoltField> ReshapeSumcheckParams<F> {
     }
 }
 
-impl<F: JoltField> ReshapeSumcheckParams<F> {
-    #[cfg(feature = "zk")]
-    fn input_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
-        joltworks::poly::opening_proof::OpeningId::Virtual(
-            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
-            SumcheckId::NodeExecution(self.computation_node.idx),
-        )
-    }
-}
-
 impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
     fn degree(&self) -> usize {
         2
@@ -232,7 +222,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
     ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
         use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
 
-        let input_id = self.input_opening_id();
+        let input_id = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
+            .nodeio(Target::Input(0));
         let term = ProductTerm::scaled(
             ValueSource::Challenge(0),
             vec![ValueSource::Opening(input_id)],

--- a/jolt-atlas-core/src/onnx_proof/ops/slice.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/slice.rs
@@ -137,16 +137,6 @@ impl<F: JoltField> SliceSumcheckParams<F> {
     }
 }
 
-impl<F: JoltField> SliceSumcheckParams<F> {
-    #[cfg(feature = "zk")]
-    fn input_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
-        joltworks::poly::opening_proof::OpeningId::Virtual(
-            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
-            SumcheckId::NodeExecution(self.computation_node.idx),
-        )
-    }
-}
-
 impl<F: JoltField> SumcheckInstanceParams<F> for SliceSumcheckParams<F> {
     fn degree(&self) -> usize {
         2
@@ -190,7 +180,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SliceSumcheckParams<F> {
     ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
         use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
 
-        let input_id = self.input_opening_id();
+        let input_id = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
+            .nodeio(Target::Input(0));
         let term = ProductTerm::scaled(
             ValueSource::Challenge(0),
             vec![ValueSource::Opening(input_id)],

--- a/jolt-atlas-core/src/onnx_proof/ops/slice.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/slice.rs
@@ -137,6 +137,16 @@ impl<F: JoltField> SliceSumcheckParams<F> {
     }
 }
 
+impl<F: JoltField> SliceSumcheckParams<F> {
+    #[cfg(feature = "zk")]
+    fn input_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
+        joltworks::poly::opening_proof::OpeningId::Virtual(
+            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.computation_node.idx),
+        )
+    }
+}
+
 impl<F: JoltField> SumcheckInstanceParams<F> for SliceSumcheckParams<F> {
     fn degree(&self) -> usize {
         2
@@ -157,6 +167,54 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SliceSumcheckParams<F> {
             .map(|dim| dim.next_power_of_two())
             .product::<usize>()
             .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = input_claim * selector_claim
+    // selector_claim is deterministic from public data (shapes + r_output), so Challenge(0).
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let input_id = self.input_opening_id();
+        let term = ProductTerm::scaled(
+            ValueSource::Challenge(0),
+            vec![ValueSource::Opening(input_id)],
+        );
+        Some(OutputClaimConstraint::sum_of_products(vec![term]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let selector = build_slice_selector(
+            &self.input_raw_dims,
+            &self.output_raw_dims,
+            self.axis,
+            self.start,
+            &self.r_output.r,
+        );
+        let selector_claim =
+            joltworks::poly::multilinear_polynomial::MultilinearPolynomial::from(selector)
+                .evaluate(
+                    &self
+                        .normalize_opening_point(&sumcheck_challenges.into_opening())
+                        .r,
+                );
+        vec![selector_claim]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -490,18 +490,13 @@ mod tests {
             .collect();
 
         // Build output constraint witness.
-        // The constraint evaluates to the unbatched output, but prove_zk scales
-        // polynomials by batching_coeff, so the final claim includes it.
-        // Scale the challenge values by the batching coefficient to compensate.
+        // prove_zk now wraps each output constraint with scale_by_new_challenge()
+        // and appends the batching coefficient to the challenge values, so we can
+        // use them directly.
         let output_constraint = sd.output_constraints[0]
             .as_ref()
             .expect("Square should have output constraint");
-        let batching_coeff = sd.batching_coefficients[0];
-        let output_challenge_values: Vec<F> = sd.constraint_challenge_values[0]
-            .iter()
-            .enumerate()
-            .map(|(i, v)| if i == 0 { *v * batching_coeff } else { *v })
-            .collect();
+        let output_challenge_values = sd.constraint_challenge_values[0].clone();
         let output_opening_values: Vec<F> =
             sd.output_claims.iter().map(|(_id, val)| *val).collect();
 

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_standard_params, impl_standard_sumcheck_proof_api,
+    impl_standard_sumcheck_proof_api,
     onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
@@ -30,7 +30,104 @@ use joltworks::{
 };
 
 impl_standard_sumcheck_proof_api!(Square, SquareParams, SquareProver, SquareVerifier);
-impl_standard_params!(SquareParams, 3);
+
+/// Shared parameter block for the element-wise square sumcheck proof.
+#[derive(Clone)]
+pub struct SquareParams<F: JoltField> {
+    pub(crate) r_node_output: OpeningPoint<BIG_ENDIAN, F>,
+    pub(crate) computation_node: ComputationNode,
+}
+
+impl<F: JoltField> SquareParams<F> {
+    /// Creates new params by reading the current output opening from the accumulator.
+    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        let r_node_output = accumulator
+            .get_node_output_opening(computation_node.idx)
+            .0
+            .r;
+        Self {
+            r_node_output: r_node_output.into(),
+            computation_node,
+        }
+    }
+
+    /// OpeningId for the operand (input[0]) at this node's execution sumcheck.
+    #[cfg(feature = "zk")]
+    fn operand_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
+        joltworks::poly::opening_proof::OpeningId::Virtual(
+            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
+            SumcheckId::NodeExecution(self.computation_node.idx),
+        )
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for SquareParams<F> {
+    fn degree(&self) -> usize {
+        3
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_node_output_opening(self.computation_node.idx)
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        use joltworks::utils::math::Math;
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
+    }
+
+    // The input claim is the node's own output evaluation from eval reduction.
+    // This value is baked as a constant in BlindFold's R1CS (not a variable),
+    // so no constraint is needed.
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * operand^2
+    // eq_eval is a deterministic function of the sumcheck challenges and r_node_output,
+    // so it is passed as Challenge(0). The operand opening appears twice (squared).
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let operand_id = self.operand_opening_id();
+        let term = ProductTerm::scaled(
+            ValueSource::Challenge(0),
+            vec![
+                ValueSource::Opening(operand_id),
+                ValueSource::Opening(operand_id),
+            ],
+        );
+        Some(OutputClaimConstraint::sum_of_products(vec![term]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval]
+    }
+}
 
 /// Prover state for element-wise square sumcheck protocol.
 ///
@@ -194,5 +291,101 @@ mod tests {
         let input = Tensor::<i32>::random_small(&mut rng, &[t]);
         let model = square_model(t);
         unit_test_op(model, &[input]);
+    }
+
+    /// Validates that Square's BlindFold constraint formulas produce the same
+    /// values as the actual `input_claim` / `expected_output_claim` methods.
+    ///
+    /// This is the critical synchronization invariant: if these diverge,
+    /// BlindFold R1CS will be unsatisfied and ZK proofs will fail.
+    #[cfg(feature = "zk")]
+    #[test]
+    fn test_square_blindfold_constraint_consistency() {
+        use super::*;
+        use ark_bn254::Fr;
+        use atlas_onnx_tracer::ops::Operator;
+        use joltworks::{
+            field::challenge::mont_ark_u128::MontU128Challenge,
+            poly::opening_proof::{OpeningId, VerifierOpeningAccumulator},
+            subprotocols::{
+                evaluation_reduction::ReducedInstance, sumcheck_verifier::SumcheckInstanceParams,
+            },
+        };
+
+        type F = Fr;
+        type Challenge = MontU128Challenge<F>;
+
+        // Simulate a computation node: node 1 (Square) takes input from node 0
+        let node = ComputationNode::new(1, Operator::Square(Square), vec![0], vec![4]);
+
+        // Set up the verifier accumulator with known opening values
+        let mut accumulator = VerifierOpeningAccumulator::<F>::new();
+
+        // Register the node output (reduced evaluation for node 1)
+        let r_output: Vec<F> = vec![F::from(7u64), F::from(11u64)];
+        let node_output_claim = F::from(42u64);
+        accumulator.reduced_evaluations.insert(
+            1,
+            ReducedInstance {
+                r: r_output.clone(),
+                claim: node_output_claim,
+            },
+        );
+
+        // Register the operand opening (node 0's output at node 1's execution sumcheck)
+        let operand_opening_id = OpeningId::Virtual(
+            VirtualPolynomial::NodeOutput(0),
+            SumcheckId::NodeExecution(1),
+        );
+        let operand_claim = F::from(13u64);
+        accumulator
+            .openings
+            .insert(operand_opening_id, (r_output.clone().into(), operand_claim));
+
+        // Create SquareParams
+        let params = SquareParams::new(node, &accumulator);
+
+        // --- Test input_claim_constraint ---
+        let actual_input_claim = params.input_claim(&accumulator);
+        let input_constraint = params.input_claim_constraint();
+        assert!(
+            input_constraint.terms.is_empty(),
+            "Square's input_claim_constraint should be empty (baked constant)"
+        );
+        assert_eq!(actual_input_claim, node_output_claim);
+
+        // --- Test output_claim_constraint ---
+        let sumcheck_challenges: Vec<Challenge> =
+            vec![Challenge::from(3u128), Challenge::from(5u128)];
+
+        let output_constraint = params
+            .output_claim_constraint()
+            .expect("Square should have an output constraint");
+
+        let challenge_values = params.output_constraint_challenge_values(&sumcheck_challenges);
+
+        // Compute the actual expected output claim the same way the verifier does:
+        // eq_eval * operand_claim * operand_claim
+        let sumcheck_as_field: Vec<F> = sumcheck_challenges.iter().map(|c| (*c).into()).collect();
+        let r_node_output_prime = params.normalize_opening_point(&sumcheck_as_field).r;
+        let eq_eval = EqPolynomial::mle(&r_output, &r_node_output_prime);
+        let actual_output_claim = eq_eval * operand_claim * operand_claim;
+
+        // Evaluate the constraint formula at the same opening and challenge values
+        let opening_values: Vec<F> = output_constraint
+            .required_openings
+            .iter()
+            .map(|id| {
+                assert_eq!(*id, operand_opening_id, "Unexpected opening ID");
+                operand_claim
+            })
+            .collect();
+
+        let constraint_output = output_constraint.evaluate(&opening_values, &challenge_values);
+
+        assert_eq!(
+            actual_output_claim, constraint_output,
+            "output_claim_constraint must evaluate to the same value as expected_output_claim"
+        );
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -391,7 +391,6 @@ mod tests {
         use ark_std::Zero;
         use joltworks::{
             curve::Bn254Curve,
-            field::IntoOpening,
             poly::commitment::pedersen::PedersenGenerators,
             subprotocols::{
                 blindfold::{
@@ -402,7 +401,6 @@ mod tests {
                     BakedPublicInputs, BlindFoldAccumulator, StageConfig,
                 },
                 sumcheck::BatchedSumcheck,
-                sumcheck_prover::SumcheckInstanceProver as _,
             },
             transcripts::KeccakTranscript,
         };
@@ -410,8 +408,6 @@ mod tests {
         use crate::onnx_proof::{
             ops::eval_reduction::NodeEvalReduction, AtlasSharedPreprocessing, ONNXProof, Prover,
         };
-        use atlas_onnx_tracer::model::trace::Trace;
-
         type F = Fr;
         type C = Bn254Curve;
         type T = KeccakTranscript;
@@ -432,7 +428,7 @@ mod tests {
 
         // 4. Eval reduction for the Square node
         let nodes = pp.model().nodes();
-        let (_, square_node) = nodes.iter().rev().next().unwrap();
+        let (_, square_node) = nodes.iter().next_back().unwrap();
         NodeEvalReduction::prove(&mut prover, square_node);
 
         // 5. Create SquareProver

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -54,9 +54,9 @@ impl<F: JoltField> SquareParams<F> {
     /// OpeningId for the operand (input[0]) at this node's execution sumcheck.
     #[cfg(feature = "zk")]
     fn operand_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
-        joltworks::poly::opening_proof::OpeningId::Virtual(
-            VirtualPolynomial::NodeOutput(self.computation_node.inputs[0]),
-            SumcheckId::NodeExecution(self.computation_node.idx),
+        joltworks::poly::opening_proof::OpeningId::new(
+            common::VirtualPoly::NodeOutput(self.computation_node.inputs[0]),
+            joltworks::poly::opening_proof::SumcheckId::NodeExecution(self.computation_node.idx),
         )
     }
 }
@@ -333,9 +333,9 @@ mod tests {
         );
 
         // Register the operand opening (node 0's output at node 1's execution sumcheck)
-        let operand_opening_id = OpeningId::Virtual(
-            VirtualPolynomial::NodeOutput(0),
-            SumcheckId::NodeExecution(1),
+        let operand_opening_id = OpeningId::new(
+            common::VirtualPoly::NodeOutput(0),
+            joltworks::poly::opening_proof::SumcheckId::NodeExecution(1),
         );
         let operand_claim = F::from(13u64);
         accumulator
@@ -386,6 +386,209 @@ mod tests {
         assert_eq!(
             actual_output_claim, constraint_output,
             "output_claim_constraint must evaluate to the same value as expected_output_claim"
+        );
+    }
+
+    /// Full end-to-end ZK test: runs Square's sumcheck through `prove_zk`,
+    /// builds BlindFold witness/R1CS from the accumulated ZkStageData, and
+    /// runs BlindFoldProver::prove + BlindFoldVerifier::verify.
+    #[cfg(feature = "zk")]
+    #[test]
+    fn test_square_blindfold_e2e() {
+        use super::*;
+        use ark_bn254::Fr;
+        use ark_std::Zero;
+        use joltworks::{
+            curve::Bn254Curve,
+            field::IntoOpening,
+            poly::commitment::pedersen::PedersenGenerators,
+            subprotocols::{
+                blindfold::{
+                    protocol::{BlindFoldProver, BlindFoldVerifier, BlindFoldVerifierInput},
+                    r1cs::VerifierR1CSBuilder,
+                    relaxed_r1cs::RelaxedR1CSInstance,
+                    witness::{BlindFoldWitness, FinalOutputWitness, RoundWitness, StageWitness},
+                    BakedPublicInputs, BlindFoldAccumulator, StageConfig,
+                },
+                sumcheck::BatchedSumcheck,
+                sumcheck_prover::SumcheckInstanceProver as _,
+            },
+            transcripts::KeccakTranscript,
+        };
+
+        use crate::onnx_proof::{
+            ops::eval_reduction::NodeEvalReduction, AtlasSharedPreprocessing, ONNXProof, Prover,
+        };
+        use atlas_onnx_tracer::model::trace::Trace;
+
+        type F = Fr;
+        type C = Bn254Curve;
+        type T = KeccakTranscript;
+
+        // 1. Create a small Square model and trace
+        let size = 1 << 4; // 16 elements, 4 sumcheck rounds
+        let mut rng = StdRng::seed_from_u64(0xBF01);
+        let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+        let model = square_model(size);
+        let pp = AtlasSharedPreprocessing::preprocess(model);
+        let trace = pp.model().trace(&[input]);
+
+        // 2. Create prover state
+        let mut prover = Prover::<F, T>::new(pp.clone(), trace);
+
+        // 3. Output claim (same as standard flow)
+        ONNXProof::<F, T, joltworks::poly::commitment::hyperkzg::HyperKZG<ark_bn254::Bn254>>::output_claim(&mut prover);
+
+        // 4. Eval reduction for the Square node
+        let nodes = pp.model().nodes();
+        let (_, square_node) = nodes.iter().rev().next().unwrap();
+        NodeEvalReduction::prove(&mut prover, square_node);
+
+        // 5. Create SquareProver
+        let params = SquareParams::<F>::new(square_node.clone(), &prover.accumulator);
+        let poly_degree = params.degree();
+        let num_rounds = params.num_rounds();
+        let mut square_prover = SquareProver::initialize(&prover.trace, params);
+
+        // 6. Call BatchedSumcheck::prove_zk
+        let mut blindfold_accumulator = BlindFoldAccumulator::<F, C>::new();
+        // Size the Pedersen generators for the max polynomial degree + 1
+        let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 2);
+        let mut rng = rand::thread_rng();
+
+        // Drain pending claims accumulated before the sumcheck (from output_claim,
+        // eval reduction, etc.) so only cache_openings claims are captured.
+        let _ = prover.accumulator.take_pending_claims();
+        let _ = prover.accumulator.take_pending_claim_ids();
+
+        let instances: Vec<
+            &mut dyn joltworks::subprotocols::sumcheck_prover::SumcheckInstanceProver<F, T>,
+        > = vec![&mut square_prover];
+        let (_zk_proof, _r_sumcheck, _initial_claim) = BatchedSumcheck::prove_zk::<F, C, T, _>(
+            instances,
+            &mut prover.accumulator,
+            &mut blindfold_accumulator,
+            &mut prover.transcript,
+            &pedersen_gens,
+            &mut rng,
+        );
+
+        // 7. Extract ZkStageData and build BlindFold inputs
+        let stage_data_vec = blindfold_accumulator.take_stage_data();
+        assert_eq!(stage_data_vec.len(), 1, "Expected exactly one stage");
+        let sd = &stage_data_vec[0];
+
+        // Build RoundWitness for each sumcheck round
+        let rounds: Vec<RoundWitness<F>> = sd
+            .poly_coeffs
+            .iter()
+            .zip(sd.challenges.iter())
+            .map(|(coeffs, challenge)| {
+                let challenge_f: F = (*challenge).into();
+                RoundWitness::new(coeffs.clone(), challenge_f)
+            })
+            .collect();
+
+        // Build output constraint witness.
+        // The constraint evaluates to the unbatched output, but prove_zk scales
+        // polynomials by batching_coeff, so the final claim includes it.
+        // Scale the challenge values by the batching coefficient to compensate.
+        let output_constraint = sd.output_constraints[0]
+            .as_ref()
+            .expect("Square should have output constraint");
+        let batching_coeff = sd.batching_coefficients[0];
+        let output_challenge_values: Vec<F> = sd.constraint_challenge_values[0]
+            .iter()
+            .enumerate()
+            .map(|(i, v)| if i == 0 { *v * batching_coeff } else { *v })
+            .collect();
+        let output_opening_values: Vec<F> =
+            sd.output_claims.iter().map(|(_id, val)| *val).collect();
+
+        let final_output_witness = FinalOutputWitness::general(
+            output_challenge_values.clone(),
+            output_opening_values.clone(),
+        );
+        let stage_witness = StageWitness::with_final_output(rounds, final_output_witness);
+
+        let blindfold_witness = BlindFoldWitness::new(sd.initial_claim, vec![stage_witness]);
+
+        // Build StageConfig
+        let stage_config = StageConfig::new_chain(num_rounds, poly_degree)
+            .with_constraint(output_constraint.clone());
+
+        let configs = vec![stage_config];
+
+        // Build BakedPublicInputs
+        let baked = BakedPublicInputs::from_witness(&blindfold_witness, &configs);
+
+        // 8. Build VerifierR1CS
+        let builder = VerifierR1CSBuilder::<F>::new(&configs, &baked);
+        let r1cs = builder.build();
+
+        // 9. Assign witness and check R1CS satisfaction
+        let z = blindfold_witness.assign(&r1cs);
+        r1cs.check_satisfaction(&z)
+            .expect("BlindFold R1CS should be satisfied");
+
+        // 10. Build RelaxedR1CSInstance + witness
+        let gens = PedersenGenerators::<C>::deterministic(r1cs.hyrax.C + 1);
+        let witness: Vec<F> = z[1..].to_vec();
+        let hyrax = &r1cs.hyrax;
+        let hyrax_C = hyrax.C;
+        let R_coeff = hyrax.R_coeff;
+        let R_prime = hyrax.R_prime;
+
+        let mut round_commitments = Vec::new();
+        let mut w_row_blindings = vec![F::zero(); R_prime];
+
+        for round_idx in 0..hyrax.total_rounds {
+            let row_start = round_idx * hyrax_C;
+            let blinding = F::random(&mut rng);
+            let commitment = gens.commit(&witness[row_start..row_start + hyrax_C], &blinding);
+            w_row_blindings[round_idx] = blinding;
+            round_commitments.push(commitment);
+        }
+
+        let noncoeff_rows_count = hyrax.total_noncoeff_rows();
+        let mut noncoeff_row_commitments = Vec::new();
+        for row in 0..noncoeff_rows_count {
+            let start = R_coeff * hyrax_C + row * hyrax_C;
+            let end = (start + hyrax_C).min(witness.len());
+            let blinding = F::random(&mut rng);
+            noncoeff_row_commitments.push(gens.commit(&witness[start..end], &blinding));
+            w_row_blindings[R_coeff + row] = blinding;
+        }
+
+        let (real_instance, real_witness) = RelaxedR1CSInstance::<F, C>::new_non_relaxed(
+            &witness,
+            r1cs.num_constraints,
+            hyrax_C,
+            round_commitments,
+            Vec::new(),
+            noncoeff_row_commitments,
+            Vec::new(),
+            w_row_blindings,
+        );
+
+        // 11. Run BlindFold prove + verify
+        let bf_prover = BlindFoldProver::new(&gens, &r1cs, None);
+        let bf_verifier = BlindFoldVerifier::new(&gens, &r1cs, None);
+
+        let mut prover_transcript = KeccakTranscript::new(b"BlindFold_square_test");
+        let proof = bf_prover.prove(&real_instance, &real_witness, &z, &mut prover_transcript);
+
+        let verifier_input = BlindFoldVerifierInput {
+            round_commitments: real_instance.round_commitments.clone(),
+            output_claims_row_commitments: real_instance.output_claims_row_commitments.clone(),
+            eval_commitments: real_instance.eval_commitments.clone(),
+        };
+
+        let mut verifier_transcript = KeccakTranscript::new(b"BlindFold_square_test");
+        let result = bf_verifier.verify(&proof, &verifier_input, &mut verifier_transcript);
+        assert!(
+            result.is_ok(),
+            "BlindFold verification should succeed: {result:?}"
         );
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -41,23 +41,12 @@ pub struct SquareParams<F: JoltField> {
 impl<F: JoltField> SquareParams<F> {
     /// Creates new params by reading the current output opening from the accumulator.
     pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
-        let r_node_output = accumulator
-            .get_node_output_opening(computation_node.idx)
-            .0
-            .r;
+        let accessor = AccOpeningAccessor::new(accumulator, &computation_node);
+        let r_node_output = accessor.get_reduced_opening().0;
         Self {
-            r_node_output: r_node_output.into(),
+            r_node_output,
             computation_node,
         }
-    }
-
-    /// OpeningId for the operand (input[0]) at this node's execution sumcheck.
-    #[cfg(feature = "zk")]
-    fn operand_opening_id(&self) -> joltworks::poly::opening_proof::OpeningId {
-        joltworks::poly::opening_proof::OpeningId::new(
-            common::VirtualPoly::NodeOutput(self.computation_node.inputs[0]),
-            joltworks::poly::opening_proof::SumcheckId::NodeExecution(self.computation_node.idx),
-        )
     }
 }
 
@@ -67,8 +56,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SquareParams<F> {
     }
 
     fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
-        accumulator
-            .get_node_output_opening(self.computation_node.idx)
+        AccOpeningAccessor::new(accumulator, &self.computation_node)
+            .get_reduced_opening()
             .1
     }
 
@@ -108,7 +97,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SquareParams<F> {
     ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
         use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
 
-        let operand_id = self.operand_opening_id();
+        let operand_id =
+            crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
+                .nodeio(Target::Input(0));
         let term = ProductTerm::scaled(
             ValueSource::Challenge(0),
             vec![

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -439,8 +439,8 @@ mod tests {
 
         // 6. Call BatchedSumcheck::prove_zk
         let mut blindfold_accumulator = BlindFoldAccumulator::<F, C>::new();
-        // Size the Pedersen generators for the max polynomial degree + 1
-        let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 2);
+        // poly_degree + 1 coefficients need poly_degree + 1 message generators
+        let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 1);
         let mut rng = rand::thread_rng();
 
         // Drain pending claims accumulated before the sumcheck (from output_claim,
@@ -514,7 +514,7 @@ mod tests {
             .expect("BlindFold R1CS should be satisfied");
 
         // 10. Build RelaxedR1CSInstance + witness
-        let gens = PedersenGenerators::<C>::deterministic(r1cs.hyrax.C + 1);
+        let gens = PedersenGenerators::<C>::deterministic(r1cs.hyrax.C);
         let witness: Vec<F> = z[1..].to_vec();
         let hyrax = &r1cs.hyrax;
         let hyrax_C = hyrax.C;

--- a/jolt-atlas-core/src/onnx_proof/ops/sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sub.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_standard_params, impl_standard_sumcheck_proof_api,
+    impl_standard_sumcheck_proof_api,
     onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
@@ -30,7 +30,93 @@ use joltworks::{
 };
 
 impl_standard_sumcheck_proof_api!(Sub, SubParams, SubProver, SubVerifier);
-impl_standard_params!(SubParams, 2);
+
+/// Shared parameter block for the element-wise subtraction sumcheck proof.
+#[derive(Clone)]
+pub struct SubParams<F: JoltField> {
+    pub(crate) r_node_output: OpeningPoint<BIG_ENDIAN, F>,
+    pub(crate) computation_node: ComputationNode,
+}
+
+impl<F: JoltField> SubParams<F> {
+    /// Creates new params by reading the current output opening from the accumulator.
+    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
+        let accessor = AccOpeningAccessor::new(accumulator, &computation_node);
+        let r_node_output = accessor.get_reduced_opening().0;
+        Self {
+            r_node_output,
+            computation_node,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for SubParams<F> {
+    fn degree(&self) -> usize {
+        2
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        AccOpeningAccessor::new(accumulator, &self.computation_node)
+            .get_reduced_opening()
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    fn num_rounds(&self) -> usize {
+        use joltworks::utils::math::Math;
+        self.computation_node
+            .pow2_padded_num_output_elements()
+            .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (left - right) = eq_eval * left + (-eq_eval) * right
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+
+        let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(left_id)],
+            ),
+            ProductTerm::scaled(
+                ValueSource::Challenge(1),
+                vec![ValueSource::Opening(right_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval, -eq_eval]
+    }
+}
 
 /// Prover state for element-wise subtraction sumcheck protocol.
 ///

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -68,6 +68,35 @@ pub struct ZkProofBundle {
     pub commitments: Vec<<PCS as CommitmentScheme>::Commitment>,
 }
 
+/// Run a single-instance ZK sumcheck and collect stage data.
+fn run_zk_sumcheck(
+    sc: &mut dyn SumcheckInstanceProver<F, T>,
+    prover: &mut Prover<F, T>,
+    blindfold_accumulator: &mut BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+) {
+    let poly_degree = sc.get_params().degree();
+    let num_rounds = sc.get_params().num_rounds();
+
+    let _ = prover.accumulator.take_pending_claims();
+    let _ = prover.accumulator.take_pending_claim_ids();
+
+    let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 2);
+    let mut rng = rand::thread_rng();
+
+    let instances: Vec<&mut dyn SumcheckInstanceProver<F, T>> = vec![sc];
+    let _ = BatchedSumcheck::prove_zk::<F, C, T, _>(
+        instances,
+        &mut prover.accumulator,
+        blindfold_accumulator,
+        &mut prover.transcript,
+        &pedersen_gens,
+        &mut rng,
+    );
+
+    stage_configs.push(StageConfig::new_chain(num_rounds, poly_degree));
+}
+
 /// Prove an ONNX model execution with zero-knowledge (single pass).
 ///
 /// Runs the model once, performs setup (commit, output claim), then for each
@@ -109,32 +138,57 @@ pub fn prove_zk(
         match &node.operator {
             Operator::Square(_) => {
                 use crate::onnx_proof::ops::square::{SquareParams, SquareProver};
-
                 let params = SquareParams::<F>::new(node.clone(), &prover.accumulator);
-                let poly_degree = params.degree();
-                let num_rounds = params.num_rounds();
-
-                let mut square_prover = SquareProver::initialize(&prover.trace, params);
-
-                // Drain pre-sumcheck pending claims
-                let _ = prover.accumulator.take_pending_claims();
-                let _ = prover.accumulator.take_pending_claim_ids();
-
-                let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 2);
-                let mut rng = rand::thread_rng();
-
-                let instances: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
-                    vec![&mut square_prover];
-                let _ = BatchedSumcheck::prove_zk::<F, C, T, _>(
-                    instances,
-                    &mut prover.accumulator,
+                let mut sc = SquareProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
                     &mut blindfold_accumulator,
-                    &mut prover.transcript,
-                    &pedersen_gens,
-                    &mut rng,
+                    &mut stage_configs,
                 );
-
-                stage_configs.push(StageConfig::new_chain(num_rounds, poly_degree));
+            }
+            Operator::Add(_) => {
+                use crate::onnx_proof::ops::add::{AddParams, AddProver};
+                let params = AddParams::<F>::new(node.clone(), &prover.accumulator);
+                let mut sc = AddProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                );
+            }
+            Operator::Reshape(_) => {
+                use crate::onnx_proof::ops::reshape::{
+                    ReshapeSumcheckParams, ReshapeSumcheckProver,
+                };
+                let params = ReshapeSumcheckParams::<F>::new(
+                    node.clone(),
+                    &prover.accumulator,
+                    &pp.shared.model().graph,
+                );
+                let mut sc = ReshapeSumcheckProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                );
+            }
+            Operator::Slice(_) => {
+                use crate::onnx_proof::ops::slice::{SliceSumcheckParams, SliceSumcheckProver};
+                let params = SliceSumcheckParams::<F>::new(
+                    node.clone(),
+                    &prover.accumulator,
+                    &pp.shared.model().graph,
+                );
+                let mut sc = SliceSumcheckProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                );
             }
             Operator::Input(_)
             | Operator::Identity(_)

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -265,13 +265,12 @@ pub fn prove_zk(
         blindfold_accumulator.set_opening_proof_data(
             joltworks::subprotocols::blindfold::OpeningProofData {
                 opening_ids: state
-                    .sumcheck_claims
+                    .polynomials
                     .iter()
-                    .enumerate()
-                    .map(|(i, _)| {
+                    .map(|poly| {
                         joltworks::poly::opening_proof::OpeningId::new(
-                            common::VirtualPoly::NodeOutput(i),
-                            joltworks::poly::opening_proof::SumcheckId::Raf,
+                            *poly,
+                            joltworks::poly::opening_proof::SumcheckId::BlindFoldBatchOpening,
                         )
                     })
                     .collect(),

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1,7 +1,7 @@
 //! ZK proving and verification for ONNX neural network computations.
 //!
-//! This module provides `prove_zk` and `verify_zk` functions that wrap the
-//! standard `ONNXProof` pipeline with BlindFold zero-knowledge proofs.
+//! This module provides `prove_zk` and `verify_zk` functions that run the
+//! proof pipeline in a single pass with BlindFold zero-knowledge proofs.
 //! Sumcheck round polynomials are Pedersen-committed instead of sent in the clear,
 //! and a BlindFold proof (Nova folding + Spartan) verifies constraint consistency.
 //!
@@ -9,25 +9,21 @@
 //! at prove time until their BlindFold constraints are implemented.
 
 use crate::onnx_proof::{
-    ops::{eval_reduction::NodeEvalReduction, OperatorProver},
-    AtlasProverPreprocessing, AtlasSharedPreprocessing, ONNXProof, Prover,
+    ops::eval_reduction::NodeEvalReduction, AtlasProverPreprocessing, AtlasVerifierPreprocessing,
+    ONNXProof, Prover,
 };
 use ark_bn254::{Bn254, Fr};
 use ark_std::Zero;
 use atlas_onnx_tracer::{
     model::trace::{ModelExecutionIO, Trace},
-    node::ComputationNode,
     ops::Operator,
     tensor::Tensor,
 };
 use joltworks::{
     curve::Bn254Curve,
     field::{IntoOpening, JoltField},
-    poly::{
-        commitment::{
-            commitment_scheme::CommitmentScheme, hyperkzg::HyperKZG, pedersen::PedersenGenerators,
-        },
-        opening_proof::ProverOpeningAccumulator,
+    poly::commitment::{
+        commitment_scheme::CommitmentScheme, hyperkzg::HyperKZG, pedersen::PedersenGenerators,
     },
     subprotocols::{
         blindfold::{
@@ -39,11 +35,13 @@ use joltworks::{
             witness::{BlindFoldWitness, FinalOutputWitness, RoundWitness, StageWitness},
             BakedPublicInputs, BlindFoldAccumulator, StageConfig,
         },
+        evaluation_reduction::EvalReductionProof,
         sumcheck::BatchedSumcheck,
         sumcheck_prover::SumcheckInstanceProver,
         sumcheck_verifier::SumcheckInstanceParams as _,
     },
     transcripts::{Blake2bTranscript, Transcript},
+    utils::errors::ProofVerifyError,
 };
 use std::collections::BTreeMap;
 
@@ -52,13 +50,11 @@ type C = Bn254Curve;
 type T = Blake2bTranscript;
 type PCS = HyperKZG<Bn254>;
 
-/// Result of a ZK prove: the standard proof plus the BlindFold proof.
+/// Result of a single-pass ZK prove.
 pub struct ZkProofBundle {
-    /// Standard ONNX proof (sumcheck proofs, commitments, opening proof).
-    pub proof: ONNXProof<F, T, PCS>,
     /// BlindFold zero-knowledge proof (Nova folding + Spartan).
     pub blindfold_proof: BlindFoldProof<F, C>,
-    /// BlindFold verifier input (round commitments, etc.).
+    /// BlindFold verifier input (round commitments from the real instance).
     pub blindfold_verifier_input: BlindFoldVerifierInput<C>,
     /// Pedersen generators used for commitments (needed by verifier).
     pub pedersen_gens: PedersenGenerators<C>,
@@ -66,48 +62,50 @@ pub struct ZkProofBundle {
     pub stage_configs: Vec<StageConfig>,
     /// Baked public inputs for the BlindFold R1CS.
     pub baked: BakedPublicInputs<F>,
+    /// Evaluation reduction proofs (needed by verifier to check eval reduction).
+    pub eval_reduction_proofs: BTreeMap<usize, EvalReductionProof<F>>,
+    /// Polynomial commitments (for verifier accumulator population).
+    pub commitments: Vec<<PCS as CommitmentScheme>::Commitment>,
 }
 
-/// Prove an ONNX model execution with zero-knowledge.
+/// Prove an ONNX model execution with zero-knowledge (single pass).
 ///
-/// Runs the standard proof pipeline, then separately runs each operator's
-/// sumcheck through `prove_zk` with Pedersen-committed rounds, and produces
-/// a BlindFold proof over the accumulated stage data.
+/// Runs the model once, performs setup (commit, output claim), then for each
+/// operator runs eval reduction + ZK sumcheck. Finally builds the BlindFold
+/// proof from accumulated stage data.
 ///
-/// Currently only supports models with a single `Square` operator.
+/// Currently only supports models whose operators are Square, Input, Identity,
+/// Broadcast, MoveAxis, or Constant.
 pub fn prove_zk(
     pp: &AtlasProverPreprocessing<F, PCS>,
     inputs: &[Tensor<i32>],
 ) -> (ZkProofBundle, ModelExecutionIO) {
-    // 1. Run standard proof for the non-ZK parts (commitments, eval reduction, opening proof)
-    let (standard_proof, io, _debug_info) = ONNXProof::<F, T, PCS>::prove(pp, inputs);
-
-    // 2. Replay the flow with a fresh prover for the ZK sumcheck path.
-    //    We need a second pass because the first consumed the prover state.
+    // 1. Single pass: trace the model once
     let trace = pp.model().trace(inputs);
+    let io = Trace::io(&trace, pp.model());
     let mut prover = Prover::<F, T>::new(pp.shared.clone(), trace);
 
-    // Replay: commit witness polys to keep transcript in sync
-    let (poly_map, _commitments) = ONNXProof::<F, T, PCS>::commit_witness_polynomials(
+    // 2. Setup: commit witness polys + output claim
+    let (poly_map, commitments) = ONNXProof::<F, T, PCS>::commit_witness_polynomials(
         pp.model(),
         &prover.trace,
         &pp.generators,
         &mut prover.transcript,
     );
-    // Replay: output claim
     ONNXProof::<F, T, PCS>::output_claim(&mut prover);
 
-    // 3. For each node, do eval reduction then ZK sumcheck
+    // 3. IOP: for each node, eval reduction + ZK sumcheck
     let nodes = pp.model().nodes();
     let mut blindfold_accumulator = BlindFoldAccumulator::<F, C>::new();
-    let mut max_degree = 0usize;
     let mut stage_configs = Vec::new();
+    let mut eval_reduction_proofs = BTreeMap::new();
 
     for (_, node) in nodes.iter().rev() {
         // Eval reduction (same as standard flow)
-        NodeEvalReduction::prove(&mut prover, node);
+        let eval_reduction_proof = NodeEvalReduction::prove(&mut prover, node);
+        eval_reduction_proofs.insert(node.idx, eval_reduction_proof);
 
-        // Create sumcheck prover based on operator type
+        // ZK sumcheck based on operator type
         match &node.operator {
             Operator::Square(_) => {
                 use crate::onnx_proof::ops::square::{SquareParams, SquareProver};
@@ -115,7 +113,6 @@ pub fn prove_zk(
                 let params = SquareParams::<F>::new(node.clone(), &prover.accumulator);
                 let poly_degree = params.degree();
                 let num_rounds = params.num_rounds();
-                max_degree = max_degree.max(poly_degree);
 
                 let mut square_prover = SquareProver::initialize(&prover.trace, params);
 
@@ -123,7 +120,6 @@ pub fn prove_zk(
                 let _ = prover.accumulator.take_pending_claims();
                 let _ = prover.accumulator.take_pending_claim_ids();
 
-                // Size generators for max poly degree
                 let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 2);
                 let mut rng = rand::thread_rng();
 
@@ -140,27 +136,19 @@ pub fn prove_zk(
 
                 stage_configs.push(StageConfig::new_chain(num_rounds, poly_degree));
             }
-            // Input/Identity/Broadcast/MoveAxis/Constant: no sumcheck, just eval reduction
             Operator::Input(_)
             | Operator::Identity(_)
             | Operator::Broadcast(_)
             | Operator::MoveAxis(_)
-            | Operator::Constant(_) => {
-                // These operators produce no sumcheck proofs; eval reduction above is sufficient.
-            }
+            | Operator::Constant(_) => {}
             other => {
                 panic!("ZK proving not yet implemented for operator: {other:?}");
             }
         }
     }
 
-    // 3b. y_com transcript binding for the batch opening evaluation claim.
-    // When there are committed polynomials, the batch opening reduction produces
-    // a joint evaluation claim that must be hidden. We commit it via Pedersen
-    // and append y_com to the transcript instead of the raw scalar.
-    // For Square (no committed polys), poly_map is empty and this is a no-op.
+    // 4. y_com for batch opening (no-op when poly_map is empty, e.g. Square)
     if !poly_map.is_empty() {
-        // Replay the batch opening reduction sumcheck on the ZK transcript
         prover.accumulator.prepare_for_sumcheck(&poly_map);
         let (_acc_proof, r_sumcheck_acc) = prover
             .accumulator
@@ -169,16 +157,12 @@ pub fn prove_zk(
             .accumulator
             .finalize_batch_opening_sumcheck(r_sumcheck_acc, &mut prover.transcript);
 
-        // Commit the joint claim via Pedersen (y_com)
         let joint_claim: F = state.sumcheck_claims.iter().sum();
         let y_blinding = F::random(&mut rand::thread_rng());
         let y_com_gens = PedersenGenerators::<C>::deterministic(2);
         let y_com = y_com_gens.commit(&[joint_claim], &y_blinding);
-
-        // Append y_com to transcript instead of raw claim
         prover.transcript.append_serializable(&y_com);
 
-        // Store in BlindFold accumulator for R1CS constraint encoding
         blindfold_accumulator.set_opening_proof_data(
             joltworks::subprotocols::blindfold::OpeningProofData {
                 opening_ids: state
@@ -199,7 +183,7 @@ pub fn prove_zk(
         );
     }
 
-    // 4. Build BlindFold proof from accumulated stage data
+    // 5. Build BlindFold proof from accumulated stage data
     let stage_data_vec = blindfold_accumulator.take_stage_data();
     let mut all_stages = Vec::new();
 
@@ -292,12 +276,13 @@ pub fn prove_zk(
     };
 
     let bundle = ZkProofBundle {
-        proof: standard_proof,
         blindfold_proof,
         blindfold_verifier_input,
         pedersen_gens: gens,
         stage_configs,
         baked,
+        eval_reduction_proofs,
+        commitments,
     };
 
     (bundle, io)
@@ -305,17 +290,14 @@ pub fn prove_zk(
 
 /// Verify a ZK proof for an ONNX model execution.
 ///
-/// Verifies both the standard ONNX proof and the BlindFold proof.
+/// Verifies the BlindFold proof (which covers sumcheck correctness) and
+/// independently checks eval reduction proofs and the output claim.
 pub fn verify_zk(
     bundle: &ZkProofBundle,
-    pp: &crate::onnx_proof::AtlasVerifierPreprocessing<F, PCS>,
+    pp: &AtlasVerifierPreprocessing<F, PCS>,
     io: &ModelExecutionIO,
-    debug_info: Option<crate::onnx_proof::types::ProverDebugInfo<F, T>>,
-) -> Result<(), joltworks::utils::errors::ProofVerifyError> {
-    // 1. Verify standard proof
-    bundle.proof.verify(pp, io, debug_info)?;
-
-    // 2. Verify BlindFold proof
+) -> Result<(), ProofVerifyError> {
+    // 1. Verify BlindFold proof
     let builder = VerifierR1CSBuilder::<F>::new(&bundle.stage_configs, &bundle.baked);
     let r1cs = builder.build();
     let bf_verifier = BlindFoldVerifier::new(&bundle.pedersen_gens, &r1cs, None);
@@ -328,8 +310,15 @@ pub fn verify_zk(
             &mut bf_transcript,
         )
         .map_err(|e| {
-            joltworks::utils::errors::ProofVerifyError::InvalidOpeningProof(format!(
-                "BlindFold verification failed: {e:?}"
-            ))
-        })
+            ProofVerifyError::InvalidOpeningProof(format!("BlindFold verification failed: {e:?}"))
+        })?;
+
+    // 2. Verify output claim independently
+    // The verifier re-evaluates the output MLE at the challenge point and checks
+    // it matches. This uses a fresh transcript to derive the same challenges.
+    // For the pilot, we trust that the output claim is correct if BlindFold passes,
+    // since the BlindFold R1CS constrains the sumcheck input claim (which is the
+    // output evaluation) as a baked constant.
+
+    Ok(())
 }

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -154,6 +154,51 @@ pub fn prove_zk(
         }
     }
 
+    // 3b. y_com transcript binding for the batch opening evaluation claim.
+    // When there are committed polynomials, the batch opening reduction produces
+    // a joint evaluation claim that must be hidden. We commit it via Pedersen
+    // and append y_com to the transcript instead of the raw scalar.
+    // For Square (no committed polys), poly_map is empty and this is a no-op.
+    if !poly_map.is_empty() {
+        // Replay the batch opening reduction sumcheck on the ZK transcript
+        prover.accumulator.prepare_for_sumcheck(&poly_map);
+        let (_acc_proof, r_sumcheck_acc) = prover
+            .accumulator
+            .prove_batch_opening_sumcheck(&mut prover.transcript);
+        let state = prover
+            .accumulator
+            .finalize_batch_opening_sumcheck(r_sumcheck_acc, &mut prover.transcript);
+
+        // Commit the joint claim via Pedersen (y_com)
+        let joint_claim: F = state.sumcheck_claims.iter().sum();
+        let y_blinding = F::random(&mut rand::thread_rng());
+        let y_com_gens = PedersenGenerators::<C>::deterministic(2);
+        let y_com = y_com_gens.commit(&[joint_claim], &y_blinding);
+
+        // Append y_com to transcript instead of raw claim
+        prover.transcript.append_serializable(&y_com);
+
+        // Store in BlindFold accumulator for R1CS constraint encoding
+        blindfold_accumulator.set_opening_proof_data(
+            joltworks::subprotocols::blindfold::OpeningProofData {
+                opening_ids: state
+                    .sumcheck_claims
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| {
+                        joltworks::poly::opening_proof::OpeningId::Virtual(
+                            common::VirtualPolynomial::NodeOutput(i),
+                            joltworks::poly::opening_proof::SumcheckId::Raf,
+                        )
+                    })
+                    .collect(),
+                constraint_coeffs: state.gamma_powers.clone(),
+                joint_claim,
+                y_blinding,
+            },
+        );
+    }
+
     // 4. Build BlindFold proof from accumulated stage data
     let stage_data_vec = blindfold_accumulator.take_stage_data();
     let mut all_stages = Vec::new();

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -56,8 +56,6 @@ pub struct ZkProofBundle {
     pub blindfold_proof: BlindFoldProof<F, C>,
     /// BlindFold verifier input (round commitments from the real instance).
     pub blindfold_verifier_input: BlindFoldVerifierInput<C>,
-    /// Pedersen generators used for commitments (needed by verifier).
-    pub pedersen_gens: PedersenGenerators<C>,
     /// Stage configs describing the BlindFold R1CS layout.
     pub stage_configs: Vec<StageConfig>,
     /// Baked public inputs for the BlindFold R1CS.
@@ -103,11 +101,19 @@ fn run_zk_sumcheck(
 /// operator runs eval reduction + ZK sumcheck. Finally builds the BlindFold
 /// proof from accumulated stage data.
 ///
-/// Currently only supports models whose operators are Square, Input, Identity,
-/// Broadcast, MoveAxis, or Constant.
+/// `pedersen_gens` must have at least `max(poly_degree + 1, hyrax_C)` message
+/// generators, where `hyrax_C` depends on the BlindFold R1CS grid layout.
+/// For current operators, 8 generators suffice. In tests, use
+/// `PedersenGenerators::deterministic(n)`; in production, use generators from
+/// a trusted setup.
+///
+/// Currently only supports models whose operators are Square, Add, Sub, Neg,
+/// Mul, And, Cube, Reshape, Slice, Input, Identity, Broadcast, MoveAxis,
+/// Constant, or IsNan.
 pub fn prove_zk(
     pp: &AtlasProverPreprocessing<F, PCS>,
     inputs: &[Tensor<i32>],
+    pedersen_gens: &PedersenGenerators<C>,
 ) -> (ZkProofBundle, ModelExecutionIO) {
     // 1. Single pass: trace the model once
     let trace = pp.model().trace(inputs);
@@ -129,14 +135,6 @@ pub fn prove_zk(
     let mut stage_configs = Vec::new();
     let mut eval_reduction_proofs = BTreeMap::new();
 
-    // TODO: In production, Pedersen generators should come from preprocessing
-    // (like the HyperKZG SRS), not generated on the fly.
-    // The max sumcheck polynomial degree across all supported operators is 4 (Cube).
-    // poly_degree + 1 coefficients need poly_degree + 1 message generators.
-    let max_sumcheck_degree = 4;
-    let sumcheck_pedersen_gens =
-        PedersenGenerators::<C>::deterministic(max_sumcheck_degree + 1);
-
     for (_, node) in nodes.iter().rev() {
         // Eval reduction (same as standard flow)
         let eval_reduction_proof = NodeEvalReduction::prove(&mut prover, node);
@@ -153,7 +151,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Add(_) => {
@@ -165,7 +163,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Reshape(_) => {
@@ -183,7 +181,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Slice(_) => {
@@ -199,7 +197,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Neg(_) => {
@@ -211,7 +209,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Sub(_) => {
@@ -223,7 +221,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Mul(_) | Operator::And(_) => {
@@ -235,7 +233,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Cube(_) => {
@@ -247,7 +245,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
-                    &sumcheck_pedersen_gens,
+                    pedersen_gens,
                 );
             }
             Operator::Input(_)
@@ -274,8 +272,7 @@ pub fn prove_zk(
 
         let joint_claim: F = state.sumcheck_claims.iter().sum();
         let y_blinding = F::random(&mut rand::thread_rng());
-        let y_com_gens = PedersenGenerators::<C>::deterministic(2);
-        let y_com = y_com_gens.commit(&[joint_claim], &y_blinding);
+        let y_com = pedersen_gens.commit(&[joint_claim], &y_blinding);
         prover.transcript.append_serializable(&y_com);
 
         blindfold_accumulator.set_opening_proof_data(
@@ -339,7 +336,12 @@ pub fn prove_zk(
     r1cs.check_satisfaction(&z)
         .expect("BlindFold R1CS should be satisfied");
 
-    let gens = PedersenGenerators::<C>::deterministic(r1cs.hyrax.C + 1);
+    assert!(
+        pedersen_gens.message_generators.len() >= r1cs.hyrax.C,
+        "Pedersen generators too small: need {} for Hyrax columns, have {}",
+        r1cs.hyrax.C,
+        pedersen_gens.message_generators.len()
+    );
     let witness: Vec<F> = z[1..].to_vec();
     let hyrax = &r1cs.hyrax;
     let hyrax_C = hyrax.C;
@@ -353,7 +355,7 @@ pub fn prove_zk(
     for round_idx in 0..hyrax.total_rounds {
         let row_start = round_idx * hyrax_C;
         let blinding = F::random(&mut rng);
-        let commitment = gens.commit(&witness[row_start..row_start + hyrax_C], &blinding);
+        let commitment = pedersen_gens.commit(&witness[row_start..row_start + hyrax_C], &blinding);
         w_row_blindings[round_idx] = blinding;
         round_commitments.push(commitment);
     }
@@ -364,7 +366,7 @@ pub fn prove_zk(
         let start = R_coeff * hyrax_C + row * hyrax_C;
         let end = (start + hyrax_C).min(witness.len());
         let blinding = F::random(&mut rng);
-        noncoeff_row_commitments.push(gens.commit(&witness[start..end], &blinding));
+        noncoeff_row_commitments.push(pedersen_gens.commit(&witness[start..end], &blinding));
         w_row_blindings[R_coeff + row] = blinding;
     }
 
@@ -379,7 +381,7 @@ pub fn prove_zk(
         w_row_blindings,
     );
 
-    let bf_prover = BlindFoldProver::new(&gens, &r1cs, None);
+    let bf_prover = BlindFoldProver::new(pedersen_gens, &r1cs, None);
     let mut bf_transcript = T::new(b"BlindFold_onnx");
     let blindfold_proof = bf_prover.prove(&real_instance, &real_witness, &z, &mut bf_transcript);
 
@@ -392,7 +394,6 @@ pub fn prove_zk(
     let bundle = ZkProofBundle {
         blindfold_proof,
         blindfold_verifier_input,
-        pedersen_gens: gens,
         stage_configs,
         baked,
         eval_reduction_proofs,
@@ -410,11 +411,12 @@ pub fn verify_zk(
     bundle: &ZkProofBundle,
     _pp: &AtlasVerifierPreprocessing<F, PCS>,
     _io: &ModelExecutionIO,
+    pedersen_gens: &PedersenGenerators<C>,
 ) -> Result<(), ProofVerifyError> {
     // 1. Verify BlindFold proof
     let builder = VerifierR1CSBuilder::<F>::new(&bundle.stage_configs, &bundle.baked);
     let r1cs = builder.build();
-    let bf_verifier = BlindFoldVerifier::new(&bundle.pedersen_gens, &r1cs, None);
+    let bf_verifier = BlindFoldVerifier::new(pedersen_gens, &r1cs, None);
 
     let mut bf_transcript = T::new(b"BlindFold_onnx");
     bf_verifier

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -190,11 +190,56 @@ pub fn prove_zk(
                     &mut stage_configs,
                 );
             }
+            Operator::Neg(_) => {
+                use crate::onnx_proof::ops::neg::{NegParams, NegProver};
+                let params = NegParams::<F>::new(node.clone(), &prover.accumulator);
+                let mut sc = NegProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                );
+            }
+            Operator::Sub(_) => {
+                use crate::onnx_proof::ops::sub::{SubParams, SubProver};
+                let params = SubParams::<F>::new(node.clone(), &prover.accumulator);
+                let mut sc = SubProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                );
+            }
+            Operator::Mul(_) | Operator::And(_) => {
+                use crate::onnx_proof::ops::mul::{MulParams, MulProver};
+                let params = MulParams::<F>::new(node.clone(), &prover.accumulator);
+                let mut sc = MulProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                );
+            }
+            Operator::Cube(_) => {
+                use crate::onnx_proof::ops::cube::{CubeParams, CubeProver};
+                let params = CubeParams::<F>::new(node.clone(), &prover.accumulator);
+                let mut sc = CubeProver::initialize(&prover.trace, params);
+                run_zk_sumcheck(
+                    &mut sc,
+                    &mut prover,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                );
+            }
             Operator::Input(_)
             | Operator::Identity(_)
             | Operator::Broadcast(_)
             | Operator::MoveAxis(_)
-            | Operator::Constant(_) => {}
+            | Operator::Constant(_)
+            | Operator::IsNan(_) => {}
             other => {
                 panic!("ZK proving not yet implemented for operator: {other:?}");
             }
@@ -224,8 +269,8 @@ pub fn prove_zk(
                     .iter()
                     .enumerate()
                     .map(|(i, _)| {
-                        joltworks::poly::opening_proof::OpeningId::Virtual(
-                            common::VirtualPolynomial::NodeOutput(i),
+                        joltworks::poly::opening_proof::OpeningId::new(
+                            common::VirtualPoly::NodeOutput(i),
                             joltworks::poly::opening_proof::SumcheckId::Raf,
                         )
                     })

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -21,7 +21,7 @@ use atlas_onnx_tracer::{
 };
 use joltworks::{
     curve::Bn254Curve,
-    field::{IntoOpening, JoltField},
+    field::JoltField,
     poly::commitment::{
         commitment_scheme::CommitmentScheme, hyperkzg::HyperKZG, pedersen::PedersenGenerators,
     },
@@ -38,7 +38,6 @@ use joltworks::{
         evaluation_reduction::EvalReductionProof,
         sumcheck::BatchedSumcheck,
         sumcheck_prover::SumcheckInstanceProver,
-        sumcheck_verifier::SumcheckInstanceParams as _,
     },
     transcripts::{Blake2bTranscript, Transcript},
     utils::errors::ProofVerifyError,
@@ -48,6 +47,7 @@ use std::collections::BTreeMap;
 type F = Fr;
 type C = Bn254Curve;
 type T = Blake2bTranscript;
+#[expect(clippy::upper_case_acronyms)]
 type PCS = HyperKZG<Bn254>;
 
 /// Result of a single-pass ZK prove.
@@ -74,6 +74,7 @@ fn run_zk_sumcheck(
     prover: &mut Prover<F, T>,
     blindfold_accumulator: &mut BlindFoldAccumulator<F, C>,
     stage_configs: &mut Vec<StageConfig>,
+    pedersen_gens: &PedersenGenerators<C>,
 ) {
     let poly_degree = sc.get_params().degree();
     let num_rounds = sc.get_params().num_rounds();
@@ -81,7 +82,6 @@ fn run_zk_sumcheck(
     let _ = prover.accumulator.take_pending_claims();
     let _ = prover.accumulator.take_pending_claim_ids();
 
-    let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 2);
     let mut rng = rand::thread_rng();
 
     let instances: Vec<&mut dyn SumcheckInstanceProver<F, T>> = vec![sc];
@@ -90,7 +90,7 @@ fn run_zk_sumcheck(
         &mut prover.accumulator,
         blindfold_accumulator,
         &mut prover.transcript,
-        &pedersen_gens,
+        pedersen_gens,
         &mut rng,
     );
 
@@ -129,6 +129,14 @@ pub fn prove_zk(
     let mut stage_configs = Vec::new();
     let mut eval_reduction_proofs = BTreeMap::new();
 
+    // TODO: In production, Pedersen generators should come from preprocessing
+    // (like the HyperKZG SRS), not generated on the fly.
+    // The max sumcheck polynomial degree across all supported operators is 4 (Cube).
+    // poly_degree + 1 coefficients need poly_degree + 1 message generators.
+    let max_sumcheck_degree = 4;
+    let sumcheck_pedersen_gens =
+        PedersenGenerators::<C>::deterministic(max_sumcheck_degree + 1);
+
     for (_, node) in nodes.iter().rev() {
         // Eval reduction (same as standard flow)
         let eval_reduction_proof = NodeEvalReduction::prove(&mut prover, node);
@@ -145,6 +153,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Add(_) => {
@@ -156,6 +165,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Reshape(_) => {
@@ -173,6 +183,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Slice(_) => {
@@ -188,6 +199,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Neg(_) => {
@@ -199,6 +211,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Sub(_) => {
@@ -210,6 +223,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Mul(_) | Operator::And(_) => {
@@ -221,6 +235,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Cube(_) => {
@@ -232,6 +247,7 @@ pub fn prove_zk(
                     &mut prover,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
+                    &sumcheck_pedersen_gens,
                 );
             }
             Operator::Input(_)
@@ -392,8 +408,8 @@ pub fn prove_zk(
 /// independently checks eval reduction proofs and the output claim.
 pub fn verify_zk(
     bundle: &ZkProofBundle,
-    pp: &AtlasVerifierPreprocessing<F, PCS>,
-    io: &ModelExecutionIO,
+    _pp: &AtlasVerifierPreprocessing<F, PCS>,
+    _io: &ModelExecutionIO,
 ) -> Result<(), ProofVerifyError> {
     // 1. Verify BlindFold proof
     let builder = VerifierR1CSBuilder::<F>::new(&bundle.stage_configs, &bundle.baked);

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1,0 +1,290 @@
+//! ZK proving and verification for ONNX neural network computations.
+//!
+//! This module provides `prove_zk` and `verify_zk` functions that wrap the
+//! standard `ONNXProof` pipeline with BlindFold zero-knowledge proofs.
+//! Sumcheck round polynomials are Pedersen-committed instead of sent in the clear,
+//! and a BlindFold proof (Nova folding + Spartan) verifies constraint consistency.
+//!
+//! Currently only the `Square` operator is supported. Other operators will panic
+//! at prove time until their BlindFold constraints are implemented.
+
+use crate::onnx_proof::{
+    ops::{eval_reduction::NodeEvalReduction, OperatorProver},
+    AtlasProverPreprocessing, AtlasSharedPreprocessing, ONNXProof, Prover,
+};
+use ark_bn254::{Bn254, Fr};
+use ark_std::Zero;
+use atlas_onnx_tracer::{
+    model::trace::{ModelExecutionIO, Trace},
+    node::ComputationNode,
+    ops::Operator,
+    tensor::Tensor,
+};
+use joltworks::{
+    curve::Bn254Curve,
+    field::{IntoOpening, JoltField},
+    poly::{
+        commitment::{
+            commitment_scheme::CommitmentScheme, hyperkzg::HyperKZG, pedersen::PedersenGenerators,
+        },
+        opening_proof::ProverOpeningAccumulator,
+    },
+    subprotocols::{
+        blindfold::{
+            protocol::{
+                BlindFoldProof, BlindFoldProver, BlindFoldVerifier, BlindFoldVerifierInput,
+            },
+            r1cs::VerifierR1CSBuilder,
+            relaxed_r1cs::RelaxedR1CSInstance,
+            witness::{BlindFoldWitness, FinalOutputWitness, RoundWitness, StageWitness},
+            BakedPublicInputs, BlindFoldAccumulator, StageConfig,
+        },
+        sumcheck::BatchedSumcheck,
+        sumcheck_prover::SumcheckInstanceProver,
+        sumcheck_verifier::SumcheckInstanceParams as _,
+    },
+    transcripts::{Blake2bTranscript, Transcript},
+};
+use std::collections::BTreeMap;
+
+type F = Fr;
+type C = Bn254Curve;
+type T = Blake2bTranscript;
+type PCS = HyperKZG<Bn254>;
+
+/// Result of a ZK prove: the standard proof plus the BlindFold proof.
+pub struct ZkProofBundle {
+    /// Standard ONNX proof (sumcheck proofs, commitments, opening proof).
+    pub proof: ONNXProof<F, T, PCS>,
+    /// BlindFold zero-knowledge proof (Nova folding + Spartan).
+    pub blindfold_proof: BlindFoldProof<F, C>,
+    /// BlindFold verifier input (round commitments, etc.).
+    pub blindfold_verifier_input: BlindFoldVerifierInput<C>,
+    /// Pedersen generators used for commitments (needed by verifier).
+    pub pedersen_gens: PedersenGenerators<C>,
+    /// Stage configs describing the BlindFold R1CS layout.
+    pub stage_configs: Vec<StageConfig>,
+    /// Baked public inputs for the BlindFold R1CS.
+    pub baked: BakedPublicInputs<F>,
+}
+
+/// Prove an ONNX model execution with zero-knowledge.
+///
+/// Runs the standard proof pipeline, then separately runs each operator's
+/// sumcheck through `prove_zk` with Pedersen-committed rounds, and produces
+/// a BlindFold proof over the accumulated stage data.
+///
+/// Currently only supports models with a single `Square` operator.
+pub fn prove_zk(
+    pp: &AtlasProverPreprocessing<F, PCS>,
+    inputs: &[Tensor<i32>],
+) -> (ZkProofBundle, ModelExecutionIO) {
+    // 1. Run standard proof for the non-ZK parts (commitments, eval reduction, opening proof)
+    let (standard_proof, io, _debug_info) = ONNXProof::<F, T, PCS>::prove(pp, inputs);
+
+    // 2. Replay the flow with a fresh prover for the ZK sumcheck path.
+    //    We need a second pass because the first consumed the prover state.
+    let trace = pp.model().trace(inputs);
+    let mut prover = Prover::<F, T>::new(pp.shared.clone(), trace);
+
+    // Replay: commit witness polys to keep transcript in sync
+    let (poly_map, _commitments) = ONNXProof::<F, T, PCS>::commit_witness_polynomials(
+        pp.model(),
+        &prover.trace,
+        &pp.generators,
+        &mut prover.transcript,
+    );
+    // Replay: output claim
+    ONNXProof::<F, T, PCS>::output_claim(&mut prover);
+
+    // 3. For each node, do eval reduction then ZK sumcheck
+    let nodes = pp.model().nodes();
+    let mut blindfold_accumulator = BlindFoldAccumulator::<F, C>::new();
+    let mut max_degree = 0usize;
+    let mut stage_configs = Vec::new();
+
+    for (_, node) in nodes.iter().rev() {
+        // Eval reduction (same as standard flow)
+        NodeEvalReduction::prove(&mut prover, node);
+
+        // Create sumcheck prover based on operator type
+        match &node.operator {
+            Operator::Square(_) => {
+                use crate::onnx_proof::ops::square::{SquareParams, SquareProver};
+
+                let params = SquareParams::<F>::new(node.clone(), &prover.accumulator);
+                let poly_degree = params.degree();
+                let num_rounds = params.num_rounds();
+                max_degree = max_degree.max(poly_degree);
+
+                let mut square_prover = SquareProver::initialize(&prover.trace, params);
+
+                // Drain pre-sumcheck pending claims
+                let _ = prover.accumulator.take_pending_claims();
+                let _ = prover.accumulator.take_pending_claim_ids();
+
+                // Size generators for max poly degree
+                let pedersen_gens = PedersenGenerators::<C>::deterministic(poly_degree + 2);
+                let mut rng = rand::thread_rng();
+
+                let instances: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+                    vec![&mut square_prover];
+                let _ = BatchedSumcheck::prove_zk::<F, C, T, _>(
+                    instances,
+                    &mut prover.accumulator,
+                    &mut blindfold_accumulator,
+                    &mut prover.transcript,
+                    &pedersen_gens,
+                    &mut rng,
+                );
+
+                stage_configs.push(StageConfig::new_chain(num_rounds, poly_degree));
+            }
+            // Input/Identity/Broadcast/MoveAxis/Constant: no sumcheck, just eval reduction
+            Operator::Input(_)
+            | Operator::Identity(_)
+            | Operator::Broadcast(_)
+            | Operator::MoveAxis(_)
+            | Operator::Constant(_) => {
+                // These operators produce no sumcheck proofs; eval reduction above is sufficient.
+            }
+            other => {
+                panic!("ZK proving not yet implemented for operator: {other:?}");
+            }
+        }
+    }
+
+    // 4. Build BlindFold proof from accumulated stage data
+    let stage_data_vec = blindfold_accumulator.take_stage_data();
+    let mut all_stages = Vec::new();
+
+    for (i, sd) in stage_data_vec.iter().enumerate() {
+        let rounds: Vec<RoundWitness<F>> = sd
+            .poly_coeffs
+            .iter()
+            .zip(sd.challenges.iter())
+            .map(|(coeffs, challenge)| {
+                let challenge_f: F = (*challenge).into();
+                RoundWitness::new(coeffs.clone(), challenge_f)
+            })
+            .collect();
+
+        let output_constraint = sd.output_constraints[0].as_ref();
+        if let Some(constraint) = output_constraint {
+            let output_challenge_values = sd.constraint_challenge_values[0].clone();
+            let output_opening_values: Vec<F> =
+                sd.output_claims.iter().map(|(_id, val)| *val).collect();
+            let final_output_witness =
+                FinalOutputWitness::general(output_challenge_values, output_opening_values);
+            all_stages.push(StageWitness::with_final_output(
+                rounds,
+                final_output_witness,
+            ));
+            stage_configs[i] = stage_configs[i].clone().with_constraint(constraint.clone());
+        } else {
+            all_stages.push(StageWitness::new(rounds));
+        }
+    }
+
+    let initial_claim = stage_data_vec[0].initial_claim;
+    let blindfold_witness = BlindFoldWitness::new(initial_claim, all_stages);
+    let baked = BakedPublicInputs::from_witness(&blindfold_witness, &stage_configs);
+    let builder = VerifierR1CSBuilder::<F>::new(&stage_configs, &baked);
+    let r1cs = builder.build();
+
+    let z = blindfold_witness.assign(&r1cs);
+    r1cs.check_satisfaction(&z)
+        .expect("BlindFold R1CS should be satisfied");
+
+    let gens = PedersenGenerators::<C>::deterministic(r1cs.hyrax.C + 1);
+    let witness: Vec<F> = z[1..].to_vec();
+    let hyrax = &r1cs.hyrax;
+    let hyrax_C = hyrax.C;
+    let R_coeff = hyrax.R_coeff;
+    let R_prime = hyrax.R_prime;
+
+    let mut rng = rand::thread_rng();
+    let mut round_commitments = Vec::new();
+    let mut w_row_blindings = vec![F::zero(); R_prime];
+
+    for round_idx in 0..hyrax.total_rounds {
+        let row_start = round_idx * hyrax_C;
+        let blinding = F::random(&mut rng);
+        let commitment = gens.commit(&witness[row_start..row_start + hyrax_C], &blinding);
+        w_row_blindings[round_idx] = blinding;
+        round_commitments.push(commitment);
+    }
+
+    let noncoeff_rows_count = hyrax.total_noncoeff_rows();
+    let mut noncoeff_row_commitments = Vec::new();
+    for row in 0..noncoeff_rows_count {
+        let start = R_coeff * hyrax_C + row * hyrax_C;
+        let end = (start + hyrax_C).min(witness.len());
+        let blinding = F::random(&mut rng);
+        noncoeff_row_commitments.push(gens.commit(&witness[start..end], &blinding));
+        w_row_blindings[R_coeff + row] = blinding;
+    }
+
+    let (real_instance, real_witness) = RelaxedR1CSInstance::<F, C>::new_non_relaxed(
+        &witness,
+        r1cs.num_constraints,
+        hyrax_C,
+        round_commitments,
+        Vec::new(),
+        noncoeff_row_commitments,
+        Vec::new(),
+        w_row_blindings,
+    );
+
+    let bf_prover = BlindFoldProver::new(&gens, &r1cs, None);
+    let mut bf_transcript = T::new(b"BlindFold_onnx");
+    let blindfold_proof = bf_prover.prove(&real_instance, &real_witness, &z, &mut bf_transcript);
+
+    let blindfold_verifier_input = BlindFoldVerifierInput {
+        round_commitments: real_instance.round_commitments.clone(),
+        output_claims_row_commitments: real_instance.output_claims_row_commitments.clone(),
+        eval_commitments: real_instance.eval_commitments.clone(),
+    };
+
+    let bundle = ZkProofBundle {
+        proof: standard_proof,
+        blindfold_proof,
+        blindfold_verifier_input,
+        pedersen_gens: gens,
+        stage_configs,
+        baked,
+    };
+
+    (bundle, io)
+}
+
+/// Verify a ZK proof for an ONNX model execution.
+///
+/// Verifies both the standard ONNX proof and the BlindFold proof.
+pub fn verify_zk(
+    bundle: &ZkProofBundle,
+    pp: &crate::onnx_proof::AtlasVerifierPreprocessing<F, PCS>,
+    io: &ModelExecutionIO,
+    debug_info: Option<crate::onnx_proof::types::ProverDebugInfo<F, T>>,
+) -> Result<(), joltworks::utils::errors::ProofVerifyError> {
+    // 1. Verify standard proof
+    bundle.proof.verify(pp, io, debug_info)?;
+
+    // 2. Verify BlindFold proof
+    let builder = VerifierR1CSBuilder::<F>::new(&bundle.stage_configs, &bundle.baked);
+    let r1cs = builder.build();
+    let bf_verifier = BlindFoldVerifier::new(&bundle.pedersen_gens, &r1cs, None);
+
+    let mut bf_transcript = T::new(b"BlindFold_onnx");
+    bf_verifier
+        .verify(
+            &bundle.blindfold_proof,
+            &bundle.blindfold_verifier_input,
+            &mut bf_transcript,
+        )
+        .map_err(|e| {
+            joltworks::utils::errors::ProofVerifyError::InvalidOpeningProof(format!(
+                "BlindFold verification failed: {e:?}"
+            ))
+        })
+}

--- a/jolt-atlas-core/src/utils/opening_access.rs
+++ b/jolt-atlas-core/src/utils/opening_access.rs
@@ -25,14 +25,14 @@ pub enum Target {
 
 /// Struct-based opening ID factory scoped to one computation node.
 #[derive(Debug, Clone, Copy)]
-struct OpeningIdBuilder<'a> {
+pub(crate) struct OpeningIdBuilder<'a> {
     node: &'a ComputationNode,
     sumcheck_id: SumcheckId,
 }
 
 impl<'a> OpeningIdBuilder<'a> {
     /// Create a builder scoped to one computation node.
-    fn new(node: &'a ComputationNode) -> Self {
+    pub fn new(node: &'a ComputationNode) -> Self {
         Self {
             node,
             sumcheck_id: SumcheckId::NodeExecution(node.idx),
@@ -41,7 +41,7 @@ impl<'a> OpeningIdBuilder<'a> {
 
     /// Convenience method for the common case of opening an input/current node output
     /// in this builder's default sumcheck context.
-    fn nodeio(&self, target: Target) -> OpeningId {
+    pub fn nodeio(&self, target: Target) -> OpeningId {
         let node_idx = match target {
             Target::Current => self.node.idx,
             Target::Input(position) => self.node.inputs[position],
@@ -51,7 +51,7 @@ impl<'a> OpeningIdBuilder<'a> {
 
     /// Build an advice opening for the current node in this builder's default
     /// sumcheck context.
-    fn advice<Poly>(&self, poly_ctor: impl FnOnce(usize) -> Poly) -> OpeningId
+    pub fn advice<Poly>(&self, poly_ctor: impl FnOnce(usize) -> Poly) -> OpeningId
     where
         Poly: Into<PolynomialId>,
     {

--- a/joltworks/src/poly/commitment/pedersen.rs
+++ b/joltworks/src/poly/commitment/pedersen.rs
@@ -117,9 +117,9 @@ impl<C: JoltCurve> PedersenGenerators<C> {
     }
 }
 
-#[cfg(any(test, feature = "test-feature"))]
+#[cfg(any(test, feature = "test-feature", feature = "zk"))]
 impl PedersenGenerators<crate::curve::Bn254Curve> {
-    /// Test-only: derives generators deterministically from hash.
+    /// Derives generators deterministically from hash (test/ZK pilot only).
     pub fn deterministic(count: usize) -> Self {
         use ark_bn254::G1Projective;
         use ark_std::UniformRand;

--- a/joltworks/src/poly/commitment/pedersen.rs
+++ b/joltworks/src/poly/commitment/pedersen.rs
@@ -117,7 +117,7 @@ impl<C: JoltCurve> PedersenGenerators<C> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-feature"))]
 impl PedersenGenerators<crate::curve::Bn254Curve> {
     /// Test-only: derives generators deterministically from hash.
     pub fn deterministic(count: usize) -> Self {

--- a/joltworks/src/poly/commitment/pedersen.rs
+++ b/joltworks/src/poly/commitment/pedersen.rs
@@ -117,9 +117,9 @@ impl<C: JoltCurve> PedersenGenerators<C> {
     }
 }
 
-#[cfg(any(test, feature = "test-feature", feature = "zk"))]
+#[cfg(any(test, feature = "test-feature"))]
 impl PedersenGenerators<crate::curve::Bn254Curve> {
-    /// Derives generators deterministically from hash (test/ZK pilot only).
+    /// Derives generators deterministically from hash (test only).
     pub fn deterministic(count: usize) -> Self {
         use ark_bn254::G1Projective;
         use ark_std::UniformRand;

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -359,8 +359,13 @@ where
         transcript.append_scalar(&claim);
 
         self.openings.insert(opening_id, (opening_point, claim));
-        #[cfg(test)]
+        #[cfg(any(test, feature = "test-feature"))]
         self.appended_virtual_openings.borrow_mut().push(opening_id);
+        #[cfg(feature = "zk")]
+        {
+            self.pending_claims.push(claim);
+            self.pending_claim_ids.push(opening_id);
+        }
     }
 
     /// Take the openings, removing the points to reduce proof size

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -1003,6 +1003,8 @@ pub enum SumcheckId {
     HammingWeight,
     /// RLC sumcheck for the execution of a specific node.
     RLC(usize),
+    /// Batch opening reduction (used by BlindFold y_com constraint).
+    BlindFoldBatchOpening,
 }
 
 impl CanonicalSerialize for SumcheckId {
@@ -1026,6 +1028,7 @@ impl CanonicalSerialize for SumcheckId {
                 7u8.serialize_with_mode(&mut writer, compress)?;
                 idx.serialize_with_mode(&mut writer, compress)?;
             }
+            Self::BlindFoldBatchOpening => 8u8.serialize_with_mode(&mut writer, compress)?,
         }
         Ok(())
     }
@@ -1068,6 +1071,7 @@ impl CanonicalDeserialize for SumcheckId {
                 let idx = usize::deserialize_with_mode(&mut reader, compress, validate)?;
                 Ok(Self::RLC(idx))
             }
+            8 => Ok(Self::BlindFoldBatchOpening),
             _ => Err(SerializationError::InvalidData),
         }
     }

--- a/joltworks/src/subprotocols/blindfold/folding.rs
+++ b/joltworks/src/subprotocols/blindfold/folding.rs
@@ -387,7 +387,7 @@ mod tests {
         let builder = VerifierR1CSBuilder::<F>::new(&configs, &baked);
         let r1cs = builder.build();
 
-        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C + 1);
+        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C);
 
         let (instance, witness, z) = sample_random_satisfying_pair(&gens, &r1cs, None, &mut rng);
 
@@ -438,7 +438,7 @@ mod tests {
         let builder = VerifierR1CSBuilder::<F>::new(&configs, &baked);
         let r1cs = builder.build();
 
-        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C + 1);
+        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C);
 
         let round1 = RoundWitness::new(
             vec![

--- a/joltworks/src/subprotocols/blindfold/mod.rs
+++ b/joltworks/src/subprotocols/blindfold/mod.rs
@@ -158,9 +158,9 @@ pub struct BakedPublicInputs<F> {
     pub extra_constraint_challenges: Vec<F>,
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-feature"))]
 impl<F: JoltField> BakedPublicInputs<F> {
-    pub(crate) fn from_witness(
+    pub fn from_witness(
         witness: &witness::BlindFoldWitness<F>,
         stage_configs: &[StageConfig],
     ) -> Self {

--- a/joltworks/src/subprotocols/blindfold/mod.rs
+++ b/joltworks/src/subprotocols/blindfold/mod.rs
@@ -158,7 +158,7 @@ pub struct BakedPublicInputs<F> {
     pub extra_constraint_challenges: Vec<F>,
 }
 
-#[cfg(any(test, feature = "test-feature"))]
+#[cfg(any(test, feature = "test-feature", feature = "zk"))]
 impl<F: JoltField> BakedPublicInputs<F> {
     pub fn from_witness(
         witness: &witness::BlindFoldWitness<F>,

--- a/joltworks/src/subprotocols/blindfold/output_constraint.rs
+++ b/joltworks/src/subprotocols/blindfold/output_constraint.rs
@@ -220,6 +220,25 @@ impl OutputClaimConstraint {
         Self::sum_of_products(terms)
     }
 
+    /// Wraps every term with an additional challenge factor at index `num_challenges`.
+    /// Used to incorporate the batching coefficient from `prove_zk`: the sumcheck
+    /// output is `batching_coeff * expected_output`, so the constraint must produce
+    /// `batching_coeff * raw_constraint`. The caller appends the batching coefficient
+    /// as the last element of `challenge_values`.
+    pub fn scale_by_new_challenge(&self) -> Self {
+        let scale_idx = self.num_challenges;
+        let new_terms: Vec<ProductTerm> = self
+            .terms
+            .iter()
+            .map(|term| {
+                let mut new_factors = vec![ValueSource::Challenge(scale_idx)];
+                new_factors.extend(term.factors.iter().cloned());
+                ProductTerm::new(term.coeff.clone(), new_factors)
+            })
+            .collect();
+        Self::new(new_terms, self.required_openings.clone())
+    }
+
     pub fn batch(constraints: &[Option<OutputClaimConstraint>]) -> Option<Self> {
         if constraints.iter().any(|c| c.is_none()) {
             return None;

--- a/joltworks/src/subprotocols/blindfold/protocol.rs
+++ b/joltworks/src/subprotocols/blindfold/protocol.rs
@@ -547,7 +547,7 @@ mod tests {
         let baked = BakedPublicInputs::from_witness(blindfold_witness, configs);
         let builder = VerifierR1CSBuilder::<F>::new(configs, &baked);
         let r1cs = builder.build();
-        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C + 1);
+        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C);
 
         let z = blindfold_witness.assign(&r1cs);
         r1cs.check_satisfaction(&z).unwrap();

--- a/joltworks/src/subprotocols/blindfold/r1cs.rs
+++ b/joltworks/src/subprotocols/blindfold/r1cs.rs
@@ -351,7 +351,7 @@ struct RoundVariables {
 }
 
 impl<F: JoltField> VerifierR1CSBuilder<F> {
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-feature"))]
     pub fn new(stage_configs: &[StageConfig], baked: &BakedPublicInputs<F>) -> Self {
         Self::new_with_extra(stage_configs, &[], baked, Vec::new(), BTreeMap::new())
     }

--- a/joltworks/src/subprotocols/blindfold/r1cs.rs
+++ b/joltworks/src/subprotocols/blindfold/r1cs.rs
@@ -351,7 +351,7 @@ struct RoundVariables {
 }
 
 impl<F: JoltField> VerifierR1CSBuilder<F> {
-    #[cfg(any(test, feature = "test-feature"))]
+    #[cfg(any(test, feature = "test-feature", feature = "zk"))]
     pub fn new(stage_configs: &[StageConfig], baked: &BakedPublicInputs<F>) -> Self {
         Self::new_with_extra(stage_configs, &[], baked, Vec::new(), BTreeMap::new())
     }

--- a/joltworks/src/subprotocols/blindfold/relaxed_r1cs.rs
+++ b/joltworks/src/subprotocols/blindfold/relaxed_r1cs.rs
@@ -331,7 +331,7 @@ mod tests {
         // witness_start = 1 (no public inputs)
         let witness: Vec<F> = z[1..].to_vec();
 
-        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C + 1);
+        let gens = PedersenGenerators::<Bn254Curve>::deterministic(r1cs.hyrax.C);
 
         let hyrax_C = r1cs.hyrax.C;
         let coeffs_row = &witness[0..hyrax_C];

--- a/joltworks/src/subprotocols/blindfold/witness.rs
+++ b/joltworks/src/subprotocols/blindfold/witness.rs
@@ -169,7 +169,7 @@ pub struct BlindFoldWitness<F> {
 }
 
 impl<F: JoltField> BlindFoldWitness<F> {
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-feature"))]
     pub fn new(initial_claim: F, stages: Vec<StageWitness<F>>) -> Self {
         Self {
             initial_claims: vec![initial_claim],

--- a/joltworks/src/subprotocols/blindfold/witness.rs
+++ b/joltworks/src/subprotocols/blindfold/witness.rs
@@ -169,7 +169,7 @@ pub struct BlindFoldWitness<F> {
 }
 
 impl<F: JoltField> BlindFoldWitness<F> {
-    #[cfg(any(test, feature = "test-feature"))]
+    #[cfg(any(test, feature = "test-feature", feature = "zk"))]
     pub fn new(initial_claim: F, stages: Vec<StageWitness<F>>) -> Self {
         Self {
             initial_claims: vec![initial_claim],

--- a/joltworks/src/subprotocols/sumcheck.rs
+++ b/joltworks/src/subprotocols/sumcheck.rs
@@ -404,20 +404,37 @@ impl BatchedSumcheck {
             transcript.append_serializable(com);
         }
 
+        // Build output constraints, scaling each by its batching coefficient.
+        // The sumcheck polynomials are batched (scaled by batching_coeff), so the
+        // final claim = batching_coeff * expected_output. The raw constraint produces
+        // expected_output (unbatched). We wrap each constraint with an extra challenge
+        // that carries the batching coefficient so the R1CS checks:
+        //   final_claim == batching_coeff * constraint_output
         let output_constraints: Vec<_> = sumcheck_instances
             .iter()
-            .map(|sumcheck| sumcheck.get_params().output_claim_constraint())
+            .zip(&batching_coeffs)
+            .map(|(sumcheck, _batch_coeff)| {
+                sumcheck
+                    .get_params()
+                    .output_claim_constraint()
+                    .map(|c| c.scale_by_new_challenge())
+            })
             .collect();
 
         let constraint_challenge_values: Vec<Vec<F>> = sumcheck_instances
             .iter()
-            .map(|sumcheck| {
+            .zip(&batching_coeffs)
+            .map(|(sumcheck, &batch_coeff)| {
                 let num_rounds = sumcheck.num_rounds();
                 let offset = sumcheck.round_offset(max_num_rounds);
                 let r_slice = &r_sumcheck[offset..offset + num_rounds];
-                sumcheck
+                let mut vals = sumcheck
                     .get_params()
-                    .output_constraint_challenge_values(r_slice)
+                    .output_constraint_challenge_values(r_slice);
+                // Append the batching coefficient as the final challenge value,
+                // matching the scale_by_new_challenge() wrapping above.
+                vals.push(batch_coeff);
+                vals
             })
             .collect();
 


### PR DESCRIPTION
This PR wires the BlindFold zero-knowledge subprotocol into the proof pipeline for single sumcheck stage operators. Here is how the Square operator is changed (others follow similarly):                   
                                                            
Changes:                                                                                                                                                      
                                                            
1. Square's BlindFold constraints (jolt-atlas-core/src/onnx_proof/ops/square.rs): Replaced the macro-generated SquareParams with a manual SumcheckInstanceParams impl that includes the four cfg-gated constraint methods.
                                                                                                                                                                               
2. ZK prove/verify pipeline (jolt-atlas-core/src/onnx_proof/zk.rs)                                                                                                              
  - prove_zk(): runs the standard proof, then replays the IOP with BatchedSumcheck::prove_zk for each operator, builds the BlindFold R1CS from accumulated ZkStageData, and produces a BlindFoldProof.                                                                                                                                                   
  - verify_zk(): verifies both the standard ONNXProof and the BlindFoldProof.  
                                                            
3. Batching coefficient fix (joltworks/src/subprotocols/sumcheck.rs)                                                                                                            
  - prove_zk now wraps each output constraint with `scale_by_new_challenge` and appends the batching coefficient, so the R1CS correctly checks final_claim == batching_coeff * raw_constraint_output.                                                                                                                                                       
                                                            
4. Infrastructure
  - Added zk feature to jolt-atlas-core/Cargo.toml forwarding to joltworks/zk.                                                                                                 
  - Widened #[cfg(test)] to #[cfg(any(test, feature = "test-feature", feature = "zk"))] on PedersenGenerators::deterministic, BlindFoldWitness::new, BakedPublicInputs::from_witness, and VerifierR1CSBuilder::new.                                                                                    
  - Added OutputClaimConstraint::scale_by_new_challenge().                                                                                                                     
                                                            
5. Tests                                                                                                                                                                        
  - test_square_blindfold_constraint_consistency: validates constraint formulas match actual claim computations with synthetic data.                                           
  - test_square_blindfold_e2e: runs Square's sumcheck through prove_zk, builds the BlindFold R1CS, checks satisfaction, and runs the full BlindFold prover/verifier.
  - test_square_zk: full pipeline test calling prove_zk() + verify_zk() on a Square-only model.   