### PR TITLE
Add BlindFold ZK for Rsqrt

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -1177,6 +1177,30 @@ fn test_sin_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_rsqrt_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF20);
+    // Rsqrt needs positive inputs; avoid 0 since we divide by x
+    let input = Tensor::random_range(&mut rng, &[size], 1..256);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.rsqrt(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
@@ -15,6 +15,10 @@ use atlas_onnx_tracer::{
     ops::Rsqrt,
 };
 use common::{consts::XLEN, CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     lookup_tables::unsigned_less_than::UnsignedLessThanTable,
@@ -58,8 +62,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Rsqrt {
         let mut results = Vec::new();
         // Execution proof
         let params = RsqrtParams::new(node.clone(), &mut prover.transcript);
-        let mut prover_sumcheck =
-            RsqrtProver::initialize(&prover.trace, &mut prover.transcript, params);
+        let mut prover_sumcheck = RsqrtProver::initialize(&prover.trace, params);
         let (proof, _) = Sumcheck::prove(
             &mut prover_sumcheck,
             &mut prover.accumulator,
@@ -162,16 +165,21 @@ const DEGREE_BOUND: usize = 3;
 pub struct RsqrtParams<F: JoltField> {
     r_node_output: OpeningPoint<BIG_ENDIAN, F>,
     computation_node: ComputationNode,
+    /// Folding challenge for batching the inverse and sqrt relations.
+    gamma: F,
 }
 
 impl<F: JoltField> RsqrtParams<F> {
     /// Create new rsqrt parameters from a computation node and transcript.
+    /// Squeezes both the opening point and the folding challenge gamma.
     pub fn new<T: Transcript>(computation_node: ComputationNode, transcript: &mut T) -> Self {
         let num_vars = computation_node.pow2_padded_num_output_elements().log_2();
         let r_node_output = transcript.challenge_vector_optimized::<F>(num_vars);
+        let gamma = transcript.challenge_scalar();
         Self {
             r_node_output: r_node_output.into(),
             computation_node,
+            gamma,
         }
     }
 }
@@ -194,6 +202,80 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RsqrtParams<F> {
             .pow2_padded_num_output_elements()
             .log_2()
     }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq * (left*inv + r_i - Q^2 + gamma*(rsqrt^2 + r_s - Q*inv))
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let inv_id = builder.advice(CommittedPoly::RsqrtNodeInv);
+        let rsqrt_id = builder.nodeio(Target::Current);
+        let r_i_id = builder.advice(VirtualPoly::DivRemainder);
+        let r_s_id = builder.advice(VirtualPoly::SqrtRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            // eq * left * inv
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(left_id), ValueSource::Opening(inv_id)],
+            ),
+            // eq * r_i
+            ProductTerm::scaled(
+                ValueSource::Challenge(1),
+                vec![ValueSource::Opening(r_i_id)],
+            ),
+            // -eq * Q^2  (constant term, no openings)
+            ProductTerm::scaled(ValueSource::Challenge(2), vec![]),
+            // eq * gamma * rsqrt^2
+            ProductTerm::scaled(
+                ValueSource::Challenge(3),
+                vec![
+                    ValueSource::Opening(rsqrt_id),
+                    ValueSource::Opening(rsqrt_id),
+                ],
+            ),
+            // eq * gamma * r_s
+            ProductTerm::scaled(
+                ValueSource::Challenge(4),
+                vec![ValueSource::Opening(r_s_id)],
+            ),
+            // -eq * gamma * Q * inv
+            ProductTerm::scaled(
+                ValueSource::Challenge(5),
+                vec![ValueSource::Opening(inv_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_prime);
+        let eq_gamma = eq_eval * self.gamma;
+        vec![
+            eq_eval,                          // Ch(0): eq * left * inv
+            eq_eval,                          // Ch(1): eq * r_i
+            -eq_eval * F::from_i32(Q_SQUARE), // Ch(2): -eq * Q^2 (constant)
+            eq_gamma,                         // Ch(3): eq * gamma * rsqrt^2
+            eq_gamma,                         // Ch(4): eq * gamma * r_s
+            -eq_gamma * F::from_i32(Q),       // Ch(5): -eq * gamma * Q * inv
+        ]
+    }
 }
 
 /// Prover state for reciprocal square root sumcheck protocol.
@@ -214,11 +296,7 @@ pub struct RsqrtProver<F: JoltField> {
 
 impl<F: JoltField> RsqrtProver<F> {
     /// Initialize the prover with trace data, transcript, and parameters.
-    pub fn initialize<T: Transcript>(
-        trace: &Trace,
-        transcript: &mut T,
-        params: RsqrtParams<F>,
-    ) -> Self {
+    pub fn initialize(trace: &Trace, params: RsqrtParams<F>) -> Self {
         let eq_r_node_output =
             GruenSplitEqPolynomial::new(&params.r_node_output.r, BindingOrder::LowToHigh);
         let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
@@ -267,7 +345,7 @@ impl<F: JoltField> RsqrtProver<F> {
             assert_eq!(F::zero(), claim_sqrt)
         }
 
-        let gamma = transcript.challenge_scalar();
+        let gamma = params.gamma;
         Self {
             params,
             eq_r_node_output,
@@ -361,7 +439,7 @@ impl<F: JoltField> RsqrtVerifier<F> {
     /// Create a new verifier for the rsqrt operation with folding challenge from transcript.
     pub fn new<T: Transcript>(computation_node: ComputationNode, transcript: &mut T) -> Self {
         let params = RsqrtParams::new(computation_node, transcript);
-        let gamma = transcript.challenge_scalar();
+        let gamma = params.gamma;
         Self { params, gamma }
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -226,6 +226,80 @@ fn verify_zk_sumcheck_instances(
     Ok(())
 }
 
+/// Verify Rsqrt ZK proof: custom flow mirroring prove_rsqrt_zk.
+fn verify_rsqrt_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::ops::rsqrt::RsqrtVerifier;
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::{RiRangeCheckOperands, RsRangeCheckOperands},
+        RangeCheckEncoding, RangeCheckProvider,
+    };
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Execution sumcheck
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let v = RsqrtVerifier::new(node.clone(), transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![Box::new(v)], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // 2. Eval reduction
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    // 3. Two range checks batched
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let div_rc = RangeCheckProvider::<RiRangeCheckOperands>::new(node);
+        let div_v = div_rc
+            .read_raf_verify::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                accumulator,
+                transcript,
+            );
+        let sqrt_rc = RangeCheckProvider::<RsRangeCheckOperands>::new(node);
+        let sqrt_v = sqrt_rc
+            .read_raf_verify::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                accumulator,
+                transcript,
+            );
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![Box::new(div_v), Box::new(sqrt_v)],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    // 4. Six one-hot instances batched
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let div_enc = RangeCheckEncoding::<RiRangeCheckOperands>::new(node);
+        let [d_ra, d_hw, d_bool] =
+            joltworks::subprotocols::shout::ra_onehot_verifiers(&div_enc, accumulator, transcript);
+        let sqrt_enc = RangeCheckEncoding::<RsRangeCheckOperands>::new(node);
+        let [s_ra, s_hw, s_bool] =
+            joltworks::subprotocols::shout::ra_onehot_verifiers(&sqrt_enc, accumulator, transcript);
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![d_ra, d_hw, d_bool, s_ra, s_hw, s_bool],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    Ok(())
+}
+
 /// Verify Div operator ZK proof: custom flow mirroring prove_div_zk.
 fn verify_div_zk(
     node: &atlas_onnx_tracer::node::ComputationNode,
@@ -833,6 +907,103 @@ fn prove_cos_sin_zk(
     zk_sumcheck_proofs.push((node.idx, hw));
 }
 
+/// Prove Rsqrt with ZK: custom flow (execution from transcript, eval reduction, range checks).
+#[expect(clippy::too_many_arguments)]
+fn prove_rsqrt_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::ops::rsqrt::{RsqrtParams, RsqrtProver};
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::{RiRangeCheckOperands, RsRangeCheckOperands},
+        RangeCheckEncoding, RangeCheckProvider,
+    };
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Execution sumcheck (r_node_output + gamma from transcript)
+    let params = RsqrtParams::<F>::new(node.clone(), &mut prover.transcript);
+    let mut sc = RsqrtProver::initialize(&prover.trace, params);
+    let exec_proof = run_zk_sumcheck(
+        &mut sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, exec_proof));
+
+    // 2. Eval reduction
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // 3. Two range checks (Ri and Rs) batched together
+    let div_rc = RangeCheckProvider::<RiRangeCheckOperands>::new(node);
+    let (div_rc_sc, div_rc_idx) = div_rc
+        .read_raf_prove::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+            &prover.trace,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+    let sqrt_rc = RangeCheckProvider::<RsRangeCheckOperands>::new(node);
+    let (sqrt_rc_sc, sqrt_rc_idx) = sqrt_rc
+        .read_raf_prove::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+            &prover.trace,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+    let mut rc_instances: Vec<Box<dyn SumcheckInstanceProver<F, T>>> =
+        vec![Box::new(div_rc_sc), Box::new(sqrt_rc_sc)];
+    let rc_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        rc_instances.iter_mut().map(|v| &mut **v as _).collect();
+    let rc_proof = run_zk_batched_sumcheck(
+        rc_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, rc_proof));
+
+    // 4. Six one-hot instances (3 per range check) batched together
+    let div_enc = RangeCheckEncoding::<RiRangeCheckOperands>::new(node);
+    let [div_ra, div_hw, div_bool] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &div_enc,
+        &div_rc_idx,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let sqrt_enc = RangeCheckEncoding::<RsRangeCheckOperands>::new(node);
+    let [sqrt_ra, sqrt_hw, sqrt_bool] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &sqrt_enc,
+        &sqrt_rc_idx,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let mut oh_instances: Vec<Box<dyn SumcheckInstanceProver<F, T>>> =
+        vec![div_ra, div_hw, div_bool, sqrt_ra, sqrt_hw, sqrt_bool];
+    let oh_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        oh_instances.iter_mut().map(|v| &mut **v as _).collect();
+    let oh_proof = run_zk_batched_sumcheck(
+        oh_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, oh_proof));
+}
+
 /// Prove Div operator with ZK: custom flow with execution sumcheck before eval reduction.
 #[expect(clippy::too_many_arguments)]
 fn prove_div_zk(
@@ -992,17 +1163,30 @@ pub fn prove_zk(
                 &mut eval_reduction_h_commitments,
                 &mut zk_sumcheck_proofs,
             );
-        } else if matches!(&node.operator, Operator::Div(_)) {
-            prove_div_zk(
-                node,
-                &mut prover,
-                pedersen_gens,
-                &mut blindfold_accumulator,
-                &mut stage_configs,
-                &mut eval_reduction_proofs,
-                &mut eval_reduction_h_commitments,
-                &mut zk_sumcheck_proofs,
-            );
+        } else if matches!(&node.operator, Operator::Div(_) | Operator::Rsqrt(_)) {
+            if matches!(&node.operator, Operator::Rsqrt(_)) {
+                prove_rsqrt_zk(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                    &mut zk_sumcheck_proofs,
+                );
+            } else {
+                prove_div_zk(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                    &mut zk_sumcheck_proofs,
+                );
+            }
         } else {
             // Standard flow: eval reduction first, then execution sumcheck.
             prove_zk_eval_reduction(
@@ -1315,6 +1499,14 @@ pub fn verify_zk(
             verify_cos_sin_zk(
                 node,
                 model,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
+        } else if matches!(&node.operator, Operator::Rsqrt(_)) {
+            verify_rsqrt_zk(
+                node,
                 bundle,
                 &mut accumulator,
                 &mut transcript,


### PR DESCRIPTION
- BlindFold constraints on RsqrtParams
- prove_rsqrt_zk / verify_rsqrt_zk: custom flow with execution sumcheck from transcript, eval reduction, 2 batched range checks (Ri + Rs), 6 batched one-hot instances (3 per range check)
- test_rsqrt_zk passes