### PR TITLE
Add BlindFold ZK constraints for ScalarConstDiv operator

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -972,6 +972,30 @@ fn test_concat_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_scalar_const_div_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF12);
+    // ScalarConstDiv divides by a constant integer. The model builder takes the divisor.
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.scalar_const_div(i, 7); // divide by 7
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
@@ -128,6 +128,48 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivParams<F> {
             .pow2_padded_num_output_elements()
             .log_2()
     }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (left_operand - R_claim)
+    //        = eq_eval * left + (-eq_eval) * R
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let r_id = builder.advice(CommittedPoly::ScalarConstDivNodeRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(left_id)],
+            ),
+            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(r_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval, -eq_eval]
+    }
 }
 
 /// Prover state for scalar constant division sumcheck protocol.

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -550,6 +550,16 @@ fn create_prover_instance(
                 params,
             )))
         }
+        Operator::ScalarConstDiv(_) => {
+            use crate::onnx_proof::ops::scalar_const_div::{
+                ScalarConstDivParams, ScalarConstDivProver,
+            };
+            let params = ScalarConstDivParams::<F>::new(node.clone(), &prover.accumulator);
+            Some(Box::new(ScalarConstDivProver::initialize(
+                &prover.trace,
+                params,
+            )))
+        }
         Operator::Input(_)
         | Operator::Identity(_)
         | Operator::Broadcast(_)
@@ -619,6 +629,13 @@ fn create_verifier_instances(
                 node.clone(),
                 accumulator,
                 &model.graph,
+            ))]
+        }
+        Operator::ScalarConstDiv(_) => {
+            use crate::onnx_proof::ops::scalar_const_div::ScalarConstDivVerifier;
+            vec![Box::new(ScalarConstDivVerifier::new(
+                node.clone(),
+                accumulator,
             ))]
         }
         _ => vec![],

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -290,6 +290,12 @@ where
             claim,
         );
         self.sumchecks.insert(polynomial, sumcheck);
+
+        #[cfg(feature = "zk")]
+        {
+            self.pending_claims.push(claim);
+            self.pending_claim_ids.push(opening_id);
+        }
     }
 
     #[tracing::instrument(skip_all, name = "ProverOpeningAccumulator::append_sparse")]
@@ -669,17 +675,31 @@ where
         T: Transcript,
         U: Copy + Send + Sync + Into<F>,
     {
-        let claim = self.openings.get(&opening_id).unwrap().1;
-        transcript.append_scalar(&claim);
-
-        // Update the opening point in self.openings (it was initialized with default empty point)
-        self.openings.insert(
-            opening_id,
-            (
-                OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
-                claim,
-            ),
-        );
+        let claim = if let Some((_, claim)) = self.openings.get(&opening_id) {
+            // Standard mode: claim was pre-loaded.
+            let claim = *claim;
+            transcript.append_scalar(&claim);
+            self.openings.insert(
+                opening_id,
+                (
+                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
+                    claim,
+                ),
+            );
+            claim
+        } else if self.zk_mode {
+            // ZK mode: insert with placeholder claim. BlindFold handles correctness.
+            self.openings.insert(
+                opening_id,
+                (
+                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
+                    F::zero(),
+                ),
+            );
+            F::zero()
+        } else {
+            panic!("Tried to populate dense opening for non-existent key: {opening_id:?}");
+        };
 
         let polynomial = opening_id
             .committed_poly()


### PR DESCRIPTION
First operator with a committed polynomial (ScalarConstDivNodeRemainder). Adds constraint methods, wires prover/verifier dispatch, handles ZK-mode append_dense for committed openings, and adds ZK e2e test.