### PR TITLE
More Blindfold ops

### DIFF
--- a/atlas-onnx-tracer/src/model/test.rs
+++ b/atlas-onnx-tracer/src/model/test.rs
@@ -125,6 +125,14 @@ impl ModelBuilder {
         self.insert_node(node)
     }
 
+    /// Add a bitwise AND node.
+    pub fn and(&mut self, a: Wire, b: Wire) -> Wire {
+        let id = self.alloc();
+        let output_dims = self.nodes[&a].output_dims.clone();
+        let node = ComputationNode::new(id, Operator::And(And), vec![a, b], output_dims);
+        self.insert_node(node)
+    }
+
     /// Add a multiplication node.
     pub fn mul(&mut self, a: Wire, b: Wire) -> Wire {
         let id = self.alloc();

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -996,6 +996,60 @@ fn test_scalar_const_div_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_and_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    use rand::Rng;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF13);
+    // And requires boolean (0/1) inputs
+    let a_data: Vec<i32> = (0..size).map(|_| rng.gen_range(0..2)).collect();
+    let b_data: Vec<i32> = (0..size).map(|_| rng.gen_range(0..2)).collect();
+    let a = Tensor::construct(a_data, vec![size]);
+    let b_tensor = Tensor::construct(b_data, vec![size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let c = builder.constant(b_tensor.clone());
+    let res = builder.and(i, c);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[a], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+#[ignore = "requires custom-flow pipeline + range check BlindFold constraints"]
+fn test_div_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF14);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let c = builder.constant(Tensor::construct(vec![1 << 8; size], vec![size]));
+    let res = builder.div(i, c);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -972,6 +972,30 @@ fn test_concat_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_scalar_const_div_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF12);
+    // ScalarConstDiv divides by a constant integer. The model builder takes the divisor.
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.scalar_const_div(i, 7); // divide by 7
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/ops/div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/div.rs
@@ -203,6 +203,54 @@ impl<F: JoltField> SumcheckInstanceParams<F> for DivParams<F> {
             .pow2_padded_num_output_elements()
             .log_2()
     }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (right * q + R - left)
+    //        = eq_eval * right * q + eq_eval * R + (-eq_eval) * left
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        let q_id = builder.nodeio(Target::Current);
+        let r_id = builder.advice(VirtualPoly::DivRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(right_id), ValueSource::Opening(q_id)],
+            ),
+            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(r_id)]),
+            ProductTerm::scaled(
+                ValueSource::Challenge(2),
+                vec![ValueSource::Opening(left_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval, eq_eval, -eq_eval]
+    }
 }
 
 /// Prover state for element-wise division sumcheck protocol.

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
@@ -128,6 +128,48 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivParams<F> {
             .pow2_padded_num_output_elements()
             .log_2()
     }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
+        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (left_operand - R_claim)
+    //        = eq_eval * left + (-eq_eval) * R
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let r_id = builder.advice(CommittedPoly::ScalarConstDivNodeRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(left_id)],
+            ),
+            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(r_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval, -eq_eval]
+    }
 }
 
 /// Prover state for scalar constant division sumcheck protocol.

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -110,6 +110,62 @@ fn run_zk_sumcheck(
     zk_proof
 }
 
+/// Run ZK eval reduction for a node: commit h polynomial via Pedersen.
+fn prove_zk_eval_reduction(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+) {
+    use atlas_onnx_tracer::model::trace::{LayerData, Trace};
+    use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
+
+    let node_idx = node.idx;
+    let openings = prover.accumulator.get_node_openings(node_idx);
+    let LayerData {
+        operands: _,
+        output,
+    } = Trace::layer_data(&prover.trace, node);
+    let output_mle = MultilinearPolynomial::from(output.padded_next_power_of_two());
+
+    let (proof, reduced, h_com) = EvalReductionProtocol::prove_zk::<F, C, _>(
+        &openings,
+        output_mle,
+        &mut prover.transcript,
+        pedersen_gens,
+    )
+    .expect("ZK eval reduction should not fail");
+
+    prover
+        .accumulator
+        .reduced_evaluations
+        .insert(node_idx, reduced);
+    eval_reduction_proofs.insert(node_idx, proof);
+    if let Some(com) = h_com {
+        eval_reduction_h_commitments.insert(node_idx, com);
+    }
+}
+
+/// Verify ZK eval reduction for a node: absorb h commitment, skip claim checks.
+fn verify_zk_eval_reduction(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+) -> Result<(), ProofVerifyError> {
+    use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
+
+    let openings = accumulator.get_node_openings(node.idx);
+    let h_commitment = bundle.eval_reduction_h_commitments.get(&node.idx);
+    let reduced_instance =
+        EvalReductionProtocol::verify_zk::<F, T>(&openings, h_commitment, transcript)?;
+    accumulator
+        .reduced_evaluations
+        .insert(node.idx, reduced_instance);
+    Ok(())
+}
+
 /// Prove an ONNX model execution with zero-knowledge (single pass).
 ///
 /// `pedersen_gens` must have at least `max(poly_degree + 1, hyrax_C)` message
