### PR TITLE
Add BlindFold ZK for Einsum (8 variants) and Sum

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -1224,6 +1224,57 @@ fn test_relu_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_einsum_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let m = 1 << 2;
+    let k = 1 << 2;
+    let n = 1 << 2;
+    let mut rng = StdRng::seed_from_u64(0xBF22);
+    let a = Tensor::random_small(&mut rng, &[m, k]);
+    let b = Tensor::random_small(&mut rng, &[k, n]);
+    let mut builder = ModelBuilder::new();
+    let ia = builder.input(vec![m, k]);
+    let ib = builder.input(vec![k, n]);
+    let res = builder.einsum("mk,kn->mn", vec![ia, ib], vec![m, n]);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[a, b], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_sum_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let m = 1 << 3;
+    let n = 1 << 3;
+    let mut rng = StdRng::seed_from_u64(0xBF23);
+    let input = Tensor::random_small(&mut rng, &[m, n]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![m, n]);
+    let res = builder.sum(i, vec![0], vec![n]);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,49 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BmkBknMbnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let (b, m) = (
+            self.einsum_dims.left_operand()[0],
+            self.einsum_dims.left_operand()[1],
+        );
+        let (_, r_bn) = self.r_node_output.split_at(m.log_2());
+        let (r_b, _) = r_bn.split_at(b.log_2());
+        let (_, r_h) = sumcheck_challenges.split_at(self.log_k);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,49 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BmkKbnMbnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let (b, m) = (
+            self.einsum_dims.left_operand()[0],
+            self.einsum_dims.left_operand()[1],
+        );
+        let (_, r_bn) = self.r_node_output.split_at(m.log_2());
+        let (r_b, _) = r_bn.split_at(b.log_2());
+        let (_, r_h) = sumcheck_challenges.split_at(self.log_k);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
@@ -30,6 +30,11 @@ use joltworks::{
 use rayon::prelude::*;
 use std::array;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 const DEGREE_BOUND: usize = 2;
 
 /// Parameters for proving Einsum k,nk->n operations.
@@ -75,6 +80,38 @@ impl<F: JoltField> SumcheckInstanceParams<F> for KNkNParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.einsum_dims.left_operand()[0].log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![
+                ValueSource::Opening(left_id),
+                ValueSource::Opening(right_id),
+            ]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/m_an_a1nm.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/m_an_a1nm.rs
@@ -16,6 +16,11 @@ use joltworks::{
     utils::math::Math,
 };
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 use crate::utils::{
     dims::EinsumDims,
     opening_access::{AccOpeningAccessor, Target},
@@ -96,6 +101,38 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MAnA1nmParams<F> {
 
     fn num_rounds(&self) -> usize {
         0
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![
+                ValueSource::Opening(left_id),
+                ValueSource::Opening(right_id),
+            ]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,45 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MbkBnkBmnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let b = self.einsum_dims.left_operand()[1];
+        let (r_b, _) = self.r_node_output.split_at(b.log_2());
+        let (r_h, _r_j) = sumcheck_challenges.split_at(self.log_b);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,45 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MbkNbkBmnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let b = self.einsum_dims.left_operand()[1];
+        let (r_b, _) = self.r_node_output.split_at(b.log_2());
+        let (r_h, _r_j) = sumcheck_challenges.split_at(self.log_b);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
@@ -31,6 +31,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 const DEGREE_BOUND: usize = 2;
 
 /// Parameters for proving Einsum mk,kn->mn operations.
@@ -76,6 +81,38 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MkKnMnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.einsum_dims.right_operand()[0].log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![
+                ValueSource::Opening(left_id),
+                ValueSource::Opening(right_id),
+            ]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/rbmk_rbnk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/rbmk_rbnk_bmn.rs
@@ -27,6 +27,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 use crate::utils::{
     dims::EinsumDims,
     opening_access::{AccOpeningAccessor, Target},
@@ -207,6 +212,58 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RbmkRbnkBmnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.variant.num_rounds()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let eq_eval = match self.variant {
+            RbmkRbnkBmnVariant::AbmkAbnkAbmn { log_a, log_b, .. } => {
+                let (r_a, r_bmn) = self.r_node_output.split_at(log_a);
+                let (r_b, _) = r_bmn.split_at(log_b);
+                let sumcheck_opening = sumcheck_challenges.into_opening();
+                let (r_ab, _) = sumcheck_opening.split_at(log_a + log_b);
+                EqPolynomial::mle(&[r_a.r.as_slice(), r_b.r.as_slice()].concat(), r_ab)
+            }
+            RbmkRbnkBmnVariant::AcbmkKcnCbmn { log_c, log_b, .. } => {
+                let (r_c, r_bmn) = self.r_node_output.split_at(log_c);
+                let (r_b, _) = r_bmn.split_at(log_b);
+                let sumcheck_opening = sumcheck_challenges.into_opening();
+                let (r_cb, _) = sumcheck_opening.split_at(log_c + log_b);
+                EqPolynomial::mle(&[r_c.r.as_slice(), r_b.r.as_slice()].concat(), r_cb)
+            }
+            RbmkRbnkBmnVariant::CbmkCbknAmn { .. } => F::one(),
+        };
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 use crate::utils::{
     dims::{SumAxis, SumConfig},
     opening_access::{AccOpeningAccessor, Target},
@@ -70,6 +75,34 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SumAxisParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.sum_config.operand_dims()[self.sum_config.axis().axis_index()].log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let input_id = builder.nodeio(Target::Input(0));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![ValueSource::Opening(input_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/sum/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sum/mod.rs
@@ -21,6 +21,28 @@ use crate::{
 /// Axis-wise sum implementations for sumcheck protocol.
 pub mod axis;
 
+/// Create a Sum prover instance for the ZK pipeline.
+pub fn create_sum_prover<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    trace: &atlas_onnx_tracer::model::trace::Trace,
+    accumulator: &joltworks::poly::opening_proof::ProverOpeningAccumulator<F>,
+) -> Box<dyn joltworks::subprotocols::sumcheck_prover::SumcheckInstanceProver<F, T>> {
+    let sum_config = utils::dims::sum_config(node, model);
+    let params = SumAxisParams::new(node.clone(), sum_config, accumulator);
+    Box::new(SumAxisProver::initialize(trace, params, accumulator))
+}
+
+/// Create a Sum verifier instance for the ZK pipeline.
+pub fn create_sum_verifier<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    accumulator: &joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+) -> Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>> {
+    let sum_config = utils::dims::sum_config(node, model);
+    Box::new(SumAxisVerifier::new(node.clone(), sum_config, accumulator))
+}
+
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sum {
     #[tracing::instrument(skip_all, name = "Sum::prove")]
     fn prove(

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1769,12 +1769,31 @@ fn create_prover_instance(
                 params,
             )))
         }
+        Operator::Einsum(_) => {
+            use crate::onnx_proof::ops::einsum::EinsumProver;
+            Some(EinsumProver::sumcheck(
+                model,
+                &prover.trace,
+                node.clone(),
+                &prover.accumulator,
+            ))
+        }
+        Operator::Sum(_) => {
+            use crate::onnx_proof::ops::sum::create_sum_prover;
+            Some(create_sum_prover(
+                node,
+                model,
+                &prover.trace,
+                &prover.accumulator,
+            ))
+        }
         Operator::Input(_)
         | Operator::Identity(_)
         | Operator::Broadcast(_)
         | Operator::MoveAxis(_)
         | Operator::Constant(_)
-        | Operator::IsNan(_) => None,
+        | Operator::IsNan(_)
+        | Operator::Clamp(_) => None,
         other => {
             panic!("ZK proving not yet implemented for operator: {other:?}");
         }
@@ -1895,6 +1914,14 @@ fn create_verifier_instances(
                 accumulator,
                 transcript,
             ))]
+        }
+        Operator::Einsum(_) => {
+            use crate::onnx_proof::ops::einsum::EinsumVerifier;
+            vec![EinsumVerifier::sumcheck(model, node.clone(), accumulator)]
+        }
+        Operator::Sum(_) => {
+            use crate::onnx_proof::ops::sum::create_sum_verifier;
+            vec![create_sum_verifier(node, model, accumulator)]
         }
         _ => vec![],
     }


### PR DESCRIPTION
- BlindFold constraints on all 8 einsum params: simple product (left*right) for mk_kn_mn, k_nk_n, m_an_a1nm; eq_eval-scaled product for batch variants (bmk_bkn_mbn, bmk_kbn_mbn, mbk_bnk_bmn, mbk_nbk_bmn, rbmk_rbnk_bmn)
- BlindFold constraints on SumAxisParams: single opening (input)
- Also handle Clamp as no-op in ZK pipeline (no sumcheck)
