### PR TITLE
fix: reintroduce parallelization opt

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/ops/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cos.rs
@@ -513,7 +513,11 @@ impl<F: JoltField, T: Transcript> NeuralTeleportRangeOneHot<F, T> for Cos {
         let LayerData { operands, .. } = Trace::layer_data(trace, node);
         let input = operands[0];
         let (_, remainder) = compute_division(input, FOUR_PI_APPROX);
-        remainder.par_iter().map(|&x| x as usize).collect()
+        remainder
+            .par_iter()
+            .with_min_len(par_enabled())
+            .map(|&x| x as usize)
+            .collect()
     }
 
     fn ra_encoding(&self, node: &ComputationNode) -> Self::RaEncoding {

--- a/jolt-atlas-core/src/onnx_proof/ops/erf.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/erf.rs
@@ -501,6 +501,7 @@ impl<F: JoltField, T: Transcript> NeuralTeleportRangeOneHot<F, T> for Erf {
         let (quotient, _remainder) = compute_division(input, self.tau);
         quotient
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&x| n_bits_to_usize(x, self.log_table))
             .collect()
     }

--- a/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
@@ -497,6 +497,7 @@ impl<F: JoltField, T: Transcript> NeuralTeleportRangeOneHot<F, T> for Sigmoid {
         let (quotient, _remainder) = compute_division(input, self.tau);
         quotient
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&x| n_bits_to_usize(x, self.log_table))
             .collect()
     }

--- a/jolt-atlas-core/src/onnx_proof/ops/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sin.rs
@@ -509,7 +509,11 @@ impl<F: JoltField, T: Transcript> NeuralTeleportRangeOneHot<F, T> for Sin {
         let LayerData { operands, .. } = Trace::layer_data(trace, node);
         let input = operands[0];
         let (_, remainder) = compute_division(input, FOUR_PI_APPROX);
-        remainder.par_iter().map(|&x| x as usize).collect()
+        remainder
+            .par_iter()
+            .with_min_len(par_enabled())
+            .map(|&x| x as usize)
+            .collect()
     }
 
     fn ra_encoding(&self, node: &ComputationNode) -> Self::RaEncoding {

--- a/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
@@ -526,6 +526,7 @@ impl<F: JoltField, T: Transcript> NeuralTeleportRangeOneHot<F, T> for Tanh {
         let (quotient, _remainder) = compute_division(input, self.tau);
         quotient
             .par_iter()
+            .with_min_len(par_enabled())
             .map(|&x| n_bits_to_usize(x, self.log_table))
             .collect()
     }


### PR DESCRIPTION
A refactoring of teleported operators common logic (handling the range-checking, and one-hotness checks) was performed in previous pull request #206, and rebasing the parallelization optimization (#223) into that branch had caused to lose parts of the optimization.

This pull request aims at reintroducing them.