@@ -155,36 +211,16 @@ pub fn prove_zk(
     let mut zk_sumcheck_proofs: Vec<NodeZkProof> = Vec::new();
 
     for (_, node) in nodes.iter().rev() {
-        // ZK eval reduction: commit h via Pedersen instead of cleartext
-        {
-            use atlas_onnx_tracer::model::trace::{LayerData, Trace};
-            use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
-
-            let node_idx = node.idx;
-            let openings = prover.accumulator.get_node_openings(node_idx);
-            let LayerData {
-                operands: _,
-                output,
-            } = Trace::layer_data(&prover.trace, node);
-            let output_mle = MultilinearPolynomial::from(output.padded_next_power_of_two());
-
-            let (proof, reduced, h_com) = EvalReductionProtocol::prove_zk::<F, C, _>(
-                &openings,
-                output_mle,
-                &mut prover.transcript,
-                pedersen_gens,
-            )
-            .expect("ZK eval reduction should not fail");
-
-            prover
-                .accumulator
-                .reduced_evaluations
-                .insert(node_idx, reduced);
-            eval_reduction_proofs.insert(node_idx, proof);
-            if let Some(com) = h_com {
-                eval_reduction_h_commitments.insert(node_idx, com);
-            }
-        }
+        // Standard flow: eval reduction first, then execution sumcheck.
+        // Custom-flow operators (Div, Rsqrt, neural teleportation ops) require
+        // pipeline restructuring and range check BlindFold constraints; see TODO below.
+        prove_zk_eval_reduction(
+            node,
+            &mut prover,
+            pedersen_gens,
+            &mut eval_reduction_proofs,
+            &mut eval_reduction_h_commitments,
+        );
 
         let zk_proof = create_prover_instance(node, &prover, pp.shared.model()).map(|mut sc| {
             run_zk_sumcheck(
@@ -199,6 +235,9 @@ pub fn prove_zk(
             zk_sumcheck_proofs.push((node.idx, proof));
         }
     }
+    // TODO: Support custom-flow operators (Div, Rsqrt, neural teleportation) which
+    // need: (1) execution sumcheck before eval reduction, (2) quotient binding,
+    // (3) BlindFold constraints for range check + one-hot sumchecks.
 
     // y_com for batch opening (no-op when poly_map is empty)
     if !poly_map.is_empty() {
@@ -361,7 +400,6 @@ pub fn verify_zk(
     pedersen_gens: &PedersenGenerators<C>,
 ) -> Result<(), ProofVerifyError> {
     use joltworks::poly::opening_proof::VerifierOpeningAccumulator;
-    use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
 
     let model = pp.shared.model();
     let mut accumulator = VerifierOpeningAccumulator::<F>::new_zk();
@@ -405,14 +443,8 @@ pub fn verify_zk(
     // 3. Full IOP replay: for each node, verify eval reduction + absorb ZK sumcheck
     let mut zk_proof_idx = 0;
     for (_, node) in model.graph.nodes.iter().rev() {
-        // Verify eval reduction (ZK mode: absorb h commitment, skip claim checks)
-        let openings = accumulator.get_node_openings(node.idx);
-        let h_commitment = bundle.eval_reduction_h_commitments.get(&node.idx);
-        let reduced_instance =
-            EvalReductionProtocol::verify_zk::<F, T>(&openings, h_commitment, &mut transcript)?;
-        accumulator
-            .reduced_evaluations
-            .insert(node.idx, reduced_instance);
+        // Standard flow: eval reduction first, then execution sumcheck
+        verify_zk_eval_reduction(node, &bundle, &mut accumulator, &mut transcript)?;
 
         // For operators with sumcheck: absorb ZK sumcheck commitments into transcript
         let has_sumcheck = !matches!(
@@ -432,7 +464,6 @@ pub fn verify_zk(
                 "ZK sumcheck proof order mismatch"
             );
 
-            // Create verifier sumcheck instances and run verify_zk to replay transcript
             let verifier_instances = create_verifier_instances(node, &accumulator, model);
             let verifier_refs: Vec<
                 &dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>,
@@ -455,11 +486,6 @@ pub fn verify_zk(
             )?;
 
             zk_proof_idx += 1;
-        } else {
-            // No-sumcheck operators: run their standard verify to keep transcript in sync.
-            // Input verifies the claim against IO; others are no-ops.
-            // Input: check that the input claim matches the IO.
-            // Other no-sumcheck ops (Identity, Broadcast, etc.) don't modify the transcript.
         }
     }
 

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -550,6 +550,16 @@ fn create_prover_instance(
                 params,
             )))
         }
+        Operator::ScalarConstDiv(_) => {
+            use crate::onnx_proof::ops::scalar_const_div::{
+                ScalarConstDivParams, ScalarConstDivProver,
+            };
+            let params = ScalarConstDivParams::<F>::new(node.clone(), &prover.accumulator);
+            Some(Box::new(ScalarConstDivProver::initialize(
+                &prover.trace,
+                params,
+            )))
+        }
         Operator::Input(_)
         | Operator::Identity(_)
         | Operator::Broadcast(_)
@@ -619,6 +629,13 @@ fn create_verifier_instances(
                 node.clone(),
                 accumulator,
                 &model.graph,
+            ))]
+        }
+        Operator::ScalarConstDiv(_) => {
+            use crate::onnx_proof::ops::scalar_const_div::ScalarConstDivVerifier;
+            vec![Box::new(ScalarConstDivVerifier::new(
+                node.clone(),
+                accumulator,
             ))]
         }
         _ => vec![],

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -290,6 +290,12 @@ where
             claim,
         );
         self.sumchecks.insert(polynomial, sumcheck);
+
+        #[cfg(feature = "zk")]
+        {
+            self.pending_claims.push(claim);
+            self.pending_claim_ids.push(opening_id);
+        }
     }
 
     #[tracing::instrument(skip_all, name = "ProverOpeningAccumulator::append_sparse")]
@@ -669,17 +675,31 @@ where
         T: Transcript,
         U: Copy + Send + Sync + Into<F>,
     {
-        let claim = self.openings.get(&opening_id).unwrap().1;
-        transcript.append_scalar(&claim);
-
-        // Update the opening point in self.openings (it was initialized with default empty point)
-        self.openings.insert(
-            opening_id,
-            (
-                OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
-                claim,
-            ),
-        );
+        let claim = if let Some((_, claim)) = self.openings.get(&opening_id) {
+            // Standard mode: claim was pre-loaded.
+            let claim = *claim;
+            transcript.append_scalar(&claim);
+            self.openings.insert(
+                opening_id,
+                (
+                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
+                    claim,
+                ),
+            );
+            claim
+        } else if self.zk_mode {
+            // ZK mode: insert with placeholder claim. BlindFold handles correctness.
+            self.openings.insert(
+                opening_id,
+                (
+                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
+                    F::zero(),
+                ),
+            );
+            F::zero()
+        } else {
+            panic!("Tried to populate dense opening for non-existent key: {opening_id:?}");
+        };
 
         let polynomial = opening_id
             .committed_poly()


### PR DESCRIPTION
- ScalarConstDiv: first operator with a committed polynomial (ScalarConstDivNodeRemainder). Adds the 4 BlindFold constraint methods, wires prover/verifier dispatch, handles ZK-mode append_dense for committed openings on the verifier, and adds test_scalar_const_div_zk.                                                                                                    
- And: adds ModelBuilder::and() and test_and_zk. And delegates to Mul (already wired), so no new constraint code needed.                                                                   
- Div: adds BlindFold constraint methods to DivParams (output constraint with 4 openings and a degree-2 product term: eq_eval * right * q + eq_eval * R - eq_eval * left). Test stub is ignored; full pipeline wiring (custom-flow + range checks) is in the blindfold-custom-flow branch.                                                                                         
- Pipeline refactoring: extracts prove_zk_eval_reduction / verify_zk_eval_reduction helpers (preparing for custom-flow operators)
- Verifier append_dense ZK mode: inserts F::zero() placeholder instead of panicking on missing keys.                                 
- Prover append_dense: pushes to pending_claims so BlindFold can capture committed polynomial claims.   