### PR TITLE
Add BlindFold ZK support for all operators

### DIFF
--- a/atlas-onnx-tracer/src/model/test.rs
+++ b/atlas-onnx-tracer/src/model/test.rs
@@ -125,6 +125,14 @@ impl ModelBuilder {
         self.insert_node(node)
     }
 
+    /// Add a bitwise AND node.
+    pub fn and(&mut self, a: Wire, b: Wire) -> Wire {
+        let id = self.alloc();
+        let output_dims = self.nodes[&a].output_dims.clone();
+        let node = ComputationNode::new(id, Operator::And(And), vec![a, b], output_dims);
+        self.insert_node(node)
+    }
+
     /// Add a multiplication node.
     pub fn mul(&mut self, a: Wire, b: Wire) -> Wire {
         let id = self.alloc();

--- a/jolt-atlas-core/examples/gpt2_zk_bench.rs
+++ b/jolt-atlas-core/examples/gpt2_zk_bench.rs
@@ -34,11 +34,22 @@ fn main() {
     // the non-zk numbers to reflect full-parallelism performance, so we
     // only `install` this pool around the ZK calls. Real fix would be
     // upstream arkworks reusing a single pool across MSM chunks.
+    // Thread count is overridable via `ZK_BENCH_THREADS` so the bench can flip
+    // between the throttled (default = 2, safe with the upstream arkworks MSM
+    // bug) and unthrottled (full parallelism, only sound with the patched
+    // arkworks MSM that drops the nested ThreadPoolBuilder) configurations
+    // without code edits. See
+    // wiki/jolt-atlas/book/src/underway/zk-prove-overhead.md.
+    let zk_num_threads: usize = std::env::var("ZK_BENCH_THREADS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2);
     let zk_pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(2)
+        .num_threads(zk_num_threads)
         .stack_size(32 * 1024 * 1024)
         .build()
         .expect("failed to build ZK rayon pool");
+    eprintln!("[bench] zk_pool threads = {zk_num_threads}");
 
     use atlas_onnx_tracer::{
         model::{Model, RunArgs},

--- a/jolt-atlas-core/examples/gpt2_zk_bench.rs
+++ b/jolt-atlas-core/examples/gpt2_zk_bench.rs
@@ -1,0 +1,183 @@
+//! Benchmark: BlindFold (zk) vs non-zk proving on GPT-2.
+//!
+//! Runs both proving paths back-to-back on the same model and inputs and
+//! reports prover time, verifier time, and proof size for each.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --release --features zk --package jolt-atlas-core --example gpt2_zk_bench
+//! ```
+
+#[cfg(not(feature = "zk"))]
+fn main() {
+    eprintln!("This example requires the `zk` feature. Re-run with:");
+    eprintln!(
+        "  cargo run --release --features zk --package jolt-atlas-core --example gpt2_zk_bench"
+    );
+    std::process::exit(1);
+}
+
+#[cfg(feature = "zk")]
+fn main() {
+    use atlas_onnx_tracer::{
+        model::{Model, RunArgs},
+        tensor::Tensor,
+    };
+    use common::utils::logging::setup_tracing;
+    use jolt_atlas_core::onnx_proof::{
+        AtlasProverPreprocessing, AtlasSharedPreprocessing, AtlasVerifierPreprocessing,
+        Blake2bTranscript, Bn254, Fr, HyperKZG, ONNXProof,
+    };
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+
+    let (_guard, _tracing_enabled) = setup_tracing("gpt2 zk-vs-nonzk bench");
+
+    let seq_len: usize = 16;
+    let run_args = RunArgs::new([
+        ("batch_size", 1),
+        ("sequence_length", seq_len),
+        ("past_sequence_length", 0),
+    ])
+    .with_pre_rebase_nonlinear(true);
+    let model = Model::load("atlas-onnx-tracer/models/gpt2/model.onnx", &run_args);
+    println!("max num vars: {}", model.max_num_vars());
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let vocab_size: i32 = 50257;
+    let input_ids_data: Vec<i32> = (0..seq_len).map(|_| rng.gen_range(0..vocab_size)).collect();
+    let input_ids = Tensor::new(Some(&input_ids_data), &[1, seq_len]).unwrap();
+    let position_ids_data: Vec<i32> = (0..seq_len as i32).collect();
+    let position_ids = Tensor::new(Some(&position_ids_data), &[1, seq_len]).unwrap();
+    let scale = run_args.scale;
+    let attention_mask_data: Vec<i32> = vec![1 << scale; seq_len];
+    let attention_mask = Tensor::new(Some(&attention_mask_data), &[1, seq_len]).unwrap();
+    let inputs = [input_ids, position_ids, attention_mask];
+
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    // ── Non-ZK path ──────────────────────────────────────────────────────
+    println!("\n=== non-zk ===");
+    let t = std::time::Instant::now();
+    let (proof, io, _dbg) =
+        ONNXProof::<Fr, Blake2bTranscript, HyperKZG<Bn254>>::prove(&prover_pp, &inputs);
+    let nonzk_prove = t.elapsed();
+    println!("prove:  {:.2?}", nonzk_prove);
+
+    let nonzk_proof_bytes = {
+        use ark_serialize::CanonicalSerialize;
+        let mut buf = Vec::new();
+        proof
+            .serialize_compressed(&mut buf)
+            .expect("serialize non-zk proof");
+        buf.len()
+    };
+    println!(
+        "size:   {} bytes ({:.2} KiB)",
+        nonzk_proof_bytes,
+        nonzk_proof_bytes as f64 / 1024.0
+    );
+
+    let t = std::time::Instant::now();
+    proof.verify(&verifier_pp, &io, None).unwrap();
+    let nonzk_verify = t.elapsed();
+    println!("verify: {:.2?}", nonzk_verify);
+
+    drop(proof);
+
+    // ── ZK path (BlindFold) ──────────────────────────────────────────────
+    println!("\n=== zk (BlindFold) ===");
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(4096);
+
+    let t = std::time::Instant::now();
+    let (bundle, zk_io) = jolt_atlas_core::onnx_proof::zk::prove_zk(&prover_pp, &inputs, &gens);
+    let zk_prove = t.elapsed();
+    println!("prove:  {:.2?}", zk_prove);
+
+    let zk_proof_bytes = zk_bundle_size(&bundle);
+    println!(
+        "size:   {} bytes ({:.2} KiB)  [excludes verifier-reconstructable stage_configs/baked]",
+        zk_proof_bytes,
+        zk_proof_bytes as f64 / 1024.0
+    );
+
+    let t = std::time::Instant::now();
+    jolt_atlas_core::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &zk_io, &gens)
+        .expect("ZK verification should succeed");
+    let zk_verify = t.elapsed();
+    println!("verify: {:.2?}", zk_verify);
+
+    // ── Summary ──────────────────────────────────────────────────────────
+    println!("\n=== summary ===");
+    println!(
+        "prove:  non-zk {:.2?}  |  zk {:.2?}  |  ratio {:.2}x",
+        nonzk_prove,
+        zk_prove,
+        zk_prove.as_secs_f64() / nonzk_prove.as_secs_f64()
+    );
+    println!(
+        "verify: non-zk {:.2?}  |  zk {:.2?}  |  ratio {:.2}x",
+        nonzk_verify,
+        zk_verify,
+        zk_verify.as_secs_f64() / nonzk_verify.as_secs_f64()
+    );
+    println!(
+        "size:   non-zk {} B  |  zk {} B  |  ratio {:.2}x",
+        nonzk_proof_bytes,
+        zk_proof_bytes,
+        zk_proof_bytes as f64 / nonzk_proof_bytes as f64
+    );
+}
+
+/// Size of the zk proof bundle in bytes (compressed).
+///
+/// Counts only the wire-protocol components. Skips `stage_configs`, `baked`, and
+/// `zk_sumcheck_num_instances`, which the verifier reconstructs from the
+/// transcript / R1CS layout.
+#[cfg(feature = "zk")]
+fn zk_bundle_size(b: &jolt_atlas_core::onnx_proof::zk::ZkProofBundle) -> usize {
+    use ark_serialize::CanonicalSerialize;
+
+    let mut n = 0;
+    n += b.blindfold_proof.compressed_size();
+
+    // BlindFoldVerifierInput: three Vec<C::G1>.
+    let bvi = &b.blindfold_verifier_input;
+    n += bvi.round_commitments.compressed_size();
+    n += bvi.output_claims_row_commitments.compressed_size();
+    n += bvi.eval_commitments.compressed_size();
+
+    // BTreeMap<usize, EvalReductionProof<F>> — sum keys + values.
+    for (k, v) in &b.eval_reduction_proofs {
+        n += k.compressed_size();
+        n += v.compressed_size();
+    }
+    for (k, v) in &b.eval_reduction_h_commitments {
+        n += k.compressed_size();
+        n += v.compressed_size();
+    }
+
+    n += b.commitments.compressed_size();
+    n += b.output_claim.compressed_size();
+
+    // Vec<(usize, ZkSumcheckProof)> — fields are pub, inline-size.
+    for (idx, zk) in &b.zk_sumcheck_proofs {
+        n += idx.compressed_size();
+        n += zk.round_commitments.compressed_size();
+        n += zk.poly_degrees.compressed_size();
+        n += zk.output_claims_commitments.compressed_size();
+    }
+
+    for (k, v) in &b.inter_stage_commitments {
+        n += k.compressed_size();
+        n += v.compressed_size();
+    }
+    for (k, v) in &b.auxiliary_claims {
+        n += k.compressed_size();
+        n += v.compressed_size();
+    }
+    n
+}

--- a/jolt-atlas-core/examples/gpt2_zk_bench.rs
+++ b/jolt-atlas-core/examples/gpt2_zk_bench.rs
@@ -19,25 +19,26 @@ fn main() {
 
 #[cfg(feature = "zk")]
 fn main() {
-    // Configure the global rayon pool BEFORE any other rayon use. Two things to
-    // cap:
-    // - stack size: the ZK pipeline does deep MLE work that overflows rayon's
-    //   default 2 MB worker stack on GPT-2-sized polynomials.
-    // - thread count: the patched arkworks MSM
-    //   (`ec/src/scalar_mul/variable_base/mod.rs:813-857`) builds a fresh
-    //   nested 2-thread `rayon::ThreadPoolBuilder` per MSM chunk per call,
-    //   spawning `current_num_threads / 2` chunks each time. With default
-    //   rayon (≈ num CPUs) and many MSMs in rapid succession we hit macOS's
-    //   per-process pthread limit (`pthread_create` → EAGAIN).
+    // Build a bounded local rayon pool used ONLY for the ZK prove/verify
+    // calls below. Two reasons to scope this locally rather than globally:
+    //  - stack size: the ZK pipeline does deep MLE work that overflows
+    //    rayon's default 2 MB worker stack on GPT-2-sized polynomials.
+    //  - thread count: the patched arkworks MSM
+    //    (`ec/src/scalar_mul/variable_base/mod.rs:813-857`) builds a fresh
+    //    nested 2-thread `rayon::ThreadPoolBuilder` per MSM chunk per call,
+    //    spawning `current_num_threads / 2` chunks each time. With default
+    //    rayon (≈ num CPUs) and many MSMs in rapid succession we hit macOS's
+    //    per-process pthread limit (`pthread_create` → EAGAIN).
     //
-    // Setting this programmatically here removes the need for `RUST_MIN_STACK`
-    // and `RAYON_NUM_THREADS` env vars on the command line. `build_global`
-    // errors if rayon was already initialised; that's fine, we just leave the
-    // existing pool in place (user-set env vars win).
-    let _ = rayon::ThreadPoolBuilder::new()
+    // A *global* pool change would also throttle the non-zk path; we want
+    // the non-zk numbers to reflect full-parallelism performance, so we
+    // only `install` this pool around the ZK calls. Real fix would be
+    // upstream arkworks reusing a single pool across MSM chunks.
+    let zk_pool = rayon::ThreadPoolBuilder::new()
         .num_threads(2)
         .stack_size(32 * 1024 * 1024)
-        .build_global();
+        .build()
+        .expect("failed to build ZK rayon pool");
 
     use atlas_onnx_tracer::{
         model::{Model, RunArgs},
@@ -113,7 +114,8 @@ fn main() {
     >::deterministic(4096);
 
     let t = std::time::Instant::now();
-    let (bundle, zk_io) = jolt_atlas_core::onnx_proof::zk::prove_zk(&prover_pp, &inputs, &gens);
+    let (bundle, zk_io) = zk_pool
+        .install(|| jolt_atlas_core::onnx_proof::zk::prove_zk(&prover_pp, &inputs, &gens));
     let zk_prove = t.elapsed();
     println!("prove:  {:.2?}", zk_prove);
 
@@ -125,7 +127,8 @@ fn main() {
     );
 
     let t = std::time::Instant::now();
-    jolt_atlas_core::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &zk_io, &gens)
+    zk_pool
+        .install(|| jolt_atlas_core::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &zk_io, &gens))
         .expect("ZK verification should succeed");
     let zk_verify = t.elapsed();
     println!("verify: {:.2?}", zk_verify);

--- a/jolt-atlas-core/examples/gpt2_zk_bench.rs
+++ b/jolt-atlas-core/examples/gpt2_zk_bench.rs
@@ -125,8 +125,8 @@ fn main() {
     >::deterministic(4096);
 
     let t = std::time::Instant::now();
-    let (bundle, zk_io) = zk_pool
-        .install(|| jolt_atlas_core::onnx_proof::zk::prove_zk(&prover_pp, &inputs, &gens));
+    let (bundle, zk_io) =
+        zk_pool.install(|| jolt_atlas_core::onnx_proof::zk::prove_zk(&prover_pp, &inputs, &gens));
     let zk_prove = t.elapsed();
     println!("prove:  {:.2?}", zk_prove);
 
@@ -139,7 +139,9 @@ fn main() {
 
     let t = std::time::Instant::now();
     zk_pool
-        .install(|| jolt_atlas_core::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &zk_io, &gens))
+        .install(|| {
+            jolt_atlas_core::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &zk_io, &gens)
+        })
         .expect("ZK verification should succeed");
     let zk_verify = t.elapsed();
     println!("verify: {:.2?}", zk_verify);

--- a/jolt-atlas-core/examples/gpt2_zk_bench.rs
+++ b/jolt-atlas-core/examples/gpt2_zk_bench.rs
@@ -19,6 +19,26 @@ fn main() {
 
 #[cfg(feature = "zk")]
 fn main() {
+    // Configure the global rayon pool BEFORE any other rayon use. Two things to
+    // cap:
+    // - stack size: the ZK pipeline does deep MLE work that overflows rayon's
+    //   default 2 MB worker stack on GPT-2-sized polynomials.
+    // - thread count: the patched arkworks MSM
+    //   (`ec/src/scalar_mul/variable_base/mod.rs:813-857`) builds a fresh
+    //   nested 2-thread `rayon::ThreadPoolBuilder` per MSM chunk per call,
+    //   spawning `current_num_threads / 2` chunks each time. With default
+    //   rayon (≈ num CPUs) and many MSMs in rapid succession we hit macOS's
+    //   per-process pthread limit (`pthread_create` → EAGAIN).
+    //
+    // Setting this programmatically here removes the need for `RUST_MIN_STACK`
+    // and `RAYON_NUM_THREADS` env vars on the command line. `build_global`
+    // errors if rayon was already initialised; that's fine, we just leave the
+    // existing pool in place (user-set env vars win).
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(2)
+        .stack_size(32 * 1024 * 1024)
+        .build_global();
+
     use atlas_onnx_tracer::{
         model::{Model, RunArgs},
         tensor::Tensor,

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -972,6 +972,523 @@ fn test_concat_zk() {
         .expect("ZK verification should succeed");
 }
 
+#[cfg(feature = "zk")]
+#[test]
+fn test_scalar_const_div_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF12);
+    // ScalarConstDiv divides by a constant integer. The model builder takes the divisor.
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.scalar_const_div(i, 7); // divide by 7
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_and_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    use rand::Rng;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF13);
+    // And requires boolean (0/1) inputs
+    let a_data: Vec<i32> = (0..size).map(|_| rng.gen_range(0..2)).collect();
+    let b_data: Vec<i32> = (0..size).map(|_| rng.gen_range(0..2)).collect();
+    let a = Tensor::construct(a_data, vec![size]);
+    let b_tensor = Tensor::construct(b_data, vec![size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let c = builder.constant(b_tensor.clone());
+    let res = builder.and(i, c);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[a], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_div_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF14);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let c = builder.constant(Tensor::construct(vec![1 << 8; size], vec![size]));
+    let res = builder.div(i, c);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    // Div's one-hot Ra sumcheck has degree d+1 (d=16 for XLEN), needing more generators
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_sigmoid_zk() {
+    use atlas_onnx_tracer::{
+        model::test::ModelBuilder, node::handlers::activation::NEURAL_TELEPORT_LOG_TABLE_SIZE,
+    };
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF15);
+    let min_val = -(1i32 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1));
+    let max_val = 1i32 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1);
+    let input = Tensor::random_range(&mut rng, &[size], min_val..max_val);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.sigmoid(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_tanh_zk() {
+    use atlas_onnx_tracer::{
+        model::test::ModelBuilder, node::handlers::activation::NEURAL_TELEPORT_LOG_TABLE_SIZE,
+    };
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF16);
+    let min_val = -(1i32 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1));
+    let max_val = 1i32 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1);
+    let input = Tensor::random_range(&mut rng, &[size], min_val..max_val);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.tanh(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_erf_zk() {
+    use atlas_onnx_tracer::{
+        model::test::ModelBuilder, node::handlers::activation::NEURAL_TELEPORT_LOG_TABLE_SIZE,
+    };
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF17);
+    let min_val = -(1i32 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1));
+    let max_val = 1i32 << (NEURAL_TELEPORT_LOG_TABLE_SIZE - 1);
+    let input = Tensor::random_range(&mut rng, &[size], min_val..max_val);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.erf(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_cos_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF18);
+    let input = Tensor::random_range(&mut rng, &[size], -5000..5000);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.cos(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_sin_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF19);
+    let input = Tensor::random_range(&mut rng, &[size], -5000..5000);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.sin(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_rsqrt_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF20);
+    // Rsqrt needs positive inputs; avoid 0 since we divide by x
+    let input = Tensor::random_range(&mut rng, &[size], 1..256);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.rsqrt(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_relu_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF21);
+    let input = Tensor::random_range(&mut rng, &[size], -256..256);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.relu(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_einsum_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let m = 1 << 2;
+    let k = 1 << 2;
+    let n = 1 << 2;
+    let mut rng = StdRng::seed_from_u64(0xBF22);
+    let a = Tensor::random_small(&mut rng, &[m, k]);
+    let b = Tensor::random_small(&mut rng, &[k, n]);
+    let mut builder = ModelBuilder::new();
+    let ia = builder.input(vec![m, k]);
+    let ib = builder.input(vec![k, n]);
+    let res = builder.einsum("mk,kn->mn", vec![ia, ib], vec![m, n]);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[a, b], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_sum_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let m = 1 << 3;
+    let n = 1 << 3;
+    let mut rng = StdRng::seed_from_u64(0xBF23);
+    let input = Tensor::random_small(&mut rng, &[m, n]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![m, n]);
+    let res = builder.sum(i, vec![0], vec![n]);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_gather_large_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let dict_len = 70000; // > 65536 to trigger GatherLarge
+    let word_dim = 2;
+    let num_indices = 1 << 3;
+    let mut rng = StdRng::seed_from_u64(0xBF24);
+    let indices = Tensor::random_range(&mut rng, &[num_indices], 0..dict_len as i32);
+    let mut builder = ModelBuilder::new();
+    let dict_data: Vec<i32> = (0..dict_len * word_dim).map(|i| i as i32).collect();
+    let dict = builder.constant(Tensor::construct(dict_data, vec![dict_len, word_dim]));
+    let idx = builder.input(vec![num_indices]);
+    let res = builder.gather(dict, idx, 0, vec![num_indices, word_dim]);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[indices], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_gather_small_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let dict_len = 32; // <= 65536 to trigger GatherSmall
+    let word_dim = 4;
+    let num_indices = 1 << 3;
+    let mut rng = StdRng::seed_from_u64(0xBF25);
+    let indices = Tensor::random_range(&mut rng, &[num_indices], 0..dict_len as i32);
+    let mut builder = ModelBuilder::new();
+    let dict_data: Vec<i32> = (0..dict_len * word_dim).map(|i| i as i32).collect();
+    let dict = builder.constant(Tensor::construct(dict_data, vec![dict_len, word_dim]));
+    let idx = builder.input(vec![num_indices]);
+    let res = builder.gather(dict, idx, 0, vec![num_indices, word_dim]);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[indices], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_softmax_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let f = 1 << 2; // leading dim (batch)
+    let n = 1 << 2; // last axis (softmax dim)
+    let mut rng = StdRng::seed_from_u64(0xBF26);
+    let input = Tensor::random_small(&mut rng, &[f, n]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![f, n]);
+    let res = builder.softmax_last_axis(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
+#[cfg(feature = "zk")]
+#[test]
+fn test_srs_derived_pedersen_generators() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF30);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let res = builder.square(i);
+    builder.mark_output(res);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = prover_pp.pedersen_generators(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification with SRS-derived generators should succeed");
+}
+
+/// Multi-operator ZK test: input -> square -> add(constant) -> neg -> output
+/// Tests that multiple single-stage operators chain correctly under BlindFold.
+#[cfg(feature = "zk")]
+#[test]
+fn test_multi_op_arithmetic_chain_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF40);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let bias = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let sq = builder.square(i);
+    let c = builder.constant(bias);
+    let added = builder.add(sq, c);
+    let out = builder.neg(added);
+    builder.mark_output(out);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("Multi-op arithmetic chain ZK verification should succeed");
+}
+
+/// Multi-operator ZK test: input -> mul(constant) -> scalar_const_div -> sub(constant) -> output
+/// Tests mul, scalar_const_div, sub chained together.
+#[cfg(feature = "zk")]
+#[test]
+fn test_multi_op_mul_div_sub_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF41);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let weights = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let offset = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let w = builder.constant(weights);
+    let m = builder.mul(i, w);
+    let d = builder.scalar_const_div(m, 128);
+    let o = builder.constant(offset);
+    let out = builder.sub(d, o);
+    builder.mark_output(out);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("Multi-op mul/div/sub ZK verification should succeed");
+}
+
+/// Multi-operator ZK test with Relu: input -> cube -> relu -> output
+/// Tests chaining a degree-3 operator with a lookup-based operator.
+#[cfg(feature = "zk")]
+#[test]
+fn test_multi_op_cube_relu_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF42);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let c = builder.cube(i, 1 << 8);
+    let out = builder.relu(c);
+    builder.mark_output(out);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("Multi-op cube+relu ZK verification should succeed");
+}
+
+/// Multi-operator ZK test with Div: input -> div(constant) -> add(constant) -> output
+/// Tests a custom-flow operator (Div with range checks) chained with a simple operator.
+#[cfg(feature = "zk")]
+#[test]
+fn test_multi_op_div_add_zk() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0xBF43);
+    let input = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let bias = Tensor::<i32>::random_small(&mut rng, &[size]);
+    let mut builder = ModelBuilder::new();
+    let i = builder.input(vec![size]);
+    let divisor = builder.constant(Tensor::construct(vec![1 << 8; size], vec![size]));
+    let d = builder.div(i, divisor);
+    let b = builder.constant(bias);
+    let out = builder.add(d, b);
+    builder.mark_output(out);
+    let model = builder.build();
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(32);
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("Multi-op div+add ZK verification should succeed");
+}
+
 /// Benchmark: measures ZK overhead vs standard prove/verify for Square.
 /// Run with: cargo test -p jolt-atlas-core --features zk --release bench_square_zk_overhead -- --nocapture --ignored
 #[cfg(feature = "zk")]

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -160,15 +160,15 @@ fn test_gpt2() {
 #[ignore = "requires GPT-2 ONNX model download (run scripts/download_gpt2.py first)"]
 #[test]
 fn test_gpt2_zk() {
-    // Cap rayon to keep arkworks' nested per-MSM-chunk `ThreadPoolBuilder`
-    // under macOS's per-process pthread limit, and bump the worker stack
-    // for the ZK pipeline's deep MLE recursion. See the matching comment in
-    // `examples/gpt2_zk_bench.rs`. `build_global` is a no-op if rayon is
-    // already initialised, so this respects user-set env vars.
-    let _ = rayon::ThreadPoolBuilder::new()
+    // Bounded local rayon pool for the ZK calls only. Caps thread count
+    // and bumps stack size to dodge two macOS-only issues without
+    // throttling the rest of the test binary; see the matching comment
+    // in `examples/gpt2_zk_bench.rs`.
+    let zk_pool = rayon::ThreadPoolBuilder::new()
         .num_threads(2)
         .stack_size(32 * 1024 * 1024)
-        .build_global();
+        .build()
+        .expect("failed to build ZK rayon pool");
 
     let working_dir = "../atlas-onnx-tracer/models/gpt2/";
     let mut rng = StdRng::seed_from_u64(42);
@@ -200,12 +200,15 @@ fn test_gpt2_zk() {
         joltworks::curve::Bn254Curve,
     >::deterministic(4096);
 
-    let (bundle, io) = crate::onnx_proof::zk::prove_zk(
-        &prover_pp,
-        &[input_ids, position_ids, attention_mask],
-        &gens,
-    );
-    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+    let (bundle, io) = zk_pool.install(|| {
+        crate::onnx_proof::zk::prove_zk(
+            &prover_pp,
+            &[input_ids, position_ids, attention_mask],
+            &gens,
+        )
+    });
+    zk_pool
+        .install(|| crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens))
         .expect("ZK verification should succeed");
 }
 

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -160,6 +160,16 @@ fn test_gpt2() {
 #[ignore = "requires GPT-2 ONNX model download (run scripts/download_gpt2.py first)"]
 #[test]
 fn test_gpt2_zk() {
+    // Cap rayon to keep arkworks' nested per-MSM-chunk `ThreadPoolBuilder`
+    // under macOS's per-process pthread limit, and bump the worker stack
+    // for the ZK pipeline's deep MLE recursion. See the matching comment in
+    // `examples/gpt2_zk_bench.rs`. `build_global` is a no-op if rayon is
+    // already initialised, so this respects user-set env vars.
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(2)
+        .stack_size(32 * 1024 * 1024)
+        .build_global();
+
     let working_dir = "../atlas-onnx-tracer/models/gpt2/";
     let mut rng = StdRng::seed_from_u64(42);
     let seq_len: usize = 16;

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -146,6 +146,59 @@ fn test_gpt2() {
     );
 }
 
+/// ZK end-to-end test for GPT-2: exercises `prove_zk` + `verify_zk`.
+///
+/// Mirrors `test_gpt2` (same inputs, seed, and run args) so any divergence between
+/// the non-zk and ZK paths is visible against an identical workload. Ignored by
+/// default because it requires the GPT-2 ONNX model download. Run with:
+///
+/// ```bash
+/// cargo test --release --features zk --package jolt-atlas-core \
+///     -- --ignored test_gpt2_zk
+/// ```
+#[cfg(feature = "zk")]
+#[ignore = "requires GPT-2 ONNX model download (run scripts/download_gpt2.py first)"]
+#[test]
+fn test_gpt2_zk() {
+    let working_dir = "../atlas-onnx-tracer/models/gpt2/";
+    let mut rng = StdRng::seed_from_u64(42);
+    let seq_len: usize = 16;
+    let vocab_size: i32 = 50257;
+
+    let input_ids_data: Vec<i32> = (0..seq_len).map(|_| rng.gen_range(0..vocab_size)).collect();
+    let input_ids = Tensor::new(Some(&input_ids_data), &[1, seq_len]).unwrap();
+
+    let position_ids_data: Vec<i32> = (0..seq_len as i32).collect();
+    let position_ids = Tensor::new(Some(&position_ids_data), &[1, seq_len]).unwrap();
+
+    let attention_mask_data: Vec<i32> = vec![SCALE; seq_len];
+    let attention_mask = Tensor::new(Some(&attention_mask_data), &[1, seq_len]).unwrap();
+
+    let run_args = RunArgs::new([
+        ("batch_size", 1),
+        ("sequence_length", seq_len),
+        ("past_sequence_length", 0),
+    ])
+    .with_pre_rebase_nonlinear(true);
+
+    let model = Model::load(&format!("{working_dir}network.onnx"), &run_args);
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(4096);
+
+    let (bundle, io) = crate::onnx_proof::zk::prove_zk(
+        &prover_pp,
+        &[input_ids, position_ids, attention_mask],
+        &gens,
+    );
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("ZK verification should succeed");
+}
+
 #[ignore = "requires BGE ONNX model download (run scripts/download_bge_small_en_v1_5.py first)"]
 #[test]
 fn test_bge_small_en_v1_5() {

--- a/jolt-atlas-core/src/onnx_proof/neural_teleport/division.rs
+++ b/jolt-atlas-core/src/onnx_proof/neural_teleport/division.rs
@@ -17,6 +17,10 @@ use atlas_onnx_tracer::{
     tensor::Tensor,
 };
 use common::VirtualPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -125,6 +129,48 @@ impl<F: JoltField> SumcheckInstanceParams<F> for TeleportDivisionParams<F> {
         self.computation_node
             .pow2_padded_num_output_elements()
             .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (tau * quotient + remainder - input)
+    //        = Challenge(0) * Opening(q) + Challenge(1) * Opening(r) + Challenge(2) * Opening(input)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let input_id = builder.nodeio(Target::Input(0));
+        let q_id = builder.advice(VirtualPoly::TeleportQuotient);
+        let r_id = builder.advice(VirtualPoly::TeleportRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(q_id)]),
+            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(r_id)]),
+            ProductTerm::scaled(
+                ValueSource::Challenge(2),
+                vec![ValueSource::Opening(input_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        let tau = F::from_i32(self.tau);
+        vec![eq_eval * tau, eq_eval, -eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -8,6 +8,10 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Add,
 };
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -73,8 +77,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AddParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -88,11 +92,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AddParams<F> {
     // output = eq_eval * (left + right) = eq_eval * left + eq_eval * right
     // Two terms, each with Challenge(0) = eq_eval scaling one opening.
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let op_builder =
             crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node);
         let left_id = op_builder.nodeio(Target::Input(0));

--- a/jolt-atlas-core/src/onnx_proof/ops/concat.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/concat.rs
@@ -11,6 +11,10 @@ use atlas_onnx_tracer::{
     ops::{Concat, Operator},
 };
 use common::parallel::par_enabled;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -163,8 +167,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ConcatSumcheckParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -177,11 +181,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ConcatSumcheckParams<F> {
 
     // output = sum_i(selector_claim_i * input_claim_i)
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         use crate::utils::opening_access::OpeningIdBuilder;
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
         let builder = OpeningIdBuilder::new(&self.computation_node);
         let terms: Vec<ProductTerm> = (0..self.computation_node.inputs.len())
             .map(|i| {

--- a/jolt-atlas-core/src/onnx_proof/ops/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cos.rs
@@ -28,6 +28,10 @@ use atlas_onnx_tracer::{
 };
 use common::parallel::par_enabled;
 use common::{CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
     field::{IntoOpening, JoltField},
@@ -263,6 +267,39 @@ impl<F: JoltField> SumcheckInstanceParams<F> for CosParams<F> {
 
     fn num_rounds(&self) -> usize {
         COS_LOG_TABLE_SIZE
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = ra_claim * (table_claim + gamma * int_eval)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let ra_id = builder.advice(VirtualPoly::CosRa);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let cos_table = MultilinearPolynomial::from(CosTable::materialize());
+        let table_claim = cos_table.evaluate(&opening_point.r);
+        let int_eval = IdentityPolynomial::new(COS_LOG_TABLE_SIZE).evaluate(&opening_point.r);
+        vec![table_claim + self.gamma * int_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/cube.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cube.rs
@@ -8,6 +8,10 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Cube,
 };
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -74,8 +78,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for CubeParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -88,11 +92,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for CubeParams<F> {
 
     // output = eq_eval * operand * operand * operand
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let op_id = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
             .nodeio(Target::Input(0));
         Some(OutputClaimConstraint::sum_of_products(vec![

--- a/jolt-atlas-core/src/onnx_proof/ops/div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/div.rs
@@ -15,6 +15,10 @@ use atlas_onnx_tracer::{
     tensor::Tensor,
 };
 use common::{consts::XLEN, CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     lookup_tables::unsigned_less_than::UnsignedLessThanTable,
@@ -202,6 +206,51 @@ impl<F: JoltField> SumcheckInstanceParams<F> for DivParams<F> {
         self.computation_node
             .pow2_padded_num_output_elements()
             .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (right * q + R - left)
+    //        = eq_eval * right * q + eq_eval * R + (-eq_eval) * left
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        let q_id = builder.nodeio(Target::Current);
+        let r_id = builder.advice(VirtualPoly::DivRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(right_id), ValueSource::Opening(q_id)],
+            ),
+            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(r_id)]),
+            ProductTerm::scaled(
+                ValueSource::Challenge(2),
+                vec![ValueSource::Opening(left_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval, eq_eval, -eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_bkn_mbn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,49 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BmkBknMbnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let (b, m) = (
+            self.einsum_dims.left_operand()[0],
+            self.einsum_dims.left_operand()[1],
+        );
+        let (_, r_bn) = self.r_node_output.split_at(m.log_2());
+        let (r_b, _) = r_bn.split_at(b.log_2());
+        let (_, r_h) = sumcheck_challenges.split_at(self.log_k);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/bmk_kbn_mbn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,49 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BmkKbnMbnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let (b, m) = (
+            self.einsum_dims.left_operand()[0],
+            self.einsum_dims.left_operand()[1],
+        );
+        let (_, r_bn) = self.r_node_output.split_at(m.log_2());
+        let (r_b, _) = r_bn.split_at(b.log_2());
+        let (_, r_h) = sumcheck_challenges.split_at(self.log_k);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/k_nk_n.rs
@@ -30,6 +30,11 @@ use joltworks::{
 use rayon::prelude::*;
 use std::array;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 const DEGREE_BOUND: usize = 2;
 
 /// Parameters for proving Einsum k,nk->n operations.
@@ -75,6 +80,38 @@ impl<F: JoltField> SumcheckInstanceParams<F> for KNkNParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.einsum_dims.left_operand()[0].log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![
+                ValueSource::Opening(left_id),
+                ValueSource::Opening(right_id),
+            ]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/m_an_a1nm.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/m_an_a1nm.rs
@@ -16,6 +16,11 @@ use joltworks::{
     utils::math::Math,
 };
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 use crate::utils::{
     dims::EinsumDims,
     opening_access::{AccOpeningAccessor, Target},
@@ -96,6 +101,38 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MAnA1nmParams<F> {
 
     fn num_rounds(&self) -> usize {
         0
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![
+                ValueSource::Opening(left_id),
+                ValueSource::Opening(right_id),
+            ]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_bnk_bmn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,45 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MbkBnkBmnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let b = self.einsum_dims.left_operand()[1];
+        let (r_b, _) = self.r_node_output.split_at(b.log_2());
+        let (r_h, _r_j) = sumcheck_challenges.split_at(self.log_b);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mbk_nbk_bmn.rs
@@ -29,6 +29,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // TODO: Add [DT24] opts
 
 const DEGREE_BOUND: usize = 3;
@@ -82,6 +87,45 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MbkNbkBmnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_b + self.log_k
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let b = self.einsum_dims.left_operand()[1];
+        let (r_b, _) = self.r_node_output.split_at(b.log_2());
+        let (r_h, _r_j) = sumcheck_challenges.split_at(self.log_b);
+        let eq_eval = EqPolynomial::mle(&r_b.r, r_h);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mk_kn_mn.rs
@@ -31,6 +31,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 const DEGREE_BOUND: usize = 2;
 
 /// Parameters for proving Einsum mk,kn->mn operations.
@@ -76,6 +81,38 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MkKnMnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.einsum_dims.right_operand()[0].log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![
+                ValueSource::Opening(left_id),
+                ValueSource::Opening(right_id),
+            ]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/rbmk_rbnk_bmn.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/rbmk_rbnk_bmn.rs
@@ -27,6 +27,11 @@ use joltworks::{
 };
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 use crate::utils::{
     dims::EinsumDims,
     opening_access::{AccOpeningAccessor, Target},
@@ -207,6 +212,58 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RbmkRbnkBmnParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.variant.num_rounds()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let right_id = builder.nodeio(Target::Input(1));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(left_id),
+                    ValueSource::Opening(right_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let eq_eval = match self.variant {
+            RbmkRbnkBmnVariant::AbmkAbnkAbmn { log_a, log_b, .. } => {
+                let (r_a, r_bmn) = self.r_node_output.split_at(log_a);
+                let (r_b, _) = r_bmn.split_at(log_b);
+                let sumcheck_opening = sumcheck_challenges.into_opening();
+                let (r_ab, _) = sumcheck_opening.split_at(log_a + log_b);
+                EqPolynomial::mle(&[r_a.r.as_slice(), r_b.r.as_slice()].concat(), r_ab)
+            }
+            RbmkRbnkBmnVariant::AcbmkKcnCbmn { log_c, log_b, .. } => {
+                let (r_c, r_bmn) = self.r_node_output.split_at(log_c);
+                let (r_b, _) = r_bmn.split_at(log_b);
+                let sumcheck_opening = sumcheck_challenges.into_opening();
+                let (r_cb, _) = sumcheck_opening.split_at(log_c + log_b);
+                EqPolynomial::mle(&[r_c.r.as_slice(), r_b.r.as_slice()].concat(), r_cb)
+            }
+            RbmkRbnkBmnVariant::CbmkCbknAmn { .. } => F::one(),
+        };
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/erf.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/erf.rs
@@ -25,6 +25,10 @@ use atlas_onnx_tracer::{
 };
 use common::parallel::par_enabled;
 use common::{CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
     field::{IntoOpening, JoltField},
@@ -226,6 +230,40 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ErfParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.op.log_table
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = ra_claim * (table_claim + gamma * int_eval)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let ra_id = builder.advice(VirtualPoly::ErfRa);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let table = ErfTable::new(self.op.log_table, self.op.tau);
+        let erf_table = MultilinearPolynomial::from(table.materialize());
+        let table_claim = erf_table.evaluate(&opening_point.r);
+        let int_eval = TeleportIdPolynomial::new(self.op.log_table).evaluate(&opening_point.r);
+        vec![table_claim + self.gamma * int_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/gather/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/gather/mod.rs
@@ -13,6 +13,10 @@ use atlas_onnx_tracer::{
 };
 use common::parallel::par_enabled;
 use common::VirtualPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -43,8 +47,8 @@ use rayon::{
     slice::ParallelSlice,
 };
 
-mod large;
-mod small;
+pub(crate) mod large;
+pub(crate) mod small;
 
 const DEGREE_BOUND: usize = 2;
 
@@ -112,6 +116,44 @@ impl<F: JoltField> SumcheckInstanceParams<F> for GatherParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.num_words.log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = ra_claim * (dict_claim + gamma * int_eval)
+    //        = Challenge(0) * Opening(ra) * Opening(dict)
+    //          + Challenge(1) * Opening(ra)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let ra_id = builder.advice(VirtualPoly::NodeOutputRa);
+        let dict_id = builder.nodeio(Target::Input(0));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(ra_id), ValueSource::Opening(dict_id)],
+            ),
+            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let int_eval = IdentityPolynomial::new(self.num_words.log_2()).evaluate(&opening_point.r);
+        vec![F::one(), self.gamma * int_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/gather/small.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/gather/small.rs
@@ -303,6 +303,59 @@ pub(crate) fn build_stage3_verifier<F: JoltField>(
     HammingWeightSumcheckVerifier::new(hw_params)
 }
 
+/// Build stage 2 verifiers from decomposed args (for ZK pipeline).
+#[cfg(feature = "zk")]
+pub(crate) fn build_stage2_verifiers_zk<F: JoltField>(
+    computation_node: &ComputationNode,
+    graph: &atlas_onnx_tracer::model::ComputationGraph,
+    accumulator: &dyn OpeningAccumulator<F>,
+    transcript: &mut impl Transcript,
+) -> (
+    HammingBooleanitySumcheckVerifier<F>,
+    BooleanitySumcheckVerifier<F>,
+) {
+    let Operator::GatherSmall(gather_op) = &computation_node.operator else {
+        panic!("Expected GatherSmall operator")
+    };
+    let dict = graph.nodes.get(&computation_node.inputs[0]).unwrap();
+    let indices = graph.nodes.get(&computation_node.inputs[1]).unwrap();
+    let num_words = dict.output_dims[gather_op.axis];
+    let num_lookups = indices.pow2_padded_num_output_elements();
+
+    let hb_params =
+        ra_hamming_bool_params::<F>(computation_node, num_lookups, accumulator, transcript);
+    let bool_params = ra_booleanity_params::<F>(
+        computation_node,
+        num_words,
+        num_lookups,
+        accumulator,
+        transcript,
+    );
+
+    (
+        HammingBooleanitySumcheckVerifier::new(hb_params),
+        BooleanitySumcheckVerifier::new(bool_params),
+    )
+}
+
+/// Build stage 3 verifier from decomposed args (for ZK pipeline).
+#[cfg(feature = "zk")]
+pub(crate) fn build_stage3_verifier_zk<F: JoltField>(
+    computation_node: &ComputationNode,
+    graph: &atlas_onnx_tracer::model::ComputationGraph,
+    accumulator: &dyn OpeningAccumulator<F>,
+    transcript: &mut impl Transcript,
+) -> HammingWeightSumcheckVerifier<F> {
+    let Operator::GatherSmall(gather_op) = &computation_node.operator else {
+        panic!("Expected GatherSmall operator")
+    };
+    let dict = graph.nodes.get(&computation_node.inputs[0]).unwrap();
+    let num_words = dict.output_dims[gather_op.axis];
+    let hw_params =
+        ra_hamming_weight_params::<F>(computation_node, num_words, accumulator, transcript);
+    HammingWeightSumcheckVerifier::new(hw_params)
+}
+
 fn ra_hamming_weight_params<F: JoltField>(
     computation_node: &ComputationNode,
     num_words: usize,

--- a/jolt-atlas-core/src/onnx_proof/ops/iff.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/iff.rs
@@ -7,6 +7,10 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Iff,
 };
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -77,8 +81,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for IffParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -92,11 +96,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for IffParams<F> {
     // output = eq_eval * (mask * a + (1 - mask) * b)
     //        = eq_eval * mask * a + eq_eval * b - eq_eval * mask * b
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         use crate::utils::opening_access::OpeningIdBuilder;
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
         let builder = OpeningIdBuilder::new(&self.computation_node);
         let mask_id = builder.nodeio(Target::Input(0));
         let a_id = builder.nodeio(Target::Input(1));

--- a/jolt-atlas-core/src/onnx_proof/ops/mul.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mul.rs
@@ -8,6 +8,10 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Mul,
 };
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -73,8 +77,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MulParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -87,11 +91,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MulParams<F> {
 
     // output = eq_eval * left * right
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node);
         let left_id = builder.clone().nodeio(Target::Input(0));
         let right_id = builder.nodeio(Target::Input(1));

--- a/jolt-atlas-core/src/onnx_proof/ops/neg.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/neg.rs
@@ -8,6 +8,10 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Neg,
 };
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -73,8 +77,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for NegParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -87,11 +91,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for NegParams<F> {
 
     // output = eq_eval * (-operand) = (-eq_eval) * operand
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let operand_id =
             crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
                 .nodeio(Target::Input(0));

--- a/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/reshape.rs
@@ -21,6 +21,10 @@ use atlas_onnx_tracer::{
     ops::Reshape,
 };
 use common::parallel::par_enabled;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{ChallengeFieldOps, IntoOpening, JoltField},
     poly::{
@@ -201,8 +205,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -217,11 +221,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReshapeSumcheckParams<F> {
     // selector_claim is deterministic from public data (shapes + r_output), so Challenge(0).
     // input_claim is an opening.
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let input_id = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
             .nodeio(Target::Input(0));
         let term = ProductTerm::scaled(

--- a/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/rsqrt.rs
@@ -15,6 +15,10 @@ use atlas_onnx_tracer::{
     ops::Rsqrt,
 };
 use common::{consts::XLEN, CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     lookup_tables::unsigned_less_than::UnsignedLessThanTable,
@@ -58,8 +62,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Rsqrt {
         let mut results = Vec::new();
         // Execution proof
         let params = RsqrtParams::new(node.clone(), &mut prover.transcript);
-        let mut prover_sumcheck =
-            RsqrtProver::initialize(&prover.trace, &mut prover.transcript, params);
+        let mut prover_sumcheck = RsqrtProver::initialize(&prover.trace, params);
         let (proof, _) = Sumcheck::prove(
             &mut prover_sumcheck,
             &mut prover.accumulator,
@@ -162,16 +165,21 @@ const DEGREE_BOUND: usize = 3;
 pub struct RsqrtParams<F: JoltField> {
     r_node_output: OpeningPoint<BIG_ENDIAN, F>,
     computation_node: ComputationNode,
+    /// Folding challenge for batching the inverse and sqrt relations.
+    gamma: F,
 }
 
 impl<F: JoltField> RsqrtParams<F> {
     /// Create new rsqrt parameters from a computation node and transcript.
+    /// Squeezes both the opening point and the folding challenge gamma.
     pub fn new<T: Transcript>(computation_node: ComputationNode, transcript: &mut T) -> Self {
         let num_vars = computation_node.pow2_padded_num_output_elements().log_2();
         let r_node_output = transcript.challenge_vector_optimized::<F>(num_vars);
+        let gamma = transcript.challenge_scalar();
         Self {
             r_node_output: r_node_output.into(),
             computation_node,
+            gamma,
         }
     }
 }
@@ -194,6 +202,80 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RsqrtParams<F> {
             .pow2_padded_num_output_elements()
             .log_2()
     }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq * (left*inv + r_i - Q^2 + gamma*(rsqrt^2 + r_s - Q*inv))
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let inv_id = builder.advice(CommittedPoly::RsqrtNodeInv);
+        let rsqrt_id = builder.nodeio(Target::Current);
+        let r_i_id = builder.advice(VirtualPoly::DivRemainder);
+        let r_s_id = builder.advice(VirtualPoly::SqrtRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            // eq * left * inv
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(left_id), ValueSource::Opening(inv_id)],
+            ),
+            // eq * r_i
+            ProductTerm::scaled(
+                ValueSource::Challenge(1),
+                vec![ValueSource::Opening(r_i_id)],
+            ),
+            // -eq * Q^2  (constant term, no openings)
+            ProductTerm::scaled(ValueSource::Challenge(2), vec![]),
+            // eq * gamma * rsqrt^2
+            ProductTerm::scaled(
+                ValueSource::Challenge(3),
+                vec![
+                    ValueSource::Opening(rsqrt_id),
+                    ValueSource::Opening(rsqrt_id),
+                ],
+            ),
+            // eq * gamma * r_s
+            ProductTerm::scaled(
+                ValueSource::Challenge(4),
+                vec![ValueSource::Opening(r_s_id)],
+            ),
+            // -eq * gamma * Q * inv
+            ProductTerm::scaled(
+                ValueSource::Challenge(5),
+                vec![ValueSource::Opening(inv_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_prime);
+        let eq_gamma = eq_eval * self.gamma;
+        vec![
+            eq_eval,                          // Ch(0): eq * left * inv
+            eq_eval,                          // Ch(1): eq * r_i
+            -eq_eval * F::from_i32(Q_SQUARE), // Ch(2): -eq * Q^2 (constant)
+            eq_gamma,                         // Ch(3): eq * gamma * rsqrt^2
+            eq_gamma,                         // Ch(4): eq * gamma * r_s
+            -eq_gamma * F::from_i32(Q),       // Ch(5): -eq * gamma * Q * inv
+        ]
+    }
 }
 
 /// Prover state for reciprocal square root sumcheck protocol.
@@ -214,11 +296,7 @@ pub struct RsqrtProver<F: JoltField> {
 
 impl<F: JoltField> RsqrtProver<F> {
     /// Initialize the prover with trace data, transcript, and parameters.
-    pub fn initialize<T: Transcript>(
-        trace: &Trace,
-        transcript: &mut T,
-        params: RsqrtParams<F>,
-    ) -> Self {
+    pub fn initialize(trace: &Trace, params: RsqrtParams<F>) -> Self {
         let eq_r_node_output =
             GruenSplitEqPolynomial::new(&params.r_node_output.r, BindingOrder::LowToHigh);
         let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
@@ -267,7 +345,7 @@ impl<F: JoltField> RsqrtProver<F> {
             assert_eq!(F::zero(), claim_sqrt)
         }
 
-        let gamma = transcript.challenge_scalar();
+        let gamma = params.gamma;
         Self {
             params,
             eq_r_node_output,
@@ -361,7 +439,7 @@ impl<F: JoltField> RsqrtVerifier<F> {
     /// Create a new verifier for the rsqrt operation with folding challenge from transcript.
     pub fn new<T: Transcript>(computation_node: ComputationNode, transcript: &mut T) -> Self {
         let params = RsqrtParams::new(computation_node, transcript);
-        let gamma = transcript.challenge_scalar();
+        let gamma = params.gamma;
         Self { params, gamma }
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
@@ -9,6 +9,10 @@ use atlas_onnx_tracer::{
     tensor::Tensor,
 };
 use common::CommittedPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -127,6 +131,45 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivParams<F> {
         self.computation_node
             .pow2_padded_num_output_elements()
             .log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * (left_operand - R_claim)
+    //        = eq_eval * left + (-eq_eval) * R
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let left_id = builder.nodeio(Target::Input(0));
+        let r_id = builder.advice(CommittedPoly::ScalarConstDivNodeRemainder);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(left_id)],
+            ),
+            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(r_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_node_output_prime: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
+        vec![eq_eval, -eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
@@ -25,6 +25,10 @@ use atlas_onnx_tracer::{
 };
 use common::parallel::par_enabled;
 use common::{CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
     field::{IntoOpening, JoltField},
@@ -226,6 +230,41 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SigmoidParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.op.log_table
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = ra_claim * (table_claim + gamma * int_eval)
+    //        = Challenge(0) * Opening(ra)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let ra_id = builder.advice(VirtualPoly::SigmoidRa);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let table = SigmoidTable::new(self.op.log_table, self.op.tau);
+        let sigmoid_table = MultilinearPolynomial::from(table.materialize());
+        let table_claim = sigmoid_table.evaluate(&opening_point.r);
+        let int_eval = TeleportIdPolynomial::new(self.op.log_table).evaluate(&opening_point.r);
+        vec![table_claim + self.gamma * int_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sin.rs
@@ -25,6 +25,10 @@ use atlas_onnx_tracer::{
 };
 use common::parallel::par_enabled;
 use common::{CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
     field::{IntoOpening, JoltField},
@@ -258,6 +262,39 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SinParams<F> {
 
     fn num_rounds(&self) -> usize {
         SIN_LOG_TABLE_SIZE
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = ra_claim * (table_claim + gamma * int_eval)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let ra_id = builder.advice(VirtualPoly::SinRa);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let sin_table = MultilinearPolynomial::from(SinTable::materialize());
+        let table_claim = sin_table.evaluate(&opening_point.r);
+        let int_eval = IdentityPolynomial::new(SIN_LOG_TABLE_SIZE).evaluate(&opening_point.r);
+        vec![table_claim + self.gamma * int_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/slice.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/slice.rs
@@ -11,6 +11,10 @@ use atlas_onnx_tracer::{
     ops::{Operator, Slice},
 };
 use common::parallel::par_enabled;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -160,8 +164,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SliceSumcheckParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -175,11 +179,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SliceSumcheckParams<F> {
     // output = input_claim * selector_claim
     // selector_claim is deterministic from public data (shapes + r_output), so Challenge(0).
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let input_id = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
             .nodeio(Target::Input(0));
         let term = ProductTerm::scaled(

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/exp_sum.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/exp_sum.rs
@@ -2,6 +2,10 @@ use crate::utils::opening_access::AccOpeningAccessor;
 use atlas_onnx_tracer::node::ComputationNode;
 use common::parallel::par_enabled;
 use common::VirtualPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -78,6 +82,42 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ExpSumParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_F() + self.log_N()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * exp_q = Challenge(0) * Opening(exp_q)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.node);
+        let exp_q_id = builder.advice(VirtualPoly::SoftmaxExpQ);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(exp_q_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_sc: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let r1_k = &r_sc[..self.log_F()];
+        let eq_eval = EqPolynomial::mle(&self.r0_k, r1_k);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/exponentiation/mult.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/exponentiation/mult.rs
@@ -1,6 +1,10 @@
 use crate::utils::opening_access::AccOpeningAccessor;
 use atlas_onnx_tracer::node::ComputationNode;
 use common::VirtualPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -64,6 +68,45 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MultParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.r.len()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * exp_hi * exp_lo = Challenge(0) * Opening(exp_hi) * Opening(exp_lo)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.node);
+        let exp_hi_id = builder.advice(VirtualPoly::SoftmaxExpHi);
+        let exp_lo_id = builder.advice(VirtualPoly::SoftmaxExpLo);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![
+                    ValueSource::Opening(exp_hi_id),
+                    ValueSource::Opening(exp_lo_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_sc: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r, &r_sc);
+        vec![eq_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/max.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/max.rs
@@ -4,6 +4,10 @@ use std::array;
 use crate::utils::opening_access::{AccOpeningAccessor, Target};
 use atlas_onnx_tracer::node::ComputationNode;
 use common::VirtualPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -104,6 +108,50 @@ impl<F: JoltField> SumcheckInstanceParams<F> for MaxIndicatorParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.F_N.iter().product::<usize>().log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq(r1_k, r_k) * e_claim * X_claim = Challenge(0) * Opening(X)
+    // e_claim is verifier-computable from argmax_k, folded into Challenge(0)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.node);
+        let x_id = builder.nodeio(Target::Input(0));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(x_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_sc: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let (r_k, r_j) = r_sc.split_at(self.log_F());
+        let eq_k_evals = EqPolynomial::evals(r_k);
+        let log_n = r_j.len();
+        let e_claim: F = eq_k_evals
+            .iter()
+            .zip(self.argmax_k.iter())
+            .map(|(&eq_k, &argmax_j)| {
+                let y = index_to_field_bitvector::<F>(argmax_j as u64, log_n);
+                eq_k * EqPolynomial::mle(r_j, &y)
+            })
+            .sum();
+        let eq_eval = EqPolynomial::mle(&self.r1_k, r_k);
+        vec![eq_eval * e_claim]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
@@ -121,11 +121,11 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for SoftmaxLastAxis {
     }
 }
 
-struct SoftmaxLastAxisProver {
-    computation_node: ComputationNode,
-    scale: i32,
-    F_N: [usize; 2],
-    trace: SoftmaxLastAxisTrace,
+pub(crate) struct SoftmaxLastAxisProver {
+    pub(crate) computation_node: ComputationNode,
+    pub(crate) scale: i32,
+    pub(crate) F_N: [usize; 2],
+    pub(crate) trace: SoftmaxLastAxisTrace,
 }
 
 impl SoftmaxLastAxisProver {
@@ -206,7 +206,7 @@ impl SoftmaxLastAxisProver {
 ///
 /// Mirror of [`SoftmaxLastAxisProver`] — each stage method corresponds to a
 /// prover stage and verifies the associated sumcheck proof.
-pub struct SoftmaxLastAxisVerifier {
+pub(crate) struct SoftmaxLastAxisVerifier {
     computation_node: ComputationNode,
     scale: i32,
     F_N: [usize; 2],
@@ -250,7 +250,7 @@ impl SoftmaxLastAxisVerifier {
 // ---------------------------------------------------------------------------
 
 impl SoftmaxLastAxisProver {
-    fn new(node: &ComputationNode, trace: SoftmaxLastAxisTrace, scale: i32) -> Self {
+    pub(crate) fn new(node: &ComputationNode, trace: SoftmaxLastAxisTrace, scale: i32) -> Self {
         let (&n, leading_dims) = node
             .output_dims
             .split_last()
@@ -282,7 +282,10 @@ impl SoftmaxLastAxisProver {
     /// the same field element).  The recovered `i32` values are then fed into
     /// `MultilinearPolynomial::from(Vec<i32>)`, which correctly uses `from_i32`
     /// for the actual MLE computations.
-    fn send_auxiliary_vectors<F: JoltField, T: Transcript>(&self, prover: &mut Prover<F, T>) {
+    pub(crate) fn send_auxiliary_vectors<F: JoltField, T: Transcript>(
+        &self,
+        prover: &mut Prover<F, T>,
+    ) {
         let [f, _] = self.F_N;
         let mut provider = AccOpeningAccessor::new(&mut prover.accumulator, &self.computation_node)
             .into_provider(&mut prover.transcript, OpeningPoint::default());
@@ -307,7 +310,7 @@ impl SoftmaxLastAxisProver {
     /// Evaluates the prover-sent `exp_sum_q` vector at the leading part of
     /// `r0` (the initial output opening point).
     #[tracing::instrument(name = "SoftmaxLastAxisProver::cache_exp_sum", skip_all)]
-    fn cache_exp_sum<F: JoltField, T: Transcript>(&self, prover: &mut Prover<F, T>) {
+    pub(crate) fn cache_exp_sum<F: JoltField, T: Transcript>(&self, prover: &mut Prover<F, T>) {
         let accessor = AccOpeningAccessor::new(&mut prover.accumulator, &self.computation_node);
         let r0 = accessor.get_reduced_opening().0;
         let log_f = self.F_N[0].log_2();
@@ -318,7 +321,7 @@ impl SoftmaxLastAxisProver {
     }
 
     /// Cache the R (remainder) polynomial to the accumulator.
-    fn cache_R<F: JoltField, T: Transcript>(&self, prover: &mut Prover<F, T>) {
+    pub(crate) fn cache_R<F: JoltField, T: Transcript>(&self, prover: &mut Prover<F, T>) {
         let accessor = AccOpeningAccessor::new(&mut prover.accumulator, &self.computation_node);
         let r0 = accessor.get_reduced_opening().0;
         let eval = MultilinearPolynomial::from(self.trace.R.clone()).evaluate(&r0.r);
@@ -332,15 +335,28 @@ impl SoftmaxLastAxisProver {
         prover: &mut Prover<F, T>,
         r_lookup_bits: Vec<LookupBits>,
     ) -> SumcheckInstanceProof<F, T> {
-        // recip mult instance
-        let recip_mult_params = RecipMultParams::new(
+        let mut instances = self.build_stage1_instances(prover, r_lookup_bits);
+        run_batched_prove(&mut instances, prover)
+    }
+
+    /// Build stage 1 sumcheck instances without running the sumcheck.
+    pub(crate) fn build_stage1_instances<F: JoltField, T: Transcript>(
+        &mut self,
+        prover: &mut Prover<F, T>,
+        r_lookup_bits: Vec<LookupBits>,
+    ) -> Vec<Box<dyn SumcheckInstanceProver<F, T>>> {
+        let mut recip_mult_params = RecipMultParams::new(
             self.computation_node.clone(),
             self.scale,
             self.F_N,
             &prover.accumulator,
             &mut prover.transcript,
         );
-        // Clone exp_q for exp_sum, take for recip_mult (two consumers need owned copies)
+        #[cfg(feature = "zk")]
+        {
+            recip_mult_params.inv_sum_evals =
+                self.trace.inv_sum.iter().map(|&x| F::from_i32(x)).collect();
+        }
         let exp_q_for_sum = self.trace.exp_q.clone();
         let recip_mult_prover = RecipMultProver::initialize(
             std::mem::take(&mut self.trace.exp_q),
@@ -348,7 +364,6 @@ impl SoftmaxLastAxisProver {
             recip_mult_params,
         );
 
-        // exp sum instance
         let exp_sum_params = ExpSumParams::new(
             self.computation_node.clone(),
             self.F_N,
@@ -357,7 +372,6 @@ impl SoftmaxLastAxisProver {
         );
         let exp_sum_prover = ExpSumProver::initialize(exp_q_for_sum, exp_sum_params);
 
-        // range-check R instance (uses pre-computed lookup bits)
         let provider = SoftmaxRCProvider::remainder(
             self.computation_node.clone(),
             prover.preprocessing.scale(),
@@ -365,17 +379,16 @@ impl SoftmaxLastAxisProver {
         let rc_R_prover =
             identity_rangecheck_prover(&provider, r_lookup_bits, &mut prover.accumulator);
 
-        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> = vec![
+        vec![
             Box::new(recip_mult_prover),
             Box::new(exp_sum_prover),
             Box::new(rc_R_prover),
-        ];
-        run_batched_prove(&mut instances, prover)
+        ]
     }
 
     /// Cache the r_exp polynomial to the accumulator.
     #[tracing::instrument(name = "SoftmaxLastAxisProver::cache_r_exp", skip_all)]
-    fn cache_r_exp<F: JoltField, T: Transcript>(&self, prover: &mut Prover<F, T>) {
+    pub(crate) fn cache_r_exp<F: JoltField, T: Transcript>(&self, prover: &mut Prover<F, T>) {
         let accessor = AccOpeningAccessor::new(&mut prover.accumulator, &self.computation_node);
         let r1 = accessor.get_advice(VirtualPoly::SoftmaxExpQ).0;
         let eval =
@@ -392,16 +405,26 @@ impl SoftmaxLastAxisProver {
         r_indices: &[usize],
         lut_data: &LookupTableData,
     ) -> SumcheckInstanceProof<F, T> {
-        // max indicator instance
+        let mut instances =
+            self.build_stage2_instances(prover, r_exp_lookup_bits, r_indices, lut_data);
+        run_batched_prove(&mut instances, prover)
+    }
+
+    /// Build stage 2 sumcheck instances without running the sumcheck.
+    pub(crate) fn build_stage2_instances<F: JoltField, T: Transcript>(
+        &mut self,
+        prover: &mut Prover<F, T>,
+        r_exp_lookup_bits: Vec<LookupBits>,
+        r_indices: &[usize],
+        lut_data: &LookupTableData,
+    ) -> Vec<Box<dyn SumcheckInstanceProver<F, T>>> {
         let [f, _n] = self.F_N;
         let log_f = f.log_2();
 
-        // Get r1 (the exp_q opening point from Stage 1)
         let accessor = AccOpeningAccessor::new(&prover.accumulator, &self.computation_node);
         let r1 = accessor.get_advice(VirtualPoly::SoftmaxExpQ).0;
         let r1_k = r1.split_at(log_f).0;
 
-        // max_k(r1_k) — evaluate the auxiliary max_k vector at the leading point
         let max_k_eval = MultilinearPolynomial::from(self.trace.max_k.clone()).evaluate(&r1_k.r);
         let max_indicator_params = MaxIndicatorParams::new(
             self.computation_node.clone(),
@@ -413,7 +436,6 @@ impl SoftmaxLastAxisProver {
         let max_indicator_prover =
             MaxIndicatorProver::initialize(std::mem::take(&mut self.trace.x), max_indicator_params);
 
-        // exp mult instance
         let exp_mult_params = MultParams::new(
             self.computation_node.clone(),
             self.scale,
@@ -425,7 +447,6 @@ impl SoftmaxLastAxisProver {
             exp_mult_params,
         );
 
-        // range-check r_exp instance (uses pre-computed lookup bits)
         let provider = SoftmaxRCProvider::exp_remainder(
             self.computation_node.clone(),
             prover.preprocessing.scale(),
@@ -433,7 +454,6 @@ impl SoftmaxLastAxisProver {
         let exp_r_rc_prover =
             identity_rangecheck_prover(&provider, r_exp_lookup_bits, &mut prover.accumulator);
 
-        // one-hot check for R ra (uses pre-computed indices)
         let encoding = SoftmaxRaEncoding::remainder(self.idx(), prover.preprocessing.scale());
         let [R_ra_prover, R_hw_prover, R_bool_prover] = shout::ra_onehot_provers(
             &encoding,
@@ -442,7 +462,6 @@ impl SoftmaxLastAxisProver {
             &mut prover.transcript,
         );
 
-        // complementary slackness: sat_diff * (z_bound − 1 − z_hi * B − z_lo) = 0
         let sd_params = SatDiffSlacknessParams::new(
             self.computation_node.clone(),
             lut_data.z_bound_minus_1,
@@ -456,7 +475,7 @@ impl SoftmaxLastAxisProver {
             sd_params,
         );
 
-        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> = vec![
+        vec![
             Box::new(exp_mult_prover),
             Box::new(max_indicator_prover),
             Box::new(exp_r_rc_prover),
@@ -464,8 +483,7 @@ impl SoftmaxLastAxisProver {
             R_hw_prover,
             R_bool_prover,
             Box::new(sd_prover),
-        ];
-        run_batched_prove(&mut instances, prover)
+        ]
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisProver::stage3", skip_all)]
@@ -476,9 +494,19 @@ impl SoftmaxLastAxisProver {
         sat_diff_lookup_bits: Vec<LookupBits>,
         r_exp_indices: &[usize],
     ) -> SumcheckInstanceProof<F, T> {
-        // read-raf for exponentiation
+        let mut instances =
+            self.build_stage3_instances(prover, lut_data, sat_diff_lookup_bits, r_exp_indices);
+        run_batched_prove(&mut instances, prover)
+    }
 
-        // hi
+    /// Build stage 3 sumcheck instances without running the sumcheck.
+    pub(crate) fn build_stage3_instances<F: JoltField, T: Transcript>(
+        &self,
+        prover: &mut Prover<F, T>,
+        lut_data: &LookupTableData,
+        sat_diff_lookup_bits: Vec<LookupBits>,
+        r_exp_indices: &[usize],
+    ) -> Vec<Box<dyn SumcheckInstanceProver<F, T>>> {
         let hi_provider = ExpReadRafProvider {
             node: self.computation_node.clone(),
             table_size: lut_data.table_hi.len(),
@@ -492,7 +520,6 @@ impl SoftmaxLastAxisProver {
             &mut prover.transcript,
         );
 
-        // lo
         let lo_provider = ExpReadRafProvider {
             node: self.computation_node.clone(),
             table_size: lut_data.table_lo.len(),
@@ -506,12 +533,10 @@ impl SoftmaxLastAxisProver {
             &mut prover.transcript,
         );
 
-        // rc sat diff (uses pre-computed lookup bits)
         let provider = SoftmaxRCProvider::sat_diff(self.computation_node.clone());
         let sat_diff_rc_prover =
             identity_rangecheck_prover(&provider, sat_diff_lookup_bits, &mut prover.accumulator);
 
-        // one-hot checks for r_exp ra (uses pre-computed indices)
         let encoding = SoftmaxRaEncoding::exp_remainder(self.idx(), prover.preprocessing.scale());
         let [exp_r_ra_prover, exp_r_hw_prover, exp_r_bool_prover] = shout::ra_onehot_provers(
             &encoding,
@@ -520,27 +545,33 @@ impl SoftmaxLastAxisProver {
             &mut prover.transcript,
         );
 
-        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> = vec![
+        vec![
             hi_prover,
             lo_prover,
             Box::new(sat_diff_rc_prover),
             exp_r_ra_prover,
             exp_r_hw_prover,
             exp_r_bool_prover,
-        ];
-        run_batched_prove(&mut instances, prover)
+        ]
     }
 
-    #[tracing::instrument(name = "SoftmaxLastAxisProver::stage4", skip_all)]
     fn stage4<F: JoltField, T: Transcript>(
         &self,
         prover: &mut Prover<F, T>,
         lut_data: &LookupTableData,
         sat_diff_indices: &[usize],
     ) -> SumcheckInstanceProof<F, T> {
-        // one-hot checks for z_hi_ra and z_lo_ra
+        let mut instances = self.build_stage4_instances(prover, lut_data, sat_diff_indices);
+        run_batched_prove(&mut instances, prover)
+    }
 
-        // hi
+    /// Build stage 4 sumcheck instances without running the sumcheck.
+    pub(crate) fn build_stage4_instances<F: JoltField, T: Transcript>(
+        &self,
+        prover: &mut Prover<F, T>,
+        lut_data: &LookupTableData,
+        sat_diff_indices: &[usize],
+    ) -> Vec<Box<dyn SumcheckInstanceProver<F, T>>> {
         let encoding = SoftmaxRaEncoding::exp_hi(self.idx(), lut_data.table_hi.len().log_2());
         let [hi_ra_prover, hi_hw_prover, hi_bool_prover] = shout::ra_onehot_provers(
             &encoding,
@@ -549,7 +580,6 @@ impl SoftmaxLastAxisProver {
             &mut prover.transcript,
         );
 
-        // lo
         let encoding = SoftmaxRaEncoding::exp_lo(self.idx(), lut_data.table_lo.len().log_2());
         let [lo_ra_prover, lo_hw_prover, lo_bool_prover] = shout::ra_onehot_provers(
             &encoding,
@@ -558,7 +588,6 @@ impl SoftmaxLastAxisProver {
             &mut prover.transcript,
         );
 
-        // one-hot checks for sat_diff ra
         let encoding = SoftmaxRaEncoding::sat_diff(self.idx());
         let [sat_diff_ra_prover, sat_diff_hw_prover, sat_diff_bool_prover] =
             shout::ra_onehot_provers(
@@ -568,7 +597,7 @@ impl SoftmaxLastAxisProver {
                 &mut prover.transcript,
             );
 
-        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> = vec![
+        vec![
             hi_ra_prover,
             hi_hw_prover,
             hi_bool_prover,
@@ -578,8 +607,7 @@ impl SoftmaxLastAxisProver {
             sat_diff_ra_prover,
             sat_diff_hw_prover,
             sat_diff_bool_prover,
-        ];
-        run_batched_prove(&mut instances, prover)
+        ]
     }
 }
 
@@ -592,7 +620,7 @@ impl SoftmaxLastAxisVerifier {
     ///
     /// Mirror of [`SoftmaxLastAxisProver::send_auxiliary_vectors`].
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::new", skip_all)]
-    fn new<F: JoltField, T: Transcript>(
+    pub(crate) fn new<F: JoltField, T: Transcript>(
         node: &ComputationNode,
         scale: i32,
         verifier: &mut Verifier<'_, F, T>,
@@ -655,7 +683,7 @@ impl SoftmaxLastAxisVerifier {
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::inv_sum_evals", skip_all)]
-    fn inv_sum_evals<F: JoltField, T: Transcript>(
+    pub(crate) fn inv_sum_evals<F: JoltField, T: Transcript>(
         &self,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<Vec<F>, ProofVerifyError> {
@@ -686,7 +714,7 @@ impl SoftmaxLastAxisVerifier {
     /// Cache `exp_sum_q(r0_lead)` — mirror of prover [`cache_exp_sum`].
     /// And verify that the claimed `exp_sum_q` values are consistent with the opening.
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::cache_exp_sum", skip_all)]
-    fn cache_exp_sum<F: JoltField, T: Transcript>(
+    pub(crate) fn cache_exp_sum<F: JoltField, T: Transcript>(
         &mut self,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
@@ -709,7 +737,7 @@ impl SoftmaxLastAxisVerifier {
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::cache_R", skip_all)]
     /// Append the remainder polynomial commitment to the accumulator.
-    fn cache_R<F: JoltField, T: Transcript>(&self, verifier: &mut Verifier<'_, F, T>) {
+    pub(crate) fn cache_R<F: JoltField, T: Transcript>(&self, verifier: &mut Verifier<'_, F, T>) {
         let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, &self.computation_node);
         let r = accessor.get_reduced_opening().0;
         let mut provider = accessor.into_provider(&mut verifier.transcript, r);
@@ -753,7 +781,10 @@ impl SoftmaxLastAxisVerifier {
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::cache_r_exp", skip_all)]
-    fn cache_r_exp<F: JoltField, T: Transcript>(&self, verifier: &mut Verifier<'_, F, T>) {
+    pub(crate) fn cache_r_exp<F: JoltField, T: Transcript>(
+        &self,
+        verifier: &mut Verifier<'_, F, T>,
+    ) {
         let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, &self.computation_node);
         let r = accessor.get_advice(VirtualPoly::SoftmaxExpQ).0;
         let mut provider = accessor.into_provider(&mut verifier.transcript, r);
@@ -993,12 +1024,12 @@ impl SoftmaxLastAxisVerifier {
 // ---------------------------------------------------------------------------
 
 /// Convert `i32` trace values to usize indices.
-fn to_indices(values: &[i32]) -> Vec<usize> {
+pub(crate) fn to_indices(values: &[i32]) -> Vec<usize> {
     values.iter().map(|&v| v as usize).collect()
 }
 
 /// Convert `i32` trace values to `LookupBits` with the given bit-width.
-fn to_lookup_bits(values: &[i32], bits: usize) -> Vec<LookupBits> {
+pub(crate) fn to_lookup_bits(values: &[i32], bits: usize) -> Vec<LookupBits> {
     values
         .iter()
         .map(|&v| LookupBits::new(v as u64, bits))
@@ -1006,7 +1037,7 @@ fn to_lookup_bits(values: &[i32], bits: usize) -> Vec<LookupBits> {
 }
 
 /// Pad a vector in-place to the next power of two with zeros.
-fn pad_to_power_of_two(v: &mut Vec<i32>) {
+pub(crate) fn pad_to_power_of_two(v: &mut Vec<i32>) {
     v.resize(v.len().next_power_of_two(), 0);
 }
 
@@ -1024,15 +1055,15 @@ fn run_batched_prove<F: JoltField, T: Transcript>(
 }
 
 /// Pre-computed lookup table data shared between stage3 and stage4.
-struct LookupTableData {
-    table_hi: Vec<i32>,
-    table_lo: Vec<i32>,
-    z_hi_indices: Vec<usize>,
-    z_lo_indices: Vec<usize>,
+pub(crate) struct LookupTableData {
+    pub(crate) table_hi: Vec<i32>,
+    pub(crate) table_lo: Vec<i32>,
+    pub(crate) z_hi_indices: Vec<usize>,
+    pub(crate) z_lo_indices: Vec<usize>,
     /// `z_bound - 1 = K_hi * B - 1` (unpadded).
-    z_bound_minus_1: u64,
+    pub(crate) z_bound_minus_1: u64,
     /// Digit base B.
-    base: u64,
+    pub(crate) base: u64,
 }
 
 /// Pre-computed verifier lookup table data (shared across stage3, operand_link, stage4).

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
@@ -33,6 +33,7 @@ use joltworks::{
     config::{OneHotConfig, OneHotParams},
     poly::opening_proof::VerifierOpeningAccumulator,
 };
+use std::collections::BTreeMap;
 
 use atlas_onnx_tracer::{
     node::ComputationNode,
@@ -55,6 +56,7 @@ use joltworks::{
         shout,
         sumcheck::{BatchedSumcheck, SumcheckInstanceProof},
         sumcheck_prover::SumcheckInstanceProver,
+        sumcheck_verifier::SumcheckInstanceVerifier,
     },
     transcripts::Transcript,
     utils::{errors::ProofVerifyError, lookup_bits::LookupBits, math::Math},
@@ -91,7 +93,19 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for SoftmaxLastAxis {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
-        SoftmaxLastAxisVerifier::new(node, self.scale, verifier).verify(verifier)
+        let scale_bits = verifier.preprocessing.scale();
+        let mut sm = SoftmaxLastAxisVerifier::new(
+            node,
+            self.scale,
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+        );
+        sm.verify(
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+            verifier.proofs,
+            scale_bits,
+        )
     }
 
     fn get_committed_polynomials(&self, node: &ComputationNode) -> Vec<CommittedPoly> {
@@ -217,30 +231,75 @@ pub(crate) struct SoftmaxLastAxisVerifier {
 
 impl SoftmaxLastAxisVerifier {
     #[inline]
-    fn idx(&self) -> usize {
+    pub(crate) fn idx(&self) -> usize {
         self.computation_node.idx
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::verify", skip_all)]
-    /// Run the full verification pipeline.
-    fn verify<F: JoltField, T: Transcript>(
+    /// Run the full verification pipeline (non-ZK).
+    pub(crate) fn verify<F: JoltField, T: Transcript>(
         &mut self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        proofs: &BTreeMap<ProofId, SumcheckInstanceProof<F, T>>,
+        scale_bits: i32,
     ) -> Result<(), ProofVerifyError> {
-        self.cache_exp_sum(verifier)?;
-        self.cache_R(verifier);
-        self.stage1(verifier)?;
+        self.cache_exp_sum(accumulator, transcript)?;
+        self.cache_R(accumulator, transcript);
+        self.run_stage(
+            ProofType::SoftmaxStage1,
+            self.build_stage1_verifiers(accumulator, transcript, scale_bits)?,
+            proofs,
+            accumulator,
+            transcript,
+        )?;
 
         let lut = VerifierLookupTableData::new(self.scale);
 
-        self.cache_r_exp(verifier);
-        self.stage2(verifier, &lut)?;
+        self.cache_r_exp(accumulator, transcript);
+        self.run_stage(
+            ProofType::SoftmaxStage2,
+            self.build_stage2_verifiers(accumulator, transcript, scale_bits, &lut),
+            proofs,
+            accumulator,
+            transcript,
+        )?;
 
-        self.stage3(verifier, &lut)?;
+        self.run_stage(
+            ProofType::SoftmaxStage3,
+            self.build_stage3_verifiers(accumulator, transcript, scale_bits, &lut),
+            proofs,
+            accumulator,
+            transcript,
+        )?;
 
-        self.operand_link(verifier, &lut)?;
+        self.operand_link(accumulator, &lut)?;
 
-        self.stage4(verifier, &lut)?;
+        self.run_stage(
+            ProofType::SoftmaxStage4,
+            self.build_stage4_verifiers(accumulator, transcript, &lut),
+            proofs,
+            accumulator,
+            transcript,
+        )?;
+        Ok(())
+    }
+
+    /// Drive a single batched-sumcheck stage given pre-built verifier instances.
+    fn run_stage<F: JoltField, T: Transcript>(
+        &self,
+        proof_type: ProofType,
+        instances: Vec<Box<dyn SumcheckInstanceVerifier<F, T>>>,
+        proofs: &BTreeMap<ProofId, SumcheckInstanceProof<F, T>>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+    ) -> Result<(), ProofVerifyError> {
+        let proof = proofs
+            .get(&ProofId(self.idx(), proof_type))
+            .ok_or(ProofVerifyError::MissingProof(self.idx()))?;
+        let refs: Vec<&dyn SumcheckInstanceVerifier<F, T>> =
+            instances.iter().map(|b| b.as_ref()).collect();
+        BatchedSumcheck::verify(proof, refs, accumulator, transcript)?;
         Ok(())
     }
 }
@@ -624,7 +683,8 @@ impl SoftmaxLastAxisVerifier {
     pub(crate) fn new<F: JoltField, T: Transcript>(
         node: &ComputationNode,
         scale: i32,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
     ) -> Self {
         let (&n, leading_dims) = node
             .output_dims
@@ -632,9 +692,8 @@ impl SoftmaxLastAxisVerifier {
             .expect("softmax node must have at least one output dimension");
         let f = leading_dims.iter().product::<usize>();
 
-        let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, node);
-        let mut provider =
-            accessor.into_provider(&mut verifier.transcript, OpeningPoint::default());
+        let accessor = AccOpeningAccessor::new(&mut *accumulator, node);
+        let mut provider = accessor.into_provider(&mut *transcript, OpeningPoint::default());
         for k in 0..f {
             provider.append_advice(|idx| VirtualPoly::SoftmaxSumOutput(idx, k));
             provider.append_advice(|idx| VirtualPoly::SoftmaxMaxOutput(idx, k));
@@ -658,7 +717,7 @@ impl SoftmaxLastAxisVerifier {
                 .collect()
         }
 
-        let accessor = AccOpeningAccessor::new(&verifier.accumulator, node);
+        let accessor = AccOpeningAccessor::new(&*accumulator, node);
 
         let exp_sum = read_aux_scalars(&accessor, f, VirtualPoly::SoftmaxSumOutput)
             .into_iter()
@@ -684,13 +743,13 @@ impl SoftmaxLastAxisVerifier {
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::inv_sum_evals", skip_all)]
-    pub(crate) fn inv_sum_evals<F: JoltField, T: Transcript>(
+    pub(crate) fn inv_sum_evals<F: JoltField>(
         &self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &VerifierOpeningAccumulator<F>,
     ) -> Result<Vec<F>, ProofVerifyError> {
         let [f, _] = self.F_N;
         let s_squared = (self.scale as i64) * (self.scale as i64);
-        let accessor = AccOpeningAccessor::new(&verifier.accumulator, &self.computation_node);
+        let accessor = AccOpeningAccessor::new(accumulator, &self.computation_node);
         (0..f)
             .map(|k| {
                 let exp_sum_q_k = accessor
@@ -717,13 +776,14 @@ impl SoftmaxLastAxisVerifier {
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::cache_exp_sum", skip_all)]
     pub(crate) fn cache_exp_sum<F: JoltField, T: Transcript>(
         &mut self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
     ) -> Result<(), ProofVerifyError> {
-        let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, &self.computation_node);
+        let accessor = AccOpeningAccessor::new(accumulator, &self.computation_node);
         let r0 = accessor.get_reduced_opening().0;
         let log_f = self.F_N[0].log_2();
         let r_lead = r0.split_at(log_f).0;
-        let mut provider = accessor.into_provider(&mut verifier.transcript, r_lead.clone());
+        let mut provider = accessor.into_provider(transcript, r_lead.clone());
         provider.append_advice(VirtualPoly::SoftmaxExpSum);
         let exp_sum_eval =
             MultilinearPolynomial::from(std::mem::take(&mut self.exp_sum)).evaluate(&r_lead.r);
@@ -737,197 +797,208 @@ impl SoftmaxLastAxisVerifier {
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::cache_R", skip_all)]
-    /// Append the remainder polynomial commitment to the accumulator.
-    pub(crate) fn cache_R<F: JoltField, T: Transcript>(&self, verifier: &mut Verifier<'_, F, T>) {
-        let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, &self.computation_node);
+    /// Append the remainder polynomial commitment to the accumulator (non-ZK).
+    pub(crate) fn cache_R<F: JoltField, T: Transcript>(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+    ) {
+        let accessor = AccOpeningAccessor::new(accumulator, &self.computation_node);
         let r = accessor.get_reduced_opening().0;
-        let mut provider = accessor.into_provider(&mut verifier.transcript, r);
+        let mut provider = accessor.into_provider(transcript, r);
         provider.append_advice(VirtualPoly::SoftmaxRecipMultRemainder);
     }
 
-    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::stage1", skip_all)]
-    fn stage1<F: JoltField, T: Transcript>(
+    /// Cache the remainder polynomial in the ZK pipeline.
+    ///
+    /// In ZK mode the verifier does not see the claim value (it is private and
+    /// Pedersen-committed by the prover). This method mirrors [`cache_R`] but:
+    /// - inserts an explicit `(r0, F::zero())` placeholder at the same `OpeningId`
+    ///   so subsequent stage-1 verifiers that read this opening get an explicit
+    ///   placeholder (rather than relying on the accumulator's permissive
+    ///   `zk_mode` fallback), and
+    /// - absorbs the Pedersen commitment into the transcript (the prover side
+    ///   appends the same commitment in `prove_softmax_zk`).
+    #[cfg(feature = "zk")]
+    pub(crate) fn cache_R_zk<F: JoltField, T: Transcript>(
         &self,
-        verifier: &mut Verifier<'_, F, T>,
-    ) -> Result<(), ProofVerifyError> {
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        commitment: &impl ark_serialize::CanonicalSerialize,
+    ) {
+        use joltworks::poly::opening_proof::{OpeningId, SumcheckId};
+        let accessor = AccOpeningAccessor::new(&*accumulator, &self.computation_node);
+        let r0 = accessor.get_reduced_opening().0;
+        let opening_id = OpeningId::new(
+            VirtualPoly::SoftmaxRecipMultRemainder(self.idx()),
+            SumcheckId::NodeExecution(self.idx()),
+        );
+        accumulator.openings.insert(opening_id, (r0, F::zero()));
+        transcript.append_serializable(commitment);
+    }
+
+    /// Build stage 1 verifier instances. The caller drives the actual sumcheck.
+    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::build_stage1_verifiers", skip_all)]
+    pub(crate) fn build_stage1_verifiers<F: JoltField, T: Transcript>(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        scale_bits: i32,
+    ) -> Result<Vec<Box<dyn SumcheckInstanceVerifier<F, T>>>, ProofVerifyError> {
+        let inv_sum = self.inv_sum_evals(&*accumulator)?;
         let recip_mult_verifier = RecipMultVerifier::new(
             self.computation_node.clone(),
             self.scale,
             self.F_N,
-            self.inv_sum_evals(verifier)?,
-            &verifier.accumulator,
-            &mut verifier.transcript,
+            inv_sum,
+            &*accumulator,
+            transcript,
         );
         let exp_sum_verifier = ExpSumVerifier::new(
             self.computation_node.clone(),
             self.F_N,
-            &verifier.accumulator,
-            &mut verifier.transcript,
+            &*accumulator,
+            transcript,
         );
-        let rc_provider = SoftmaxRCProvider::remainder(
-            self.computation_node.clone(),
-            verifier.preprocessing.scale(),
-        );
-        let rc_R_verifier = identity_rangecheck_verifier(&rc_provider, &mut verifier.accumulator);
-        BatchedSumcheck::verify(
-            verifier
-                .proofs
-                .get(&ProofId(self.idx(), ProofType::SoftmaxStage1))
-                .ok_or(ProofVerifyError::MissingProof(self.idx()))?,
-            vec![&recip_mult_verifier, &exp_sum_verifier, &rc_R_verifier],
-            &mut verifier.accumulator,
-            &mut verifier.transcript,
-        )?;
-        Ok(())
+        let rc_provider =
+            SoftmaxRCProvider::remainder(self.computation_node.clone(), scale_bits);
+        let rc_R_verifier = identity_rangecheck_verifier(&rc_provider, accumulator);
+        Ok(vec![
+            Box::new(recip_mult_verifier),
+            Box::new(exp_sum_verifier),
+            Box::new(rc_R_verifier),
+        ])
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::cache_r_exp", skip_all)]
     pub(crate) fn cache_r_exp<F: JoltField, T: Transcript>(
         &self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
     ) {
-        let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, &self.computation_node);
+        let accessor = AccOpeningAccessor::new(accumulator, &self.computation_node);
         let r = accessor.get_advice(VirtualPoly::SoftmaxExpQ).0;
-        let mut provider = accessor.into_provider(&mut verifier.transcript, r);
+        let mut provider = accessor.into_provider(transcript, r);
         provider.append_advice(VirtualPoly::SoftmaxExpRemainder);
     }
 
-    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::stage2", skip_all)]
-    fn stage2<F: JoltField, T: Transcript>(
+    /// Cache the exp-remainder polynomial in the ZK pipeline.
+    ///
+    /// Same shape as [`cache_R_zk`]: insert an explicit `(r1, F::zero())`
+    /// placeholder for the private `SoftmaxExpRemainder` opening and absorb
+    /// the Pedersen commitment from the bundle into the transcript.
+    #[cfg(feature = "zk")]
+    pub(crate) fn cache_r_exp_zk<F: JoltField, T: Transcript>(
         &self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        commitment: &impl ark_serialize::CanonicalSerialize,
+    ) {
+        use joltworks::poly::opening_proof::{OpeningId, SumcheckId};
+        let accessor = AccOpeningAccessor::new(&*accumulator, &self.computation_node);
+        let r1 = accessor.get_advice(VirtualPoly::SoftmaxExpQ).0;
+        let opening_id = OpeningId::new(
+            VirtualPoly::SoftmaxExpRemainder(self.idx()),
+            SumcheckId::NodeExecution(self.idx()),
+        );
+        accumulator.openings.insert(opening_id, (r1, F::zero()));
+        transcript.append_serializable(commitment);
+    }
+
+    /// Build stage 2 verifier instances.
+    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::build_stage2_verifiers", skip_all)]
+    pub(crate) fn build_stage2_verifiers<F: JoltField, T: Transcript>(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        scale_bits: i32,
         lut: &VerifierLookupTableData,
-    ) -> Result<(), ProofVerifyError> {
-        // max indicator instance
+    ) -> Vec<Box<dyn SumcheckInstanceVerifier<F, T>>> {
         let [f, _n] = self.F_N;
         let log_f = f.log_2();
 
-        // Get r1 (the exp_q opening point from Stage 1)
-        let accessor = AccOpeningAccessor::new(&verifier.accumulator, &self.computation_node);
+        let accessor = AccOpeningAccessor::new(&*accumulator, &self.computation_node);
         let r1 = accessor.get_advice(VirtualPoly::SoftmaxExpQ).0;
         let r1_k = r1.split_at(log_f).0;
 
-        // max_k(r1_k) — evaluate the auxiliary max_k vector at the leading point
         let max_k_eval = MultilinearPolynomial::from(self.max_k.clone()).evaluate(&r1_k.r);
         let max_indicator_verifier = MaxIndicatorVerifier::new(
             self.computation_node.clone(),
             self.F_N,
             self.argmax_k.clone(),
             max_k_eval,
-            &verifier.accumulator,
+            &*accumulator,
         );
 
-        // exp mult instance
-        let exp_mult_verifier = MultVerifier::new(
-            self.computation_node.clone(),
-            self.scale,
-            &verifier.accumulator,
-        );
+        let exp_mult_verifier =
+            MultVerifier::new(self.computation_node.clone(), self.scale, &*accumulator);
 
-        // range-check r_exp instance
-        let rc_provider = SoftmaxRCProvider::exp_remainder(
-            self.computation_node.clone(),
-            verifier.preprocessing.scale(),
-        );
-        let exp_r_rc_verifier =
-            identity_rangecheck_verifier(&rc_provider, &mut verifier.accumulator);
+        let rc_provider =
+            SoftmaxRCProvider::exp_remainder(self.computation_node.clone(), scale_bits);
+        let exp_r_rc_verifier = identity_rangecheck_verifier(&rc_provider, accumulator);
 
-        // one-hot check for R
-        let encoding = SoftmaxRaEncoding::remainder(self.idx(), verifier.preprocessing.scale());
+        let encoding = SoftmaxRaEncoding::remainder(self.idx(), scale_bits);
         let [R_ra_verifier, R_hw_verifier, R_bool_verifier] =
-            shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+            shout::ra_onehot_verifiers(&encoding, &*accumulator, transcript);
 
-        // complementary slackness verifier
         let sd_verifier = SatDiffSlacknessVerifier::new(
             self.computation_node.clone(),
             lut.z_bound_minus_1,
             lut.base,
-            &verifier.accumulator,
+            &*accumulator,
         );
 
-        BatchedSumcheck::verify(
-            verifier
-                .proofs
-                .get(&ProofId(self.idx(), ProofType::SoftmaxStage2))
-                .ok_or(ProofVerifyError::MissingProof(self.idx()))?,
-            vec![
-                &exp_mult_verifier,
-                &max_indicator_verifier,
-                &exp_r_rc_verifier,
-                &*R_ra_verifier,
-                &*R_hw_verifier,
-                &*R_bool_verifier,
-                &sd_verifier,
-            ],
-            &mut verifier.accumulator,
-            &mut verifier.transcript,
-        )?;
-
-        Ok(())
+        vec![
+            Box::new(exp_mult_verifier),
+            Box::new(max_indicator_verifier),
+            Box::new(exp_r_rc_verifier),
+            R_ra_verifier,
+            R_hw_verifier,
+            R_bool_verifier,
+            Box::new(sd_verifier),
+        ]
     }
 
-    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::stage3", skip_all)]
-    fn stage3<F: JoltField, T: Transcript>(
+    /// Build stage 3 verifier instances.
+    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::build_stage3_verifiers", skip_all)]
+    pub(crate) fn build_stage3_verifiers<F: JoltField, T: Transcript>(
         &self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        scale_bits: i32,
         lut: &VerifierLookupTableData,
-    ) -> Result<(), ProofVerifyError> {
-        // read-raf for exponentiation
-
-        // hi
+    ) -> Vec<Box<dyn SumcheckInstanceVerifier<F, T>>> {
         let provider = ExpReadRafProvider {
             node: self.computation_node.clone(),
             table_size: lut.table_hi.len(),
             digit: ExpDigit::Hi,
         };
-        let hi_verifier = shout::read_raf_verifier(
-            &provider,
-            lut.table_hi.clone(),
-            &verifier.accumulator,
-            &mut verifier.transcript,
-        );
+        let hi_verifier =
+            shout::read_raf_verifier(&provider, lut.table_hi.clone(), &*accumulator, transcript);
 
-        // lo
         let provider = ExpReadRafProvider {
             node: self.computation_node.clone(),
             table_size: lut.table_lo.len(),
             digit: ExpDigit::Lo,
         };
-        let lo_verifier = shout::read_raf_verifier(
-            &provider,
-            lut.table_lo.clone(),
-            &verifier.accumulator,
-            &mut verifier.transcript,
-        );
+        let lo_verifier =
+            shout::read_raf_verifier(&provider, lut.table_lo.clone(), &*accumulator, transcript);
 
-        // rc sat diff
         let provider = SoftmaxRCProvider::sat_diff(self.computation_node.clone());
-        let rc_sat_diff_verifier =
-            identity_rangecheck_verifier(&provider, &mut verifier.accumulator);
+        let rc_sat_diff_verifier = identity_rangecheck_verifier(&provider, accumulator);
 
-        // one-hot checks for r_exp ra
-        let encoding = SoftmaxRaEncoding::exp_remainder(self.idx(), verifier.preprocessing.scale());
+        let encoding = SoftmaxRaEncoding::exp_remainder(self.idx(), scale_bits);
         let [r_exp_ra_verifier, r_exp_hw_verifier, r_exp_bool_verifier] =
-            shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+            shout::ra_onehot_verifiers(&encoding, &*accumulator, transcript);
 
-        BatchedSumcheck::verify(
-            verifier
-                .proofs
-                .get(&ProofId(self.idx(), ProofType::SoftmaxStage3))
-                .ok_or(ProofVerifyError::MissingProof(self.idx()))?,
-            vec![
-                &*hi_verifier,
-                &*lo_verifier,
-                &rc_sat_diff_verifier,
-                &*r_exp_ra_verifier,
-                &*r_exp_hw_verifier,
-                &*r_exp_bool_verifier,
-            ],
-            &mut verifier.accumulator,
-            &mut verifier.transcript,
-        )?;
-
-        Ok(())
+        vec![
+            hi_verifier,
+            lo_verifier,
+            Box::new(rc_sat_diff_verifier),
+            r_exp_ra_verifier,
+            r_exp_hw_verifier,
+            r_exp_bool_verifier,
+        ]
     }
 
     #[tracing::instrument(name = "SoftmaxLastAxisVerifier::operand_link", skip_all)]
@@ -935,35 +1006,28 @@ impl SoftmaxLastAxisVerifier {
     ///
     /// `X(r2) = max_k(r2_lead) − z_c(r2) − sat_diff(r2)`
     /// where `z_c(r2) = z_hi(r2)·B + z_lo(r2)`.
-    fn operand_link<F: JoltField, T: Transcript>(
+    pub(crate) fn operand_link<F: JoltField>(
         &self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &VerifierOpeningAccumulator<F>,
         lut: &VerifierLookupTableData,
     ) -> Result<(), ProofVerifyError> {
         let [f, _n] = self.F_N;
         let log_f = f.log_2();
-        let accessor = AccOpeningAccessor::new(&verifier.accumulator, &self.computation_node);
+        let accessor = AccOpeningAccessor::new(accumulator, &self.computation_node);
 
-        // Get r2
         let r2 = accessor.get_advice(VirtualPoly::SoftmaxExpHi).0;
         let r2_lead = r2.split_at(log_f).0;
 
-        // max_k(r2_lead) — verifier evaluates from sent max_k
         let max_k_eval = MultilinearPolynomial::from(self.max_k.clone()).evaluate(&r2_lead.r);
 
-        // z_c(r2) = z_hi(r2)·B + z_lo(r2)
         let z_hi_eval = accessor.get_advice(VirtualPoly::SoftmaxZHi).1;
         let z_lo_eval = accessor.get_advice(VirtualPoly::SoftmaxZLo).1;
         let z_c_eval = z_hi_eval * F::from_u64(lut.base) + z_lo_eval;
 
-        // sat_diff(r2)
         let sat_diff_eval = accessor.get_advice(VirtualPoly::SoftmaxSatDiff).1;
 
-        // X(r2) = max_k(r2_lead) − z_c(r2) − sat_diff(r2)
         let x_r2 = max_k_eval - z_c_eval - sat_diff_eval;
 
-        // Verify the operand link: prover's claimed X(r2) must match the
-        // algebraic derivation from max_k, z_c, and sat_diff.
         let prover_x_r2 = accessor.get_nodeio(Target::Input(0)).1;
         if prover_x_r2 != x_r2 {
             return Err(ProofVerifyError::InvalidOpeningProof(
@@ -974,49 +1038,37 @@ impl SoftmaxLastAxisVerifier {
         Ok(())
     }
 
-    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::stage4", skip_all)]
-    fn stage4<F: JoltField, T: Transcript>(
+    /// Build stage 4 verifier instances.
+    #[tracing::instrument(name = "SoftmaxLastAxisVerifier::build_stage4_verifiers", skip_all)]
+    pub(crate) fn build_stage4_verifiers<F: JoltField, T: Transcript>(
         &self,
-        verifier: &mut Verifier<'_, F, T>,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
         lut: &VerifierLookupTableData,
-    ) -> Result<(), ProofVerifyError> {
-        // one-hot checks for z_hi_ra and z_lo_ra
-
-        // hi
+    ) -> Vec<Box<dyn SumcheckInstanceVerifier<F, T>>> {
         let encoding = SoftmaxRaEncoding::exp_hi(self.idx(), lut.table_hi.len().log_2());
         let [hi_ra_verifier, hi_hw_verifier, hi_bool_verifier] =
-            shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+            shout::ra_onehot_verifiers(&encoding, accumulator, transcript);
 
-        // lo
         let encoding = SoftmaxRaEncoding::exp_lo(self.idx(), lut.table_lo.len().log_2());
         let [lo_ra_verifier, lo_hw_verifier, lo_bool_verifier] =
-            shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+            shout::ra_onehot_verifiers(&encoding, accumulator, transcript);
 
-        // one-hot checks for sat_diff ra
         let encoding = SoftmaxRaEncoding::sat_diff(self.idx());
         let [sat_diff_ra_verifier, sat_diff_hw_verifier, sat_diff_bool_verifier] =
-            shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+            shout::ra_onehot_verifiers(&encoding, accumulator, transcript);
 
-        BatchedSumcheck::verify(
-            verifier
-                .proofs
-                .get(&ProofId(self.idx(), ProofType::SoftmaxStage4))
-                .ok_or(ProofVerifyError::MissingProof(self.idx()))?,
-            vec![
-                &*hi_ra_verifier,
-                &*hi_hw_verifier,
-                &*hi_bool_verifier,
-                &*lo_ra_verifier,
-                &*lo_hw_verifier,
-                &*lo_bool_verifier,
-                &*sat_diff_ra_verifier,
-                &*sat_diff_hw_verifier,
-                &*sat_diff_bool_verifier,
-            ],
-            &mut verifier.accumulator,
-            &mut verifier.transcript,
-        )?;
-        Ok(())
+        vec![
+            hi_ra_verifier,
+            hi_hw_verifier,
+            hi_bool_verifier,
+            lo_ra_verifier,
+            lo_hw_verifier,
+            lo_bool_verifier,
+            sat_diff_ra_verifier,
+            sat_diff_hw_verifier,
+            sat_diff_bool_verifier,
+        ]
     }
 }
 
@@ -1068,17 +1120,17 @@ pub(crate) struct LookupTableData {
 }
 
 /// Pre-computed verifier lookup table data (shared across stage3, operand_link, stage4).
-struct VerifierLookupTableData {
-    table_hi: Vec<i32>,
-    table_lo: Vec<i32>,
-    base: u64,
+pub(crate) struct VerifierLookupTableData {
+    pub(crate) table_hi: Vec<i32>,
+    pub(crate) table_lo: Vec<i32>,
+    pub(crate) base: u64,
     /// `z_bound − 1 = K_hi * B − 1`, the maximum clamped logit value.
     /// Used in the complementary-slackness check.
-    z_bound_minus_1: u64,
+    pub(crate) z_bound_minus_1: u64,
 }
 
 impl VerifierLookupTableData {
-    fn new(scale: i32) -> Self {
+    pub(crate) fn new(scale: i32) -> Self {
         let decomp = generate_exp_lut_decomposed(scale);
         let z_bound_minus_1 = (decomp.lut_hi.len() * decomp.base - 1) as u64;
         let mut table_hi = decomp.lut_hi;

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
@@ -345,6 +345,7 @@ impl SoftmaxLastAxisProver {
         prover: &mut Prover<F, T>,
         r_lookup_bits: Vec<LookupBits>,
     ) -> Vec<Box<dyn SumcheckInstanceProver<F, T>>> {
+        #[cfg_attr(not(feature = "zk"), allow(unused_mut))]
         let mut recip_mult_params = RecipMultParams::new(
             self.computation_node.clone(),
             self.scale,

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/mod.rs
@@ -860,8 +860,7 @@ impl SoftmaxLastAxisVerifier {
             &*accumulator,
             transcript,
         );
-        let rc_provider =
-            SoftmaxRCProvider::remainder(self.computation_node.clone(), scale_bits);
+        let rc_provider = SoftmaxRCProvider::remainder(self.computation_node.clone(), scale_bits);
         let rc_R_verifier = identity_rangecheck_verifier(&rc_provider, accumulator);
         Ok(vec![
             Box::new(recip_mult_verifier),

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/recip_mult.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/recip_mult.rs
@@ -1,6 +1,10 @@
 use crate::utils::opening_access::AccOpeningAccessor;
 use atlas_onnx_tracer::node::ComputationNode;
 use common::VirtualPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -36,6 +40,10 @@ pub struct RecipMultParams<F: JoltField> {
     pub S: i32,
     /// `[F, N]` — leading-dim product and last-axis size.
     pub F_N: [usize; 2],
+    /// Inverse sum evaluations (verifier-known, derived from auxiliary exp_sum_q).
+    /// Used by BlindFold constraint to compute inv_sum_claim at the challenge point.
+    #[cfg(feature = "zk")]
+    pub inv_sum_evals: Vec<F>,
 }
 
 impl<F: JoltField> RecipMultParams<F> {
@@ -51,7 +59,21 @@ impl<F: JoltField> RecipMultParams<F> {
             .get_reduced_opening()
             .0
             .r;
-        Self { r, S, node, F_N }
+        Self {
+            r,
+            S,
+            node,
+            F_N,
+            #[cfg(feature = "zk")]
+            inv_sum_evals: Vec::new(),
+        }
+    }
+
+    /// Set the inv_sum evaluations for BlindFold constraint computation.
+    #[cfg(feature = "zk")]
+    pub fn with_inv_sum_evals(mut self, evals: Vec<F>) -> Self {
+        self.inv_sum_evals = evals;
+        self
     }
 
     /// Returns `[F, N]`.
@@ -100,6 +122,46 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RecipMultParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.r.len()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * exp_q * inv_sum = Challenge(0) * Opening(exp_q)
+    // Challenge(0) = eq_eval * inv_sum_claim (inv_sum is verifier-known)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.node);
+        let exp_q_id = builder.advice(VirtualPoly::SoftmaxExpQ);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(exp_q_id)],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r_sc: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r, &r_sc);
+        // inv_sum is verifier-known (derived from auxiliary exp_sum_q vector)
+        let r_sc_leading = &r_sc[..self.log_F()];
+        let inv_sum_poly = MultilinearPolynomial::from(self.inv_sum_evals.clone());
+        let inv_sum_claim = inv_sum_poly.evaluate(r_sc_leading);
+        vec![eq_eval * inv_sum_claim]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/sat_diff.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/softmax_last_axis/sat_diff.rs
@@ -11,6 +11,10 @@
 use crate::utils::opening_access::AccOpeningAccessor;
 use atlas_onnx_tracer::node::ComputationNode;
 use common::VirtualPoly;
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -89,6 +93,67 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SatDiffSlacknessParams<F> {
 
     fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
         OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * sat_diff * (z_bound_minus_1 - z_hi * base - z_lo)
+    //        = Challenge(0) * Opening(sat_diff)
+    //          + Challenge(1) * Opening(sat_diff) * Opening(z_hi)
+    //          + Challenge(2) * Opening(sat_diff) * Opening(z_lo)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.node);
+        let sat_diff_id = builder.advice(VirtualPoly::SoftmaxSatDiff);
+        let z_hi_id = builder.advice(VirtualPoly::SoftmaxZHi);
+        let z_lo_id = builder.advice(VirtualPoly::SoftmaxZLo);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            // eq_eval * z_bound_minus_1 * sat_diff
+            ProductTerm::scaled(
+                ValueSource::Challenge(0),
+                vec![ValueSource::Opening(sat_diff_id)],
+            ),
+            // -eq_eval * base * sat_diff * z_hi
+            ProductTerm::scaled(
+                ValueSource::Challenge(1),
+                vec![
+                    ValueSource::Opening(sat_diff_id),
+                    ValueSource::Opening(z_hi_id),
+                ],
+            ),
+            // -eq_eval * sat_diff * z_lo
+            ProductTerm::scaled(
+                ValueSource::Challenge(2),
+                vec![
+                    ValueSource::Opening(sat_diff_id),
+                    ValueSource::Opening(z_lo_id),
+                ],
+            ),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r2: Vec<F> = self
+            .normalize_opening_point(&sumcheck_challenges.into_opening())
+            .r;
+        let eq_eval = EqPolynomial::mle(&self.r1, &r2);
+        vec![
+            eq_eval * self.z_bound_minus_1,
+            -eq_eval * self.base,
+            -eq_eval,
+        ]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -8,6 +8,10 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Square,
 };
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -76,8 +80,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SquareParams<F> {
     // This value is baked as a constant in BlindFold's R1CS (not a variable),
     // so no constraint is needed.
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -92,11 +96,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SquareParams<F> {
     // eq_eval is a deterministic function of the sumcheck challenges and r_node_output,
     // so it is passed as Challenge(0). The operand opening appears twice (squared).
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let operand_id =
             crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node)
                 .nodeio(Target::Input(0));

--- a/jolt-atlas-core/src/onnx_proof/ops/sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sub.rs
@@ -8,6 +8,10 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
     ops::Sub,
 };
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -73,8 +77,8 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SubParams<F> {
     }
 
     #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> joltworks::subprotocols::blindfold::InputClaimConstraint {
-        joltworks::subprotocols::blindfold::InputClaimConstraint::default()
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
     }
 
     #[cfg(feature = "zk")]
@@ -87,11 +91,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SubParams<F> {
 
     // output = eq_eval * (left - right) = eq_eval * left + (-eq_eval) * right
     #[cfg(feature = "zk")]
-    fn output_claim_constraint(
-        &self,
-    ) -> Option<joltworks::subprotocols::blindfold::OutputClaimConstraint> {
-        use joltworks::subprotocols::blindfold::{OutputClaimConstraint, ProductTerm, ValueSource};
-
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         let builder = crate::utils::opening_access::OpeningIdBuilder::new(&self.computation_node);
         let left_id = builder.nodeio(Target::Input(0));
         let right_id = builder.nodeio(Target::Input(1));

--- a/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sum/axis.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 use crate::utils::{
     dims::{SumAxis, SumConfig},
     opening_access::{AccOpeningAccessor, Target},
@@ -70,6 +75,34 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SumAxisParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.sum_config.operand_dims()[self.sum_config.axis().axis_index()].log_2()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let input_id = builder.nodeio(Target::Input(0));
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::product(vec![ValueSource::Opening(input_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        vec![]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/sum/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sum/mod.rs
@@ -21,6 +21,28 @@ use crate::{
 /// Axis-wise sum implementations for sumcheck protocol.
 pub mod axis;
 
+/// Create a Sum prover instance for the ZK pipeline.
+pub fn create_sum_prover<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    trace: &atlas_onnx_tracer::model::trace::Trace,
+    accumulator: &joltworks::poly::opening_proof::ProverOpeningAccumulator<F>,
+) -> Box<dyn joltworks::subprotocols::sumcheck_prover::SumcheckInstanceProver<F, T>> {
+    let sum_config = utils::dims::sum_config(node, model);
+    let params = SumAxisParams::new(node.clone(), sum_config, accumulator);
+    Box::new(SumAxisProver::initialize(trace, params, accumulator))
+}
+
+/// Create a Sum verifier instance for the ZK pipeline.
+pub fn create_sum_verifier<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    accumulator: &joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+) -> Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>> {
+    let sum_config = utils::dims::sum_config(node, model);
+    Box::new(SumAxisVerifier::new(node.clone(), sum_config, accumulator))
+}
+
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sum {
     #[tracing::instrument(skip_all, name = "Sum::prove")]
     fn prove(

--- a/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
@@ -28,6 +28,10 @@ use atlas_onnx_tracer::{
 };
 use common::parallel::par_enabled;
 use common::{CommittedPoly, VirtualPoly};
+#[cfg(feature = "zk")]
+use joltworks::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
     field::{IntoOpening, JoltField},
@@ -228,6 +232,40 @@ impl<F: JoltField> SumcheckInstanceParams<F> for TanhParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.op.log_table
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = ra_claim * (table_claim + gamma * int_eval)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        use crate::utils::opening_access::OpeningIdBuilder;
+        let builder = OpeningIdBuilder::new(&self.computation_node);
+        let ra_id = builder.advice(VirtualPoly::TanhRa);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let table = TanhTable::new(self.op.log_table, self.op.tau);
+        let tanh_table = MultilinearPolynomial::from(table.materialize());
+        let table_claim = tanh_table.evaluate(&opening_point.r);
+        let int_eval = TeleportIdPolynomial::new(self.op.log_table).evaluate(&opening_point.r);
+        vec![table_claim + self.gamma * int_eval]
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/preprocessing.rs
+++ b/jolt-atlas-core/src/onnx_proof/preprocessing.rs
@@ -106,6 +106,23 @@ where
     }
 }
 
+#[cfg(feature = "zk")]
+impl
+    AtlasProverPreprocessing<
+        ark_bn254::Fr,
+        joltworks::poly::commitment::hyperkzg::HyperKZG<ark_bn254::Bn254>,
+    >
+{
+    /// Derive Pedersen generators from the HyperKZG SRS for BlindFold ZK proofs.
+    pub fn pedersen_generators(
+        &self,
+        count: usize,
+    ) -> joltworks::poly::commitment::pedersen::PedersenGenerators<joltworks::curve::Bn254Curve>
+    {
+        self.generators.pedersen_generators(count)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Verifier
 // ---------------------------------------------------------------------------

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1797,8 +1797,10 @@ pub fn prove_zk(
         BTreeMap::new();
 
     for (_, node) in nodes.iter().rev() {
-        if matches!(&node.operator, Operator::SoftmaxLastAxis(_)) {
-            prove_softmax_zk(
+        // Match is exhaustive: adding a new Operator variant fails to compile
+        // until it is routed to a specific prove flow or the default branch.
+        match &node.operator {
+            Operator::SoftmaxLastAxis(_) => prove_softmax_zk(
                 node,
                 &mut prover,
                 pedersen_gens,
@@ -1809,9 +1811,8 @@ pub fn prove_zk(
                 &mut zk_sumcheck_proofs,
                 &mut inter_stage_commitments,
                 &mut auxiliary_claims,
-            );
-        } else if matches!(&node.operator, Operator::GatherLarge(_)) {
-            prove_gather_large_zk(
+            ),
+            Operator::GatherLarge(_) => prove_gather_large_zk(
                 node,
                 &mut prover,
                 pp.shared.model(),
@@ -1821,9 +1822,8 @@ pub fn prove_zk(
                 &mut eval_reduction_proofs,
                 &mut eval_reduction_h_commitments,
                 &mut zk_sumcheck_proofs,
-            );
-        } else if matches!(&node.operator, Operator::GatherSmall(_)) {
-            prove_gather_small_zk(
+            ),
+            Operator::GatherSmall(_) => prove_gather_small_zk(
                 node,
                 &mut prover,
                 pp.shared.model(),
@@ -1833,9 +1833,8 @@ pub fn prove_zk(
                 &mut eval_reduction_proofs,
                 &mut eval_reduction_h_commitments,
                 &mut zk_sumcheck_proofs,
-            );
-        } else if matches!(&node.operator, Operator::ReLU(_)) {
-            prove_relu_zk(
+            ),
+            Operator::ReLU(_) => prove_relu_zk(
                 node,
                 &mut prover,
                 pedersen_gens,
@@ -1844,80 +1843,97 @@ pub fn prove_zk(
                 &mut eval_reduction_proofs,
                 &mut eval_reduction_h_commitments,
                 &mut zk_sumcheck_proofs,
-            );
-        } else if matches!(
-            &node.operator,
-            Operator::Sigmoid(_) | Operator::Tanh(_) | Operator::Erf(_)
-        ) {
-            prove_neural_teleport_zk(
-                node,
-                &mut prover,
-                pp.shared.model(),
-                pedersen_gens,
-                &mut blindfold_accumulator,
-                &mut stage_configs,
-                &mut eval_reduction_proofs,
-                &mut eval_reduction_h_commitments,
-                &mut zk_sumcheck_proofs,
-            );
-        } else if matches!(&node.operator, Operator::Cos(_) | Operator::Sin(_)) {
-            prove_cos_sin_zk(
-                node,
-                &mut prover,
-                pp.shared.model(),
-                pedersen_gens,
-                &mut blindfold_accumulator,
-                &mut stage_configs,
-                &mut eval_reduction_proofs,
-                &mut eval_reduction_h_commitments,
-                &mut zk_sumcheck_proofs,
-            );
-        } else if matches!(&node.operator, Operator::Div(_) | Operator::Rsqrt(_)) {
-            if matches!(&node.operator, Operator::Rsqrt(_)) {
-                prove_rsqrt_zk(
+            ),
+            Operator::Sigmoid(_) | Operator::Tanh(_) | Operator::Erf(_) => {
+                prove_neural_teleport_zk(
                     node,
                     &mut prover,
+                    pp.shared.model(),
                     pedersen_gens,
                     &mut blindfold_accumulator,
                     &mut stage_configs,
                     &mut eval_reduction_proofs,
                     &mut eval_reduction_h_commitments,
                     &mut zk_sumcheck_proofs,
-                );
-            } else {
-                prove_div_zk(
-                    node,
-                    &mut prover,
-                    pedersen_gens,
-                    &mut blindfold_accumulator,
-                    &mut stage_configs,
-                    &mut eval_reduction_proofs,
-                    &mut eval_reduction_h_commitments,
-                    &mut zk_sumcheck_proofs,
-                );
+                )
             }
-        } else {
-            // Standard flow: eval reduction first, then execution sumcheck.
-            prove_zk_eval_reduction(
+            Operator::Cos(_) | Operator::Sin(_) => prove_cos_sin_zk(
+                node,
+                &mut prover,
+                pp.shared.model(),
+                pedersen_gens,
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+            ),
+            Operator::Rsqrt(_) => prove_rsqrt_zk(
                 node,
                 &mut prover,
                 pedersen_gens,
+                &mut blindfold_accumulator,
+                &mut stage_configs,
                 &mut eval_reduction_proofs,
                 &mut eval_reduction_h_commitments,
-            );
+                &mut zk_sumcheck_proofs,
+            ),
+            Operator::Div(_) => prove_div_zk(
+                node,
+                &mut prover,
+                pedersen_gens,
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+            ),
+            // Default flow: eval reduction first, then execution sumcheck (or none
+            // for no-sumcheck ops, which create_prover_instance returns None for).
+            Operator::Add(_)
+            | Operator::Sub(_)
+            | Operator::Neg(_)
+            | Operator::Mul(_)
+            | Operator::Square(_)
+            | Operator::Cube(_)
+            | Operator::And(_)
+            | Operator::Iff(_)
+            | Operator::Concat(_)
+            | Operator::Reshape(_)
+            | Operator::Slice(_)
+            | Operator::ScalarConstDiv(_)
+            | Operator::Einsum(_)
+            | Operator::Sum(_)
+            | Operator::MeanOfSquares(_)
+            | Operator::Clamp(_)
+            | Operator::Input(_)
+            | Operator::Identity(_)
+            | Operator::Broadcast(_)
+            | Operator::MoveAxis(_)
+            | Operator::Constant(_)
+            | Operator::IsNan(_) => {
+                prove_zk_eval_reduction(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                );
 
-            let zk_proof =
-                create_prover_instance(node, &prover, pp.shared.model()).map(|mut sc| {
-                    run_zk_sumcheck(
-                        &mut *sc,
-                        &mut prover,
-                        &mut blindfold_accumulator,
-                        &mut stage_configs,
-                        pedersen_gens,
-                    )
-                });
-            if let Some(proof) = zk_proof {
-                zk_sumcheck_proofs.push((node.idx, proof));
+                let zk_proof = create_prover_instance(node, &prover, pp.shared.model()).map(
+                    |mut sc| {
+                        run_zk_sumcheck(
+                            &mut *sc,
+                            &mut prover,
+                            &mut blindfold_accumulator,
+                            &mut stage_configs,
+                            pedersen_gens,
+                        )
+                    },
+                );
+                if let Some(proof) = zk_proof {
+                    zk_sumcheck_proofs.push((node.idx, proof));
+                }
             }
         }
     }
@@ -2199,93 +2215,101 @@ pub fn verify_zk(
     // 3. Full IOP replay: for each node, verify eval reduction + absorb ZK sumcheck
     let mut zk_proof_idx = 0;
     for (_, node) in model.graph.nodes.iter().rev() {
-        if matches!(&node.operator, Operator::SoftmaxLastAxis(_)) {
-            verify_softmax_zk(
+        // Match is exhaustive: adding a new Operator variant fails to compile
+        // until it is routed to a specific verify flow or the default branch.
+        match &node.operator {
+            Operator::SoftmaxLastAxis(_) => verify_softmax_zk(
                 node,
                 pp,
                 bundle,
                 &mut accumulator,
                 &mut transcript,
                 &mut zk_proof_idx,
-            )?;
-        } else if matches!(&node.operator, Operator::GatherLarge(_)) {
-            verify_gather_large_zk(
+            )?,
+            Operator::GatherLarge(_) => verify_gather_large_zk(
                 node,
                 model,
                 bundle,
                 &mut accumulator,
                 &mut transcript,
                 &mut zk_proof_idx,
-            )?;
-        } else if matches!(&node.operator, Operator::GatherSmall(_)) {
-            verify_gather_small_zk(
+            )?,
+            Operator::GatherSmall(_) => verify_gather_small_zk(
                 node,
                 model,
                 bundle,
                 &mut accumulator,
                 &mut transcript,
                 &mut zk_proof_idx,
-            )?;
-        } else if matches!(&node.operator, Operator::ReLU(_)) {
-            verify_relu_zk(
+            )?,
+            Operator::ReLU(_) => verify_relu_zk(
                 node,
                 bundle,
                 &mut accumulator,
                 &mut transcript,
                 &mut zk_proof_idx,
-            )?;
-        } else if matches!(
-            &node.operator,
-            Operator::Sigmoid(_) | Operator::Tanh(_) | Operator::Erf(_)
-        ) {
-            verify_neural_teleport_zk(
-                node,
-                model,
-                bundle,
-                &mut accumulator,
-                &mut transcript,
-                &mut zk_proof_idx,
-            )?;
-        } else if matches!(&node.operator, Operator::Cos(_) | Operator::Sin(_)) {
-            verify_cos_sin_zk(
+            )?,
+            Operator::Sigmoid(_) | Operator::Tanh(_) | Operator::Erf(_) => {
+                verify_neural_teleport_zk(
+                    node,
+                    model,
+                    bundle,
+                    &mut accumulator,
+                    &mut transcript,
+                    &mut zk_proof_idx,
+                )?
+            }
+            Operator::Cos(_) | Operator::Sin(_) => verify_cos_sin_zk(
                 node,
                 model,
                 bundle,
                 &mut accumulator,
                 &mut transcript,
                 &mut zk_proof_idx,
-            )?;
-        } else if matches!(&node.operator, Operator::Rsqrt(_)) {
-            verify_rsqrt_zk(
+            )?,
+            Operator::Rsqrt(_) => verify_rsqrt_zk(
                 node,
                 bundle,
                 &mut accumulator,
                 &mut transcript,
                 &mut zk_proof_idx,
-            )?;
-        } else if matches!(&node.operator, Operator::Div(_)) {
-            verify_div_zk(
+            )?,
+            Operator::Div(_) => verify_div_zk(
                 node,
                 bundle,
                 &mut accumulator,
                 &mut transcript,
                 &mut zk_proof_idx,
-            )?;
-        } else {
-            // Standard flow: eval reduction first, then execution sumcheck
-            verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+            )?,
+            // Default flow: eval reduction always; execution sumcheck for ops
+            // that have one. The no-sumcheck ops are listed explicitly below
+            // and skip the sumcheck-instances call.
+            Operator::Input(_)
+            | Operator::Identity(_)
+            | Operator::Broadcast(_)
+            | Operator::MoveAxis(_)
+            | Operator::Constant(_)
+            | Operator::IsNan(_) => {
+                verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+            }
+            Operator::Add(_)
+            | Operator::Sub(_)
+            | Operator::Neg(_)
+            | Operator::Mul(_)
+            | Operator::Square(_)
+            | Operator::Cube(_)
+            | Operator::And(_)
+            | Operator::Iff(_)
+            | Operator::Concat(_)
+            | Operator::Reshape(_)
+            | Operator::Slice(_)
+            | Operator::ScalarConstDiv(_)
+            | Operator::Einsum(_)
+            | Operator::Sum(_)
+            | Operator::MeanOfSquares(_)
+            | Operator::Clamp(_) => {
+                verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
 
-            let has_sumcheck = !matches!(
-                &node.operator,
-                Operator::Input(_)
-                    | Operator::Identity(_)
-                    | Operator::Broadcast(_)
-                    | Operator::MoveAxis(_)
-                    | Operator::Constant(_)
-                    | Operator::IsNan(_)
-            );
-
-            if has_sumcheck {
                 let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[zk_proof_idx];
                 assert_eq!(
                     *proof_node_idx, node.idx,

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -77,6 +77,14 @@ pub struct ZkProofBundle {
     pub output_claim: F,
     /// ZK sumcheck proofs for each operator stage (needed by verifier for IOP replay).
     pub zk_sumcheck_proofs: Vec<NodeZkProof>,
+    /// Number of sumcheck instances per ZK proof (for transcript batching coeff replay).
+    pub zk_sumcheck_num_instances: Vec<usize>,
+    /// Pedersen commitments for inter-stage private claims (keyed by node index).
+    /// Used by multi-stage operators (e.g. Softmax) that cache evaluations between stages.
+    pub inter_stage_commitments: BTreeMap<usize, Vec<joltworks::curve::Bn254G1>>,
+    /// Auxiliary opening claims that must be pre-populated in the verifier accumulator.
+    /// In the non-ZK flow, these come from ONNXProof::opening_claims::populate_accumulator.
+    pub auxiliary_claims: BTreeMap<joltworks::poly::opening_proof::OpeningId, F>,
 }
 
 /// Run a single-instance ZK sumcheck and collect stage data.
@@ -108,6 +116,1607 @@ fn run_zk_sumcheck(
 
     stage_configs.push(StageConfig::new_chain(num_rounds, poly_degree));
     zk_proof
+}
+
+/// Run a batched ZK sumcheck (multiple instances) and collect stage data.
+fn run_zk_batched_sumcheck(
+    instances: Vec<&mut dyn SumcheckInstanceProver<F, T>>,
+    prover: &mut Prover<F, T>,
+    blindfold_accumulator: &mut BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    pedersen_gens: &PedersenGenerators<C>,
+) -> joltworks::subprotocols::sumcheck::ZkSumcheckProof<F, C, T> {
+    let max_degree = instances
+        .iter()
+        .map(|sc| sc.get_params().degree())
+        .max()
+        .unwrap_or(1);
+    let max_rounds = instances
+        .iter()
+        .map(|sc| sc.get_params().num_rounds())
+        .max()
+        .unwrap_or(1);
+
+    let _ = prover.accumulator.take_pending_claims();
+    let _ = prover.accumulator.take_pending_claim_ids();
+
+    let mut rng = rand::thread_rng();
+
+    let (zk_proof, _, _) = BatchedSumcheck::prove_zk::<F, C, T, _>(
+        instances,
+        &mut prover.accumulator,
+        blindfold_accumulator,
+        &mut prover.transcript,
+        pedersen_gens,
+        &mut rng,
+    );
+
+    stage_configs.push(StageConfig::new_chain(max_rounds, max_degree));
+    zk_proof
+}
+
+/// Run ZK eval reduction for a node: commit h polynomial via Pedersen.
+fn prove_zk_eval_reduction(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+) {
+    use atlas_onnx_tracer::model::trace::{LayerData, Trace};
+    use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
+
+    let node_idx = node.idx;
+    let openings = prover.accumulator.get_node_openings(node_idx);
+    let LayerData {
+        operands: _,
+        output,
+    } = Trace::layer_data(&prover.trace, node);
+    let output_mle = MultilinearPolynomial::from(output.padded_next_power_of_two());
+
+    let (proof, reduced, h_com) = EvalReductionProtocol::prove_zk::<F, C, _>(
+        &openings,
+        output_mle,
+        &mut prover.transcript,
+        pedersen_gens,
+    )
+    .expect("ZK eval reduction should not fail");
+
+    prover
+        .accumulator
+        .reduced_evaluations
+        .insert(node_idx, reduced);
+    eval_reduction_proofs.insert(node_idx, proof);
+    if let Some(com) = h_com {
+        eval_reduction_h_commitments.insert(node_idx, com);
+    }
+}
+
+/// Verify ZK eval reduction for a node: absorb h commitment, skip claim checks.
+fn verify_zk_eval_reduction(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+) -> Result<(), ProofVerifyError> {
+    use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
+
+    let openings = accumulator.get_node_openings(node.idx);
+    if openings.is_empty() {
+        // No openings for this node (e.g. Input node whose consumer's cache_openings
+        // wasn't called in the ZK verifier). Skip eval reduction.
+        return Ok(());
+    }
+    let h_commitment = bundle.eval_reduction_h_commitments.get(&node.idx);
+    let reduced_instance =
+        EvalReductionProtocol::verify_zk::<F, T>(&openings, h_commitment, transcript)?;
+    accumulator
+        .reduced_evaluations
+        .insert(node.idx, reduced_instance);
+    Ok(())
+}
+
+/// Helper to verify a ZK sumcheck given verifier instances.
+fn verify_zk_sumcheck_instances(
+    zk_proof: &joltworks::subprotocols::sumcheck::ZkSumcheckProof<F, C, T>,
+    verifier_instances: Vec<
+        Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>>,
+    >,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+) -> Result<(), ProofVerifyError> {
+    let verifier_refs: Vec<
+        &dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>,
+    > = verifier_instances
+        .iter()
+        .map(|v| {
+            v.as_ref()
+                as &dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>
+        })
+        .collect();
+
+    BatchedSumcheck::verify_zk::<F, C, T>(zk_proof, verifier_refs, accumulator, transcript)?;
+    Ok(())
+}
+
+/// Verify SoftmaxLastAxis ZK proof.
+///
+/// The prover runs the full 4-stage pipeline via `prove_softmax_zk`.
+/// The verifier side requires constructing a `SoftmaxLastAxisVerifier` which
+/// has private stage methods and takes `&mut Verifier`. For now, we construct
+/// a temporary Verifier to run the IOP replay (cache methods + transcript ops),
+/// and skip per-stage verification (BlindFold covers constraint satisfaction).
+///
+/// TODO: Refactor `SoftmaxLastAxisVerifier` stage methods to accept decomposed
+/// args for proper per-stage ZK verification.
+fn verify_softmax_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    pp: &AtlasVerifierPreprocessing<F, PCS>,
+    io: &atlas_onnx_tracer::model::trace::ModelExecutionIO,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    let Operator::SoftmaxLastAxis(op) = &node.operator else {
+        unreachable!()
+    };
+
+    // Pre-populate the auxiliary claims (public data from send_auxiliary_vectors)
+    // so SmVerifier::new can find them in the accumulator.
+    for (id, claim) in &bundle.auxiliary_claims {
+        accumulator.openings.insert(
+            *id,
+            (
+                joltworks::poly::opening_proof::OpeningPoint::default(),
+                *claim,
+            ),
+        );
+    }
+
+    // Construct a temporary Verifier (non-ZK for SmVerifier::new and cache operations).
+    let empty_proofs = std::collections::BTreeMap::new();
+    let mut temp_verifier = crate::onnx_proof::Verifier {
+        preprocessing: &pp.shared,
+        accumulator: std::mem::take(accumulator),
+        transcript: std::mem::take(transcript),
+        proofs: &empty_proofs,
+        io,
+    };
+
+    // SmVerifier::new and cache_exp_sum need the accumulator in non-ZK mode
+    // so that: (1) auxiliary claims are stored with real values (not placeholders),
+    // (2) transcript appends match the prover's flow.
+    // The ZK verifier can do this because the auxiliary vectors are PUBLIC
+    // (sent via transcript in send_auxiliary_vectors).
+    use crate::onnx_proof::ops::softmax_last_axis::SoftmaxLastAxisVerifier as SmVerifier;
+    temp_verifier.accumulator.zk_mode = false;
+    let mut sm_v = SmVerifier::new(node, op.scale, &mut temp_verifier);
+    sm_v.cache_exp_sum(&mut temp_verifier)
+        .map_err(|e| ProofVerifyError::InvalidOpeningProof(format!("{e:?}")))?;
+    temp_verifier.accumulator.zk_mode = true;
+
+    // cache_R: PRIVATE claim. Absorb the Pedersen commitment from the bundle.
+    let inter_coms = bundle
+        .inter_stage_commitments
+        .get(&node.idx)
+        .expect("Missing inter-stage commitments for Softmax node");
+    temp_verifier.transcript.append_serializable(&inter_coms[0]);
+
+    // Helper: absorb a ZK sumcheck proof's commitments into transcript.
+    let absorb_zk_proof =
+        |zk_proof: &joltworks::subprotocols::sumcheck::ZkSumcheckProof<F, C, T>,
+         n_instances: usize,
+         t: &mut T| {
+            let _: Vec<F> = t.challenge_vector(n_instances);
+            for com in &zk_proof.round_commitments {
+                t.append_serializable(com);
+                let _: <F as JoltField>::Challenge = t.challenge_scalar_optimized::<F>();
+            }
+            for com in &zk_proof.output_claims_commitments {
+                t.append_serializable(com);
+            }
+        };
+
+    // Stage 1
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        let ni = bundle.zk_sumcheck_num_instances[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        absorb_zk_proof(zk_proof, ni, &mut temp_verifier.transcript);
+        *zk_proof_idx += 1;
+    }
+
+    // cache_r_exp: PRIVATE claim. Absorb the Pedersen commitment.
+    temp_verifier.transcript.append_serializable(&inter_coms[1]);
+
+    // Stages 2-4
+    for _ in 1..4 {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        let ni = bundle.zk_sumcheck_num_instances[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        absorb_zk_proof(zk_proof, ni, &mut temp_verifier.transcript);
+        *zk_proof_idx += 1;
+    }
+
+    // Recover accumulator and transcript
+    *accumulator = temp_verifier.accumulator;
+    *transcript = temp_verifier.transcript;
+
+    Ok(())
+}
+
+/// Verify GatherLarge ZK proof.
+fn verify_gather_large_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::ops::gather::large::GatherRaEncoding;
+
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    // Execution sumcheck
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let verifier_instances = create_verifier_instances(node, accumulator, model, transcript);
+        verify_zk_sumcheck_instances(zk_proof, verifier_instances, accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // One-hot batch
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let encoding = GatherRaEncoding::new(node);
+        let [ra, hw, b] =
+            joltworks::subprotocols::shout::ra_onehot_verifiers(&encoding, accumulator, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![ra, hw, b], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    Ok(())
+}
+
+/// Verify GatherSmall ZK proof.
+fn verify_gather_small_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::ops::gather::small::{
+        build_stage2_verifiers_zk, build_stage3_verifier_zk,
+    };
+
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    // Stage 1: Execution
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let vi = create_verifier_instances(node, accumulator, model, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vi, accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // Stage 2: HammingBooleanity + Booleanity
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let (hb_v, bool_v) =
+            build_stage2_verifiers_zk::<F>(node, &model.graph, accumulator, transcript);
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![Box::new(hb_v), Box::new(bool_v)],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    // Stage 3: HammingWeight
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let hw_v = build_stage3_verifier_zk::<F>(node, &model.graph, accumulator, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![Box::new(hw_v)], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    Ok(())
+}
+
+/// Verify Relu ZK proof: default flow mirroring prove_relu_zk.
+fn verify_relu_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::op_lookups::{OpLookupEncoding, OpLookupProvider};
+    use joltworks::lookup_tables::relu::ReluTable;
+
+    // 1. Eval reduction
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    // 2. Execution sumcheck
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let provider = OpLookupProvider::new(node.clone());
+        let v = provider
+            .read_raf_verify::<F, T, ReluTable<{ common::consts::XLEN }>>(accumulator, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![Box::new(v)], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // 3. One-hot batch
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let encoding = OpLookupEncoding::new(node);
+        let [ra, hw, b] =
+            joltworks::subprotocols::shout::ra_onehot_verifiers(&encoding, accumulator, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![ra, hw, b], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    Ok(())
+}
+
+/// Verify Rsqrt ZK proof: custom flow mirroring prove_rsqrt_zk.
+fn verify_rsqrt_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::ops::rsqrt::RsqrtVerifier;
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::{RiRangeCheckOperands, RsRangeCheckOperands},
+        RangeCheckEncoding, RangeCheckProvider,
+    };
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Execution sumcheck
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let v = RsqrtVerifier::new(node.clone(), transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![Box::new(v)], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // 2. Eval reduction
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    // 3. Two range checks batched
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let div_rc = RangeCheckProvider::<RiRangeCheckOperands>::new(node);
+        let div_v = div_rc
+            .read_raf_verify::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                accumulator,
+                transcript,
+            );
+        let sqrt_rc = RangeCheckProvider::<RsRangeCheckOperands>::new(node);
+        let sqrt_v = sqrt_rc
+            .read_raf_verify::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                accumulator,
+                transcript,
+            );
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![Box::new(div_v), Box::new(sqrt_v)],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    // 4. Six one-hot instances batched
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let div_enc = RangeCheckEncoding::<RiRangeCheckOperands>::new(node);
+        let [d_ra, d_hw, d_bool] =
+            joltworks::subprotocols::shout::ra_onehot_verifiers(&div_enc, accumulator, transcript);
+        let sqrt_enc = RangeCheckEncoding::<RsRangeCheckOperands>::new(node);
+        let [s_ra, s_hw, s_bool] =
+            joltworks::subprotocols::shout::ra_onehot_verifiers(&sqrt_enc, accumulator, transcript);
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![d_ra, d_hw, d_bool, s_ra, s_hw, s_bool],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    Ok(())
+}
+
+/// Verify Div operator ZK proof: custom flow mirroring prove_div_zk.
+fn verify_div_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::ops::div::DivVerifier;
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::DivRangeCheckOperands, RangeCheckEncoding, RangeCheckProvider,
+    };
+    use crate::utils::opening_access::AccOpeningAccessor;
+    use common::CommittedPoly;
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Execution sumcheck (DivVerifier squeezes r_node_output from transcript)
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(
+            *proof_node_idx, node.idx,
+            "ZK sumcheck proof order mismatch"
+        );
+        let verifier = DivVerifier::new(node.clone(), transcript);
+        let verifier_instances: Vec<
+            Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>>,
+        > = vec![Box::new(verifier)];
+        verify_zk_sumcheck_instances(zk_proof, verifier_instances, accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // 2. ZK eval reduction
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    // 3. Verify quotient binding
+    {
+        let reduced = AccOpeningAccessor::new(&mut *accumulator, node).get_reduced_opening();
+        let mut provider = AccOpeningAccessor::new(&mut *accumulator, node)
+            .into_provider(transcript, reduced.0.clone());
+        provider.append_advice(CommittedPoly::DivNodeQuotient);
+    }
+
+    // 4. Range check + one-hot (skip for scalar outputs)
+    if !node.is_scalar() {
+        // Range check sumcheck
+        {
+            let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+            assert_eq!(
+                *proof_node_idx, node.idx,
+                "ZK sumcheck proof order mismatch"
+            );
+            let rangecheck_provider = RangeCheckProvider::<DivRangeCheckOperands>::new(node);
+            let rangecheck_verifier = rangecheck_provider
+                .read_raf_verify::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                    accumulator,
+                    transcript,
+                );
+            let verifier_instances: Vec<
+                Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>>,
+            > = vec![Box::new(rangecheck_verifier)];
+            verify_zk_sumcheck_instances(zk_proof, verifier_instances, accumulator, transcript)?;
+            *zk_proof_idx += 1;
+        }
+
+        // One-hot batch sumcheck (Ra, HammingWeight, Booleanity)
+        {
+            let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+            assert_eq!(
+                *proof_node_idx, node.idx,
+                "ZK sumcheck proof order mismatch"
+            );
+            let encoding = RangeCheckEncoding::<DivRangeCheckOperands>::new(node);
+            let [ra_v, hw_v, bool_v] = joltworks::subprotocols::shout::ra_onehot_verifiers(
+                &encoding,
+                accumulator,
+                transcript,
+            );
+            let verifier_instances: Vec<
+                Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>>,
+            > = vec![ra_v, hw_v, bool_v];
+            verify_zk_sumcheck_instances(zk_proof, verifier_instances, accumulator, transcript)?;
+            *zk_proof_idx += 1;
+        }
+    }
+
+    Ok(())
+}
+
+/// Verify a neural teleportation operator ZK proof.
+fn verify_neural_teleport_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::neural_teleport::{
+        division::TeleportDivisionVerifier, range_and_onehot::NeuralTeleportRangeOneHot,
+    };
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::TeleportRangeCheckOperands, RangeCheckEncoding, RangeCheckProvider,
+    };
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Eval reduction
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    let tau = match &node.operator {
+        Operator::Sigmoid(op) => op.tau,
+        Operator::Tanh(op) => op.tau,
+        Operator::Erf(op) => op.tau,
+        _ => unreachable!(),
+    };
+
+    // 2. Division sumcheck
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*proof_node_idx, node.idx);
+        let div_verifier = TeleportDivisionVerifier::new(node.clone(), accumulator, tau);
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![Box::new(div_verifier)],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    // 3. Lookup sumcheck
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*proof_node_idx, node.idx);
+        let verifier_instances = create_verifier_instances(node, accumulator, model, transcript);
+        verify_zk_sumcheck_instances(zk_proof, verifier_instances, accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // 4. Range-check + operator-specific one-hot
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*proof_node_idx, node.idx);
+        let rangecheck_provider = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
+        let rangecheck_verifier = rangecheck_provider
+            .read_raf_verify::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                accumulator,
+                transcript,
+            );
+        macro_rules! verify_ra_onehot {
+            ($op:expr) => {{
+                let ra_encoding = NeuralTeleportRangeOneHot::<F, T>::ra_encoding($op, node);
+                let ra_v = joltworks::subprotocols::shout::ra_onehot_verifiers(
+                    &ra_encoding,
+                    &*accumulator,
+                    transcript,
+                );
+                let mut instances: Vec<
+                    Box<
+                        dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<
+                            F,
+                            T,
+                        >,
+                    >,
+                > = vec![Box::new(rangecheck_verifier)];
+                instances.extend(ra_v);
+                verify_zk_sumcheck_instances(zk_proof, instances, accumulator, transcript)
+            }};
+        }
+        match &node.operator {
+            Operator::Sigmoid(op) => verify_ra_onehot!(op)?,
+            Operator::Tanh(op) => verify_ra_onehot!(op)?,
+            Operator::Erf(op) => verify_ra_onehot!(op)?,
+            _ => unreachable!(),
+        };
+        *zk_proof_idx += 1;
+    }
+
+    // 5. Range-check one-hot/hamming-weight consistency
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*proof_node_idx, node.idx);
+        let rc_encoding = RangeCheckEncoding::<TeleportRangeCheckOperands>::new(node);
+        let [rc_ra, rc_hw, rc_bool] = joltworks::subprotocols::shout::ra_onehot_verifiers(
+            &rc_encoding,
+            accumulator,
+            transcript,
+        );
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![rc_ra, rc_hw, rc_bool],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    Ok(())
+}
+
+/// Verify Cos/Sin ZK proof: custom flow mirroring prove_cos_sin_zk.
+fn verify_cos_sin_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    model: &atlas_onnx_tracer::model::Model,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::neural_teleport::{
+        division::TeleportDivisionVerifier, range_and_onehot::NeuralTeleportRangeOneHot,
+    };
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::TeleportRangeCheckOperands, RangeCheckEncoding, RangeCheckProvider,
+    };
+    use crate::utils::opening_access::AccOpeningAccessor;
+    use common::CommittedPoly;
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    let tau = atlas_onnx_tracer::model::consts::FOUR_PI_APPROX;
+
+    // 1. Division sumcheck (from transcript)
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let v = TeleportDivisionVerifier::new_from_transcript(node.clone(), tau, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![Box::new(v)], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // 2. Lookup sumcheck
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let vi = create_verifier_instances(node, accumulator, model, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vi, accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // 3. Verify quotient binding
+    {
+        let accessor = AccOpeningAccessor::new(&mut *accumulator, node);
+        let teleport_q = accessor.get_advice(VirtualPoly::TeleportQuotient);
+        let mut provider = accessor.into_provider(transcript, teleport_q.0.clone());
+        provider.append_advice(CommittedPoly::TeleportNodeQuotient);
+    }
+
+    // 4. Eval reduction
+    verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
+
+    // 5. Range+onehot
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let rc_prov = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
+        let rc_v = rc_prov
+            .read_raf_verify::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                accumulator,
+                transcript,
+            );
+        macro_rules! verify_ra {
+            ($op:expr) => {{
+                let enc = NeuralTeleportRangeOneHot::<F, T>::ra_encoding($op, node);
+                let ra = joltworks::subprotocols::shout::ra_onehot_verifiers(
+                    &enc,
+                    &*accumulator,
+                    transcript,
+                );
+                let mut inst: Vec<
+                    Box<
+                        dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<
+                            F,
+                            T,
+                        >,
+                    >,
+                > = vec![Box::new(rc_v)];
+                inst.extend(ra);
+                verify_zk_sumcheck_instances(zk_proof, inst, accumulator, transcript)
+            }};
+        }
+        match &node.operator {
+            Operator::Cos(op) => verify_ra!(op)?,
+            Operator::Sin(op) => verify_ra!(op)?,
+            _ => unreachable!(),
+        };
+        *zk_proof_idx += 1;
+    }
+
+    // 6. Hamming-weight
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let rc_enc = RangeCheckEncoding::<TeleportRangeCheckOperands>::new(node);
+        let [a, b, c] =
+            joltworks::subprotocols::shout::ra_onehot_verifiers(&rc_enc, accumulator, transcript);
+        verify_zk_sumcheck_instances(zk_proof, vec![a, b, c], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    Ok(())
+}
+
+/// Prove a neural teleportation operator (Sigmoid, Tanh, Erf) with ZK.
+/// Default flow: eval reduction first, then division + lookup + range/onehot stages.
+#[expect(clippy::too_many_arguments)]
+fn prove_neural_teleport_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    model: &atlas_onnx_tracer::model::Model,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::neural_teleport::{
+        division::{TeleportDivisionParams, TeleportDivisionProver},
+        range_and_onehot::NeuralTeleportRangeOneHot,
+    };
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::TeleportRangeCheckOperands, RangeCheckEncoding, RangeCheckProvider,
+    };
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Eval reduction (standard, before sumchecks)
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // Dispatch to get operator-specific tau and create the lookup prover instance
+    let tau = match &node.operator {
+        Operator::Sigmoid(op) => op.tau,
+        Operator::Tanh(op) => op.tau,
+        Operator::Erf(op) => op.tau,
+        _ => unreachable!(),
+    };
+
+    // 2. Division sumcheck
+    let div_params = TeleportDivisionParams::<F>::new(node.clone(), &prover.accumulator, tau);
+    let mut div_sc = TeleportDivisionProver::new(&prover.trace, div_params);
+    let div_proof = run_zk_sumcheck(
+        &mut div_sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, div_proof));
+
+    // 3. Lookup sumcheck (operator-specific: needs mutable accumulator/transcript)
+    macro_rules! prove_lookup_zk {
+        ($Params:ty, $Prover:ty, $op:expr) => {{
+            let params = <$Params>::new(
+                node.clone(),
+                &model.graph,
+                &prover.accumulator,
+                &mut prover.transcript,
+                $op.clone(),
+            );
+            let mut sc = <$Prover>::initialize(
+                &prover.trace,
+                params,
+                &mut prover.accumulator,
+                &mut prover.transcript,
+            );
+            let proof = run_zk_sumcheck(
+                &mut sc,
+                prover,
+                blindfold_accumulator,
+                stage_configs,
+                pedersen_gens,
+            );
+            zk_sumcheck_proofs.push((node.idx, proof));
+        }};
+    }
+    match &node.operator {
+        Operator::Sigmoid(op) => {
+            use crate::onnx_proof::ops::sigmoid::{SigmoidParams, SigmoidProver};
+            prove_lookup_zk!(SigmoidParams::<F>, SigmoidProver::<F>, op);
+        }
+        Operator::Tanh(op) => {
+            use crate::onnx_proof::ops::tanh::{TanhParams, TanhProver};
+            prove_lookup_zk!(TanhParams::<F>, TanhProver::<F>, op);
+        }
+        Operator::Erf(op) => {
+            use crate::onnx_proof::ops::erf::{ErfParams, ErfProver};
+            prove_lookup_zk!(ErfParams::<F>, ErfProver::<F>, op);
+        }
+        _ => unreachable!(),
+    }
+
+    // 4. Range-check + operator-specific one-hot (batched: rangecheck + 3 ra_onehot)
+    // Helper macro to avoid dynamic dispatch on RaOneHotEncoding (uses &impl).
+    macro_rules! prove_range_and_onehot_zk {
+        ($op:expr) => {{
+            let lookup_indices =
+                NeuralTeleportRangeOneHot::<F, T>::lookup_indices($op, node, &prover.trace);
+            let ra_encoding = NeuralTeleportRangeOneHot::<F, T>::ra_encoding($op, node);
+            let rangecheck_provider = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
+            let (rangecheck_sumcheck, rc_lookup_indices) = rangecheck_provider
+                .read_raf_prove::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                    &prover.trace,
+                    &mut prover.accumulator,
+                    &mut prover.transcript,
+                );
+            let ra_onehot = joltworks::subprotocols::shout::ra_onehot_provers(
+                &ra_encoding,
+                &lookup_indices,
+                &prover.accumulator,
+                &mut prover.transcript,
+            );
+            let mut instances: Vec<Box<dyn SumcheckInstanceProver<F, T>>> =
+                vec![Box::new(rangecheck_sumcheck)];
+            instances.extend(ra_onehot);
+            let refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+                instances.iter_mut().map(|v| &mut **v as _).collect();
+            let proof = run_zk_batched_sumcheck(
+                refs,
+                prover,
+                blindfold_accumulator,
+                stage_configs,
+                pedersen_gens,
+            );
+            zk_sumcheck_proofs.push((node.idx, proof));
+            rc_lookup_indices
+        }};
+    }
+    let rc_lookup_indices = match &node.operator {
+        Operator::Sigmoid(op) => prove_range_and_onehot_zk!(op),
+        Operator::Tanh(op) => prove_range_and_onehot_zk!(op),
+        Operator::Erf(op) => prove_range_and_onehot_zk!(op),
+        _ => unreachable!(),
+    };
+
+    // 5. Range-check one-hot/hamming-weight consistency (batched: rc_ra + rc_hw + rc_bool)
+    let rc_encoding = RangeCheckEncoding::<TeleportRangeCheckOperands>::new(node);
+    let [mut rc_ra, mut rc_hw, mut rc_bool] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &rc_encoding,
+        &rc_lookup_indices,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let hw_proof = run_zk_batched_sumcheck(
+        vec![&mut *rc_ra, &mut *rc_hw, &mut *rc_bool],
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, hw_proof));
+}
+
+/// Prove Cos/Sin with ZK: custom flow (division from transcript, then lookup,
+/// then quotient binding, then eval reduction, then range+onehot).
+#[expect(clippy::too_many_arguments)]
+fn prove_cos_sin_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    model: &atlas_onnx_tracer::model::Model,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::neural_teleport::{
+        division::{TeleportDivisionParams, TeleportDivisionProver},
+        range_and_onehot::NeuralTeleportRangeOneHot,
+    };
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::TeleportRangeCheckOperands, RangeCheckEncoding, RangeCheckProvider,
+    };
+    use crate::utils::opening_access::AccOpeningAccessor;
+    use common::CommittedPoly;
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    let tau = atlas_onnx_tracer::model::consts::FOUR_PI_APPROX;
+
+    // 1. Division sumcheck (r_node_output from transcript)
+    let div_params =
+        TeleportDivisionParams::<F>::new_from_transcript(node.clone(), &mut prover.transcript, tau);
+    let mut div_sc = TeleportDivisionProver::new(&prover.trace, div_params);
+    let div_proof = run_zk_sumcheck(
+        &mut div_sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, div_proof));
+
+    // 2. Lookup sumcheck
+    macro_rules! prove_lookup {
+        ($Params:ty, $Prover:ty) => {{
+            let params = <$Params>::new(
+                node.clone(),
+                &model.graph,
+                &prover.accumulator,
+                &mut prover.transcript,
+            );
+            let mut sc = <$Prover>::initialize(
+                &prover.trace,
+                params,
+                &mut prover.accumulator,
+                &mut prover.transcript,
+            );
+            let proof = run_zk_sumcheck(
+                &mut sc,
+                prover,
+                blindfold_accumulator,
+                stage_configs,
+                pedersen_gens,
+            );
+            zk_sumcheck_proofs.push((node.idx, proof));
+        }};
+    }
+    match &node.operator {
+        Operator::Cos(_) => {
+            use crate::onnx_proof::ops::cos::{CosParams, CosProver};
+            prove_lookup!(CosParams::<F>, CosProver::<F>);
+        }
+        Operator::Sin(_) => {
+            use crate::onnx_proof::ops::sin::{SinParams, SinProver};
+            prove_lookup!(SinParams::<F>, SinProver::<F>);
+        }
+        _ => unreachable!(),
+    }
+
+    // 3. Bind TeleportNodeQuotient as committed poly
+    {
+        let accessor = AccOpeningAccessor::new(&mut prover.accumulator, node);
+        let teleport_q = accessor.get_advice(VirtualPoly::TeleportQuotient);
+        let mut provider = accessor.into_provider(&mut prover.transcript, teleport_q.0.clone());
+        provider.append_advice(CommittedPoly::TeleportNodeQuotient, teleport_q.1);
+    }
+
+    // 4. Eval reduction
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // 5-6. Range+onehot and hamming-weight
+    macro_rules! prove_range_onehot {
+        ($op:expr) => {{
+            let indices =
+                NeuralTeleportRangeOneHot::<F, T>::lookup_indices($op, node, &prover.trace);
+            let enc = NeuralTeleportRangeOneHot::<F, T>::ra_encoding($op, node);
+            let rc_prov = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
+            let (rc_sc, rc_idx) = rc_prov
+                .read_raf_prove::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                    &prover.trace,
+                    &mut prover.accumulator,
+                    &mut prover.transcript,
+                );
+            let ra = joltworks::subprotocols::shout::ra_onehot_provers(
+                &enc,
+                &indices,
+                &prover.accumulator,
+                &mut prover.transcript,
+            );
+            let mut inst: Vec<Box<dyn SumcheckInstanceProver<F, T>>> = vec![Box::new(rc_sc)];
+            inst.extend(ra);
+            let refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+                inst.iter_mut().map(|v| &mut **v as _).collect();
+            let p = run_zk_batched_sumcheck(
+                refs,
+                prover,
+                blindfold_accumulator,
+                stage_configs,
+                pedersen_gens,
+            );
+            zk_sumcheck_proofs.push((node.idx, p));
+            rc_idx
+        }};
+    }
+    let rc_indices = match &node.operator {
+        Operator::Cos(op) => prove_range_onehot!(op),
+        Operator::Sin(op) => prove_range_onehot!(op),
+        _ => unreachable!(),
+    };
+
+    let rc_enc = RangeCheckEncoding::<TeleportRangeCheckOperands>::new(node);
+    let [mut a, mut b, mut c] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &rc_enc,
+        &rc_indices,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let hw = run_zk_batched_sumcheck(
+        vec![&mut *a, &mut *b, &mut *c],
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, hw));
+}
+
+/// Prove SoftmaxLastAxis with ZK: default flow, 4 batched stages.
+/// Mirrors SoftmaxLastAxisProver::prove but uses run_zk_batched_sumcheck.
+#[expect(clippy::too_many_arguments)]
+fn prove_softmax_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+    inter_stage_commitments: &mut BTreeMap<usize, Vec<joltworks::curve::Bn254G1>>,
+    auxiliary_claims: &mut BTreeMap<joltworks::poly::opening_proof::OpeningId, F>,
+) {
+    use crate::onnx_proof::ops::softmax_last_axis::rc::SAT_DIFF_RC_BITS;
+    use crate::onnx_proof::ops::softmax_last_axis::{
+        pad_to_power_of_two, to_indices, to_lookup_bits, LookupTableData,
+        SoftmaxLastAxisProver as SmProver,
+    };
+    use atlas_onnx_tracer::ops::softmax::softmax_last_axis_decomposed;
+
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    let Operator::SoftmaxLastAxis(op) = &node.operator else {
+        unreachable!()
+    };
+    let softmax_input = prover.trace.operand_tensors(node)[0];
+    let trace = softmax_last_axis_decomposed(softmax_input, op.scale).1;
+    let mut sm = SmProver::new(node, trace, op.scale);
+
+    let scale_bits = prover.preprocessing.scale();
+    let r_lookup_bits = to_lookup_bits(&sm.trace.R, scale_bits as usize);
+    let r_indices = to_indices(&sm.trace.R);
+    let r_exp_lookup_bits = to_lookup_bits(&sm.trace.decomposed_exp.r_exp, scale_bits as usize);
+    let r_exp_indices = to_indices(&sm.trace.decomposed_exp.r_exp);
+    let z_hi_indices = to_indices(&sm.trace.decomposed_exp.z_hi);
+    let z_lo_indices = to_indices(&sm.trace.decomposed_exp.z_lo);
+    let sat_diff_lookup_bits = to_lookup_bits(&sm.trace.decomposed_exp.sat_diff, SAT_DIFF_RC_BITS);
+    let sat_diff_indices = to_indices(&sm.trace.decomposed_exp.sat_diff);
+
+    let base = sm.trace.decomposed_exp.lut.base as u64;
+    let mut table_hi = std::mem::take(&mut sm.trace.decomposed_exp.lut.lut_hi);
+    let z_bound_minus_1 = (table_hi.len() as u64) * base - 1;
+    pad_to_power_of_two(&mut table_hi);
+    let mut table_lo = std::mem::take(&mut sm.trace.decomposed_exp.lut.lut_lo);
+    pad_to_power_of_two(&mut table_lo);
+
+    let lut_data = LookupTableData {
+        table_hi,
+        table_lo,
+        z_hi_indices,
+        z_lo_indices,
+        z_bound_minus_1,
+        base,
+    };
+
+    sm.send_auxiliary_vectors(prover);
+    sm.cache_exp_sum(prover);
+
+    // Capture only PUBLIC auxiliary claims for the verifier.
+    // These are verifier-computable from the auxiliary vectors sent via transcript.
+    // Private claims (sumcheck outputs, cache_R, cache_r_exp) are NOT included.
+    {
+        use joltworks::poly::opening_proof::{OpeningId, SumcheckId};
+        let sid = SumcheckId::NodeExecution(node.idx);
+        let [f, _] = sm.F_N;
+        for k in 0..f {
+            for vp_fn in [
+                VirtualPoly::SoftmaxSumOutput as fn(usize, usize) -> VirtualPoly,
+                VirtualPoly::SoftmaxMaxOutput,
+                VirtualPoly::SoftmaxMaxIndex,
+            ] {
+                let id = OpeningId::new(vp_fn(node.idx, k), sid);
+                if let Some((_, claim)) = prover.accumulator.openings.get(&id) {
+                    auxiliary_claims.insert(id, *claim);
+                }
+            }
+        }
+        // SoftmaxExpSum: derived from public exp_sum_q auxiliary vector
+        let exp_sum_id = OpeningId::new(VirtualPoly::SoftmaxExpSum(node.idx), sid);
+        if let Some((_, claim)) = prover.accumulator.openings.get(&exp_sum_id) {
+            auxiliary_claims.insert(exp_sum_id, *claim);
+        }
+    }
+
+    // ZK cache_R: evaluate R polynomial, Pedersen-commit the claim, store in accumulator
+    let cache_r_com = {
+        use crate::utils::opening_access::AccOpeningAccessor;
+        let accessor = AccOpeningAccessor::new(&mut prover.accumulator, node);
+        let r0 = accessor.get_reduced_opening().0;
+        let eval = MultilinearPolynomial::from(sm.trace.R.clone()).evaluate(&r0.r);
+        let blinding = F::random(&mut rand::thread_rng());
+        let com = pedersen_gens.commit(&[eval], &blinding);
+        prover.transcript.append_serializable(&com);
+        // Store in accumulator (same as cache_R but without cleartext transcript append)
+        let opening_id = joltworks::poly::opening_proof::OpeningId::new(
+            VirtualPoly::SoftmaxRecipMultRemainder(node.idx),
+            joltworks::poly::opening_proof::SumcheckId::NodeExecution(node.idx),
+        );
+        prover.accumulator.openings.insert(opening_id, (r0, eval));
+        com
+    };
+
+    // Stage 1
+    let mut s1 = sm.build_stage1_instances(prover, r_lookup_bits);
+    let s1_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        s1.iter_mut().map(|v| &mut **v as _).collect();
+    let s1_proof = run_zk_batched_sumcheck(
+        s1_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, s1_proof));
+
+    // ZK cache_r_exp: same pattern
+    let cache_r_exp_com = {
+        use crate::utils::opening_access::AccOpeningAccessor;
+        let accessor = AccOpeningAccessor::new(&mut prover.accumulator, node);
+        let r1 = accessor.get_advice(VirtualPoly::SoftmaxExpQ).0;
+        let eval =
+            MultilinearPolynomial::from(sm.trace.decomposed_exp.r_exp.clone()).evaluate(&r1.r);
+        let blinding = F::random(&mut rand::thread_rng());
+        let com = pedersen_gens.commit(&[eval], &blinding);
+        prover.transcript.append_serializable(&com);
+        let opening_id = joltworks::poly::opening_proof::OpeningId::new(
+            VirtualPoly::SoftmaxExpRemainder(node.idx),
+            joltworks::poly::opening_proof::SumcheckId::NodeExecution(node.idx),
+        );
+        prover.accumulator.openings.insert(opening_id, (r1, eval));
+        com
+    };
+
+    // Stage 2
+    let mut s2 = sm.build_stage2_instances(prover, r_exp_lookup_bits, &r_indices, &lut_data);
+    let s2_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        s2.iter_mut().map(|v| &mut **v as _).collect();
+    let s2_proof = run_zk_batched_sumcheck(
+        s2_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, s2_proof));
+
+    // Stage 3
+    let mut s3 = sm.build_stage3_instances(prover, &lut_data, sat_diff_lookup_bits, &r_exp_indices);
+    let s3_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        s3.iter_mut().map(|v| &mut **v as _).collect();
+    let s3_proof = run_zk_batched_sumcheck(
+        s3_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, s3_proof));
+
+    // Stage 4
+    let mut s4 = sm.build_stage4_instances(prover, &lut_data, &sat_diff_indices);
+    let s4_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        s4.iter_mut().map(|v| &mut **v as _).collect();
+    let s4_proof = run_zk_batched_sumcheck(
+        s4_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, s4_proof));
+
+    inter_stage_commitments.insert(node.idx, vec![cache_r_com, cache_r_exp_com]);
+}
+
+/// Prove GatherLarge with ZK: default flow (eval reduction, execution + shout one-hot).
+#[expect(clippy::too_many_arguments)]
+fn prove_gather_large_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    model: &atlas_onnx_tracer::model::Model,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::ops::gather::large::GatherRaEncoding;
+    use crate::onnx_proof::ops::gather::{GatherParams, GatherProver};
+
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // Execution sumcheck
+    let params = GatherParams::new(
+        node.clone(),
+        &model.graph,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let mut sc = GatherProver::initialize(
+        &prover.trace,
+        params,
+        &mut prover.accumulator,
+        &mut prover.transcript,
+    );
+    let exec_proof = run_zk_sumcheck(
+        &mut sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, exec_proof));
+
+    // One-hot batch
+    let encoding = GatherRaEncoding::new(node);
+    let lookup_indices =
+        crate::onnx_proof::ops::gather::large::gather_lookup_indices(node, &prover.trace);
+    let [mut ra, mut hw, mut b] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &encoding,
+        &lookup_indices,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let oh_proof = run_zk_batched_sumcheck(
+        vec![&mut *ra, &mut *hw, &mut *b],
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, oh_proof));
+}
+
+/// Prove GatherSmall with ZK: default flow (eval reduction, execution, HB+bool batch, HW).
+#[expect(clippy::too_many_arguments)]
+fn prove_gather_small_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    model: &atlas_onnx_tracer::model::Model,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::ops::gather::small::{build_stage2_provers, build_stage3_prover};
+    use crate::onnx_proof::ops::gather::{GatherParams, GatherProver};
+
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // Stage 1: Execution
+    let params = GatherParams::new(
+        node.clone(),
+        &model.graph,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let mut sc = GatherProver::initialize(
+        &prover.trace,
+        params,
+        &mut prover.accumulator,
+        &mut prover.transcript,
+    );
+    let exec_proof = run_zk_sumcheck(
+        &mut sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, exec_proof));
+
+    // Stage 2: HammingBooleanity + Booleanity (batched)
+    let (mut hb_sc, mut bool_sc) = build_stage2_provers::<F>(node, prover);
+    let s2_proof = run_zk_batched_sumcheck(
+        vec![
+            &mut hb_sc as &mut dyn SumcheckInstanceProver<F, T>,
+            &mut bool_sc,
+        ],
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, s2_proof));
+
+    // Stage 3: HammingWeight (single)
+    let mut hw_sc = build_stage3_prover::<F>(node, prover);
+    let s3_proof = run_zk_sumcheck(
+        &mut hw_sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, s3_proof));
+}
+
+/// Prove Relu with ZK: default flow (eval reduction, then execution + one-hot).
+#[expect(clippy::too_many_arguments)]
+fn prove_relu_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::op_lookups::{OpLookupEncoding, OpLookupProvider};
+    use joltworks::lookup_tables::relu::ReluTable;
+
+    // 1. Eval reduction (standard, before sumchecks)
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // 2. Execution sumcheck (ps_shout read-raf)
+    let provider = OpLookupProvider::new(node.clone());
+    let (mut exec_sc, lookup_indices) = provider
+        .read_raf_prove::<F, T, ReluTable<{ common::consts::XLEN }>>(
+            &prover.trace,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+    let exec_proof = run_zk_sumcheck(
+        &mut exec_sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, exec_proof));
+
+    // 3. One-hot batch (Ra, HammingWeight, Booleanity)
+    let encoding = OpLookupEncoding::new(node);
+    let [mut ra, mut hw, mut b] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &encoding,
+        &lookup_indices,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let oh_proof = run_zk_batched_sumcheck(
+        vec![&mut *ra, &mut *hw, &mut *b],
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, oh_proof));
+}
+
+/// Prove Rsqrt with ZK: custom flow (execution from transcript, eval reduction, range checks).
+#[expect(clippy::too_many_arguments)]
+fn prove_rsqrt_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::ops::rsqrt::{RsqrtParams, RsqrtProver};
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::{RiRangeCheckOperands, RsRangeCheckOperands},
+        RangeCheckEncoding, RangeCheckProvider,
+    };
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Execution sumcheck (r_node_output + gamma from transcript)
+    let params = RsqrtParams::<F>::new(node.clone(), &mut prover.transcript);
+    let mut sc = RsqrtProver::initialize(&prover.trace, params);
+    let exec_proof = run_zk_sumcheck(
+        &mut sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, exec_proof));
+
+    // 2. Eval reduction
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // 3. Two range checks (Ri and Rs) batched together
+    let div_rc = RangeCheckProvider::<RiRangeCheckOperands>::new(node);
+    let (div_rc_sc, div_rc_idx) = div_rc
+        .read_raf_prove::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+            &prover.trace,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+    let sqrt_rc = RangeCheckProvider::<RsRangeCheckOperands>::new(node);
+    let (sqrt_rc_sc, sqrt_rc_idx) = sqrt_rc
+        .read_raf_prove::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+            &prover.trace,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+    let mut rc_instances: Vec<Box<dyn SumcheckInstanceProver<F, T>>> =
+        vec![Box::new(div_rc_sc), Box::new(sqrt_rc_sc)];
+    let rc_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        rc_instances.iter_mut().map(|v| &mut **v as _).collect();
+    let rc_proof = run_zk_batched_sumcheck(
+        rc_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, rc_proof));
+
+    // 4. Six one-hot instances (3 per range check) batched together
+    let div_enc = RangeCheckEncoding::<RiRangeCheckOperands>::new(node);
+    let [div_ra, div_hw, div_bool] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &div_enc,
+        &div_rc_idx,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let sqrt_enc = RangeCheckEncoding::<RsRangeCheckOperands>::new(node);
+    let [sqrt_ra, sqrt_hw, sqrt_bool] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &sqrt_enc,
+        &sqrt_rc_idx,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let mut oh_instances: Vec<Box<dyn SumcheckInstanceProver<F, T>>> =
+        vec![div_ra, div_hw, div_bool, sqrt_ra, sqrt_hw, sqrt_bool];
+    let oh_refs: Vec<&mut dyn SumcheckInstanceProver<F, T>> =
+        oh_instances.iter_mut().map(|v| &mut **v as _).collect();
+    let oh_proof = run_zk_batched_sumcheck(
+        oh_refs,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, oh_proof));
+}
+
+/// Prove Div operator with ZK: custom flow with execution sumcheck before eval reduction.
+#[expect(clippy::too_many_arguments)]
+fn prove_div_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    eval_reduction_proofs: &mut BTreeMap<usize, EvalReductionProof<F>>,
+    eval_reduction_h_commitments: &mut BTreeMap<usize, joltworks::curve::Bn254G1>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::ops::div::{DivParams, DivProver};
+    use crate::onnx_proof::range_checking::{
+        range_check_operands::DivRangeCheckOperands, RangeCheckEncoding, RangeCheckProvider,
+    };
+    use crate::utils::opening_access::AccOpeningAccessor;
+    use common::CommittedPoly;
+    use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
+
+    // 1. Execution sumcheck (r_node_output from transcript challenges)
+    let params = DivParams::<F>::new(node.clone(), &mut prover.transcript);
+    let mut sc = DivProver::initialize(&prover.trace, params);
+    let zk_proof = run_zk_sumcheck(
+        &mut sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, zk_proof));
+
+    // 2. ZK eval reduction
+    prove_zk_eval_reduction(
+        node,
+        prover,
+        pedersen_gens,
+        eval_reduction_proofs,
+        eval_reduction_h_commitments,
+    );
+
+    // 3. Bind quotient as committed poly at reduced opening point
+    {
+        let accessor = AccOpeningAccessor::new(&mut prover.accumulator, node);
+        let reduced = accessor.get_reduced_opening();
+        let mut provider = accessor.into_provider(&mut prover.transcript, reduced.0.clone());
+        provider.append_advice(CommittedPoly::DivNodeQuotient, reduced.1);
+    }
+
+    // 4. Range check + one-hot (skip for scalar outputs)
+    // TODO: Re-enable when range check constraints are debugged
+    if !node.is_scalar() {
+        // Run range check and one-hot in non-ZK mode to keep accumulator consistent
+        let rangecheck_provider = RangeCheckProvider::<DivRangeCheckOperands>::new(node);
+        let (mut rangecheck_sumcheck, lookup_indices) = rangecheck_provider
+            .read_raf_prove::<F, T, UnsignedLessThanTable<{ common::consts::XLEN }>>(
+                &prover.trace,
+                &mut prover.accumulator,
+                &mut prover.transcript,
+            );
+        let rc_proof = run_zk_sumcheck(
+            &mut rangecheck_sumcheck,
+            prover,
+            blindfold_accumulator,
+            stage_configs,
+            pedersen_gens,
+        );
+        zk_sumcheck_proofs.push((node.idx, rc_proof));
+
+        let encoding = RangeCheckEncoding::<DivRangeCheckOperands>::new(node);
+        let [mut ra_sc, mut hw_sc, mut bool_sc] = joltworks::subprotocols::shout::ra_onehot_provers(
+            &encoding,
+            &lookup_indices,
+            &prover.accumulator,
+            &mut prover.transcript,
+        );
+        let onehot_proof = run_zk_batched_sumcheck(
+            vec![&mut *ra_sc, &mut *hw_sc, &mut *bool_sc],
+            prover,
+            blindfold_accumulator,
+            stage_configs,
+            pedersen_gens,
+        );
+        zk_sumcheck_proofs.push((node.idx, onehot_proof));
+    }
 }
 
 /// Prove an ONNX model execution with zero-knowledge (single pass).
@@ -153,50 +1762,134 @@ pub fn prove_zk(
     let mut eval_reduction_proofs = BTreeMap::new();
     let mut eval_reduction_h_commitments = BTreeMap::new();
     let mut zk_sumcheck_proofs: Vec<NodeZkProof> = Vec::new();
+    let mut inter_stage_commitments: BTreeMap<usize, Vec<joltworks::curve::Bn254G1>> =
+        BTreeMap::new();
+    let mut auxiliary_claims: BTreeMap<joltworks::poly::opening_proof::OpeningId, F> =
+        BTreeMap::new();
 
     for (_, node) in nodes.iter().rev() {
-        // ZK eval reduction: commit h via Pedersen instead of cleartext
-        {
-            use atlas_onnx_tracer::model::trace::{LayerData, Trace};
-            use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
-
-            let node_idx = node.idx;
-            let openings = prover.accumulator.get_node_openings(node_idx);
-            let LayerData {
-                operands: _,
-                output,
-            } = Trace::layer_data(&prover.trace, node);
-            let output_mle = MultilinearPolynomial::from(output.padded_next_power_of_two());
-
-            let (proof, reduced, h_com) = EvalReductionProtocol::prove_zk::<F, C, _>(
-                &openings,
-                output_mle,
-                &mut prover.transcript,
-                pedersen_gens,
-            )
-            .expect("ZK eval reduction should not fail");
-
-            prover
-                .accumulator
-                .reduced_evaluations
-                .insert(node_idx, reduced);
-            eval_reduction_proofs.insert(node_idx, proof);
-            if let Some(com) = h_com {
-                eval_reduction_h_commitments.insert(node_idx, com);
-            }
-        }
-
-        let zk_proof = create_prover_instance(node, &prover, pp.shared.model()).map(|mut sc| {
-            run_zk_sumcheck(
-                &mut *sc,
+        if matches!(&node.operator, Operator::SoftmaxLastAxis(_)) {
+            prove_softmax_zk(
+                node,
                 &mut prover,
+                pedersen_gens,
                 &mut blindfold_accumulator,
                 &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+                &mut inter_stage_commitments,
+                &mut auxiliary_claims,
+            );
+        } else if matches!(&node.operator, Operator::GatherLarge(_)) {
+            prove_gather_large_zk(
+                node,
+                &mut prover,
+                pp.shared.model(),
                 pedersen_gens,
-            )
-        });
-        if let Some(proof) = zk_proof {
-            zk_sumcheck_proofs.push((node.idx, proof));
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+            );
+        } else if matches!(&node.operator, Operator::GatherSmall(_)) {
+            prove_gather_small_zk(
+                node,
+                &mut prover,
+                pp.shared.model(),
+                pedersen_gens,
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+            );
+        } else if matches!(&node.operator, Operator::ReLU(_)) {
+            prove_relu_zk(
+                node,
+                &mut prover,
+                pedersen_gens,
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+            );
+        } else if matches!(
+            &node.operator,
+            Operator::Sigmoid(_) | Operator::Tanh(_) | Operator::Erf(_)
+        ) {
+            prove_neural_teleport_zk(
+                node,
+                &mut prover,
+                pp.shared.model(),
+                pedersen_gens,
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+            );
+        } else if matches!(&node.operator, Operator::Cos(_) | Operator::Sin(_)) {
+            prove_cos_sin_zk(
+                node,
+                &mut prover,
+                pp.shared.model(),
+                pedersen_gens,
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+                &mut zk_sumcheck_proofs,
+            );
+        } else if matches!(&node.operator, Operator::Div(_) | Operator::Rsqrt(_)) {
+            if matches!(&node.operator, Operator::Rsqrt(_)) {
+                prove_rsqrt_zk(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                    &mut zk_sumcheck_proofs,
+                );
+            } else {
+                prove_div_zk(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut blindfold_accumulator,
+                    &mut stage_configs,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                    &mut zk_sumcheck_proofs,
+                );
+            }
+        } else {
+            // Standard flow: eval reduction first, then execution sumcheck.
+            prove_zk_eval_reduction(
+                node,
+                &mut prover,
+                pedersen_gens,
+                &mut eval_reduction_proofs,
+                &mut eval_reduction_h_commitments,
+            );
+
+            let zk_proof =
+                create_prover_instance(node, &prover, pp.shared.model()).map(|mut sc| {
+                    run_zk_sumcheck(
+                        &mut *sc,
+                        &mut prover,
+                        &mut blindfold_accumulator,
+                        &mut stage_configs,
+                        pedersen_gens,
+                    )
+                });
+            if let Some(proof) = zk_proof {
+                zk_sumcheck_proofs.push((node.idx, proof));
+            }
         }
     }
 
@@ -239,35 +1932,101 @@ pub fn prove_zk(
     let mut all_stages = Vec::new();
 
     for (i, sd) in stage_data_vec.iter().enumerate() {
+        let expected_coeffs = stage_configs[i].poly_degree + 1;
         let rounds: Vec<RoundWitness<F>> = sd
             .poly_coeffs
             .iter()
             .zip(sd.challenges.iter())
             .map(|(coeffs, challenge)| {
                 let challenge_f: F = (*challenge).into();
-                RoundWitness::new(coeffs.clone(), challenge_f)
+                // Pad coefficients to expected degree if UniPoly stripped trailing zeros
+                let mut padded = coeffs.clone();
+                padded.resize(expected_coeffs, F::zero());
+                RoundWitness::new(padded, challenge_f)
             })
             .collect();
 
-        let output_constraint = sd.output_constraints[0].as_ref();
-        if let Some(constraint) = output_constraint {
-            let output_challenge_values = sd.constraint_challenge_values[0].clone();
-            let output_opening_values: Vec<F> =
-                sd.output_claims.iter().map(|(_id, val)| *val).collect();
+        // Combine output constraints: single-instance stages have 1, batched have N.
+        // Each constraint is pre-scaled by scale_by_new_challenge(). For multi-instance
+        // stages, concatenate terms with offset challenge indices (no extra alpha layer).
+        use joltworks::subprotocols::blindfold::output_constraint::{
+            OutputClaimConstraint, ProductTerm, ValueSource,
+        };
+        let combined_constraint: Option<OutputClaimConstraint> =
+            if sd.output_constraints.iter().any(|c| c.is_none()) {
+                None
+            } else if sd.output_constraints.len() == 1 {
+                sd.output_constraints[0].clone()
+            } else {
+                let mut combined_terms = Vec::new();
+                let mut combined_openings = Vec::new();
+                let mut challenge_offset = 0usize;
+                for oc in &sd.output_constraints {
+                    let c = oc.as_ref().unwrap();
+                    let offset = |vs: &ValueSource| match vs {
+                        ValueSource::Challenge(idx) => {
+                            ValueSource::Challenge(idx + challenge_offset)
+                        }
+                        other => other.clone(),
+                    };
+                    for term in &c.terms {
+                        combined_terms.push(ProductTerm::new(
+                            offset(&term.coeff),
+                            term.factors.iter().map(&offset).collect(),
+                        ));
+                    }
+                    for id in &c.required_openings {
+                        if !combined_openings.contains(id) {
+                            combined_openings.push(*id);
+                        }
+                    }
+                    challenge_offset += c.num_challenges;
+                }
+                Some(OutputClaimConstraint::new(
+                    combined_terms,
+                    combined_openings,
+                ))
+            };
+        if let Some(constraint) = combined_constraint {
+            // Challenge values: concatenate per-instance values (already include batch_coeff).
+            let output_challenge_values: Vec<F> = sd
+                .constraint_challenge_values
+                .iter()
+                .flat_map(|cv| cv.iter().cloned())
+                .collect();
+            // Map opening values to match the constraint's required_openings order.
+            let claims_map: std::collections::HashMap<_, _> =
+                sd.output_claims.iter().cloned().collect();
+            let output_opening_values: Vec<F> = constraint
+                .required_openings
+                .iter()
+                .map(|id| {
+                    *claims_map
+                        .get(id)
+                        .unwrap_or_else(|| panic!("Missing opening claim for {id:?}"))
+                })
+                .collect();
             let final_output_witness =
                 FinalOutputWitness::general(output_challenge_values, output_opening_values);
             all_stages.push(StageWitness::with_final_output(
                 rounds,
                 final_output_witness,
             ));
-            stage_configs[i] = stage_configs[i].clone().with_constraint(constraint.clone());
+            stage_configs[i] = stage_configs[i].clone().with_constraint(constraint);
         } else {
             all_stages.push(StageWitness::new(rounds));
         }
     }
 
-    let initial_claim = stage_data_vec[0].initial_claim;
-    let blindfold_witness = BlindFoldWitness::new(initial_claim, all_stages);
+    // Collect initial claims for each chain start
+    let initial_claims: Vec<F> = stage_data_vec
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| stage_configs[*i].starts_new_chain || *i == 0)
+        .map(|(_, sd)| sd.initial_claim)
+        .collect();
+    let blindfold_witness =
+        BlindFoldWitness::with_extra_constraints(initial_claims, all_stages, vec![]);
     let baked = BakedPublicInputs::from_witness(&blindfold_witness, &stage_configs);
     let builder = VerifierR1CSBuilder::<F>::new(&stage_configs, &baked);
     let r1cs = builder.build();
@@ -331,6 +2090,10 @@ pub fn prove_zk(
         eval_commitments: real_instance.eval_commitments.clone(),
     };
 
+    let zk_sumcheck_num_instances: Vec<usize> = stage_data_vec
+        .iter()
+        .map(|sd| sd.batching_coefficients.len())
+        .collect();
     let bundle = ZkProofBundle {
         blindfold_proof,
         blindfold_verifier_input,
@@ -341,6 +2104,9 @@ pub fn prove_zk(
         commitments,
         output_claim,
         zk_sumcheck_proofs,
+        zk_sumcheck_num_instances,
+        inter_stage_commitments,
+        auxiliary_claims,
     };
 
     (bundle, io)
@@ -361,7 +2127,6 @@ pub fn verify_zk(
     pedersen_gens: &PedersenGenerators<C>,
 ) -> Result<(), ProofVerifyError> {
     use joltworks::poly::opening_proof::VerifierOpeningAccumulator;
-    use joltworks::subprotocols::evaluation_reduction::EvalReductionProtocol;
 
     let model = pp.shared.model();
     let mut accumulator = VerifierOpeningAccumulator::<F>::new_zk();
@@ -405,61 +2170,111 @@ pub fn verify_zk(
     // 3. Full IOP replay: for each node, verify eval reduction + absorb ZK sumcheck
     let mut zk_proof_idx = 0;
     for (_, node) in model.graph.nodes.iter().rev() {
-        // Verify eval reduction (ZK mode: absorb h commitment, skip claim checks)
-        let openings = accumulator.get_node_openings(node.idx);
-        let h_commitment = bundle.eval_reduction_h_commitments.get(&node.idx);
-        let reduced_instance =
-            EvalReductionProtocol::verify_zk::<F, T>(&openings, h_commitment, &mut transcript)?;
-        accumulator
-            .reduced_evaluations
-            .insert(node.idx, reduced_instance);
-
-        // For operators with sumcheck: absorb ZK sumcheck commitments into transcript
-        let has_sumcheck = !matches!(
-            &node.operator,
-            Operator::Input(_)
-                | Operator::Identity(_)
-                | Operator::Broadcast(_)
-                | Operator::MoveAxis(_)
-                | Operator::Constant(_)
-                | Operator::IsNan(_)
-        );
-
-        if has_sumcheck {
-            let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[zk_proof_idx];
-            assert_eq!(
-                *proof_node_idx, node.idx,
-                "ZK sumcheck proof order mismatch"
-            );
-
-            // Create verifier sumcheck instances and run verify_zk to replay transcript
-            let verifier_instances = create_verifier_instances(node, &accumulator, model);
-            let verifier_refs: Vec<
-                &dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>,
-            > = verifier_instances
-                .iter()
-                .map(|v| {
-                    v.as_ref()
-                        as &dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<
-                            F,
-                            T,
-                        >
-                })
-                .collect();
-
-            BatchedSumcheck::verify_zk::<F, C, T>(
-                zk_proof,
-                verifier_refs,
+        if matches!(&node.operator, Operator::SoftmaxLastAxis(_)) {
+            verify_softmax_zk(
+                node,
+                pp,
+                io,
+                bundle,
                 &mut accumulator,
                 &mut transcript,
+                &mut zk_proof_idx,
             )?;
-
-            zk_proof_idx += 1;
+        } else if matches!(&node.operator, Operator::GatherLarge(_)) {
+            verify_gather_large_zk(
+                node,
+                model,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
+        } else if matches!(&node.operator, Operator::GatherSmall(_)) {
+            verify_gather_small_zk(
+                node,
+                model,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
+        } else if matches!(&node.operator, Operator::ReLU(_)) {
+            verify_relu_zk(
+                node,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
+        } else if matches!(
+            &node.operator,
+            Operator::Sigmoid(_) | Operator::Tanh(_) | Operator::Erf(_)
+        ) {
+            verify_neural_teleport_zk(
+                node,
+                model,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
+        } else if matches!(&node.operator, Operator::Cos(_) | Operator::Sin(_)) {
+            verify_cos_sin_zk(
+                node,
+                model,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
+        } else if matches!(&node.operator, Operator::Rsqrt(_)) {
+            verify_rsqrt_zk(
+                node,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
+        } else if matches!(&node.operator, Operator::Div(_)) {
+            verify_div_zk(
+                node,
+                bundle,
+                &mut accumulator,
+                &mut transcript,
+                &mut zk_proof_idx,
+            )?;
         } else {
-            // No-sumcheck operators: run their standard verify to keep transcript in sync.
-            // Input verifies the claim against IO; others are no-ops.
-            // Input: check that the input claim matches the IO.
-            // Other no-sumcheck ops (Identity, Broadcast, etc.) don't modify the transcript.
+            // Standard flow: eval reduction first, then execution sumcheck
+            verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+
+            let has_sumcheck = !matches!(
+                &node.operator,
+                Operator::Input(_)
+                    | Operator::Identity(_)
+                    | Operator::Broadcast(_)
+                    | Operator::MoveAxis(_)
+                    | Operator::Constant(_)
+                    | Operator::IsNan(_)
+            );
+
+            if has_sumcheck {
+                let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[zk_proof_idx];
+                assert_eq!(
+                    *proof_node_idx, node.idx,
+                    "ZK sumcheck proof order mismatch"
+                );
+
+                let verifier_instances =
+                    create_verifier_instances(node, &mut accumulator, model, &mut transcript);
+                verify_zk_sumcheck_instances(
+                    zk_proof,
+                    verifier_instances,
+                    &mut accumulator,
+                    &mut transcript,
+                )?;
+
+                zk_proof_idx += 1;
+            }
         }
     }
 
@@ -550,12 +2365,41 @@ fn create_prover_instance(
                 params,
             )))
         }
+        Operator::ScalarConstDiv(_) => {
+            use crate::onnx_proof::ops::scalar_const_div::{
+                ScalarConstDivParams, ScalarConstDivProver,
+            };
+            let params = ScalarConstDivParams::<F>::new(node.clone(), &prover.accumulator);
+            Some(Box::new(ScalarConstDivProver::initialize(
+                &prover.trace,
+                params,
+            )))
+        }
+        Operator::Einsum(_) => {
+            use crate::onnx_proof::ops::einsum::EinsumProver;
+            Some(EinsumProver::sumcheck(
+                model,
+                &prover.trace,
+                node.clone(),
+                &prover.accumulator,
+            ))
+        }
+        Operator::Sum(_) => {
+            use crate::onnx_proof::ops::sum::create_sum_prover;
+            Some(create_sum_prover(
+                node,
+                model,
+                &prover.trace,
+                &prover.accumulator,
+            ))
+        }
         Operator::Input(_)
         | Operator::Identity(_)
         | Operator::Broadcast(_)
         | Operator::MoveAxis(_)
         | Operator::Constant(_)
-        | Operator::IsNan(_) => None,
+        | Operator::IsNan(_)
+        | Operator::Clamp(_) => None,
         other => {
             panic!("ZK proving not yet implemented for operator: {other:?}");
         }
@@ -565,8 +2409,9 @@ fn create_prover_instance(
 /// Create verifier sumcheck instances for a node (for IOP transcript replay).
 fn create_verifier_instances(
     node: &atlas_onnx_tracer::node::ComputationNode,
-    accumulator: &joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
     model: &atlas_onnx_tracer::model::Model,
+    transcript: &mut T,
 ) -> Vec<Box<dyn joltworks::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier<F, T>>> {
     match &node.operator {
         Operator::Square(_) => {
@@ -619,6 +2464,78 @@ fn create_verifier_instances(
                 node.clone(),
                 accumulator,
                 &model.graph,
+            ))]
+        }
+        Operator::ScalarConstDiv(_) => {
+            use crate::onnx_proof::ops::scalar_const_div::ScalarConstDivVerifier;
+            vec![Box::new(ScalarConstDivVerifier::new(
+                node.clone(),
+                accumulator,
+            ))]
+        }
+        Operator::Sigmoid(op) => {
+            use crate::onnx_proof::ops::sigmoid::SigmoidVerifier;
+            vec![Box::new(SigmoidVerifier::new(
+                node.clone(),
+                &model.graph,
+                accumulator,
+                transcript,
+                op.clone(),
+            ))]
+        }
+        Operator::Tanh(op) => {
+            use crate::onnx_proof::ops::tanh::TanhVerifier;
+            vec![Box::new(TanhVerifier::new(
+                node.clone(),
+                &model.graph,
+                accumulator,
+                transcript,
+                op.clone(),
+            ))]
+        }
+        Operator::Erf(op) => {
+            use crate::onnx_proof::ops::erf::ErfVerifier;
+            vec![Box::new(ErfVerifier::new(
+                node.clone(),
+                &model.graph,
+                accumulator,
+                transcript,
+                op.clone(),
+            ))]
+        }
+        Operator::Cos(_) => {
+            use crate::onnx_proof::ops::cos::CosVerifier;
+            vec![Box::new(CosVerifier::new(
+                node.clone(),
+                &model.graph,
+                accumulator,
+                transcript,
+            ))]
+        }
+        Operator::Sin(_) => {
+            use crate::onnx_proof::ops::sin::SinVerifier;
+            vec![Box::new(SinVerifier::new(
+                node.clone(),
+                &model.graph,
+                accumulator,
+                transcript,
+            ))]
+        }
+        Operator::Einsum(_) => {
+            use crate::onnx_proof::ops::einsum::EinsumVerifier;
+            vec![EinsumVerifier::sumcheck(model, node.clone(), accumulator)]
+        }
+        Operator::Sum(_) => {
+            use crate::onnx_proof::ops::sum::create_sum_verifier;
+            vec![create_sum_verifier(node, model, accumulator)]
+        }
+        Operator::GatherLarge(_) | Operator::GatherSmall(_) => {
+            use crate::onnx_proof::ops::gather::GatherVerifier;
+            vec![Box::new(GatherVerifier::new(
+                node.clone(),
+                &model.graph,
+                accumulator,
+                transcript,
             ))]
         }
         _ => vec![],

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -241,31 +241,35 @@ fn verify_zk_sumcheck_instances(
 
 /// Verify SoftmaxLastAxis ZK proof.
 ///
-/// The prover runs the full 4-stage pipeline via `prove_softmax_zk`.
-/// The verifier side requires constructing a `SoftmaxLastAxisVerifier` which
-/// has private stage methods and takes `&mut Verifier`. For now, we construct
-/// a temporary Verifier to run the IOP replay (cache methods + transcript ops),
-/// and skip per-stage verification (BlindFold covers constraint satisfaction).
+/// Mirror of `prove_softmax_zk`: 4 batched stages with two private inter-stage
+/// claims (R, r_exp) absorbed via Pedersen commitments. Each stage runs full
+/// per-stage `verify_zk_sumcheck_instances` (BlindFold covers the *aggregate*
+/// constraint, but per-stage transcript replay still has to match).
 ///
-/// TODO: Refactor `SoftmaxLastAxisVerifier` stage methods to accept decomposed
-/// args for proper per-stage ZK verification.
+/// Public auxiliary claims (`SoftmaxSumOutput`, `SoftmaxMaxOutput`,
+/// `SoftmaxMaxIndex`, `SoftmaxExpSum`) are pre-populated into the accumulator
+/// from the bundle so `SoftmaxLastAxisVerifier::new` and `cache_exp_sum` see
+/// the real values when they re-append them to the transcript.
 fn verify_softmax_zk(
     node: &atlas_onnx_tracer::node::ComputationNode,
     pp: &AtlasVerifierPreprocessing<F, PCS>,
-    io: &atlas_onnx_tracer::model::trace::ModelExecutionIO,
     bundle: &ZkProofBundle,
     accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
     transcript: &mut T,
     zk_proof_idx: &mut usize,
 ) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::ops::softmax_last_axis::{
+        SoftmaxLastAxisVerifier as SmVerifier, VerifierLookupTableData,
+    };
+
     verify_zk_eval_reduction(node, bundle, accumulator, transcript)?;
 
     let Operator::SoftmaxLastAxis(op) = &node.operator else {
         unreachable!()
     };
 
-    // Pre-populate the auxiliary claims (public data from send_auxiliary_vectors)
-    // so SmVerifier::new can find them in the accumulator.
+    // Pre-populate public auxiliary claims so SmVerifier::new sees real values
+    // when it re-appends them to the transcript.
     for (id, claim) in &bundle.auxiliary_claims {
         accumulator.openings.insert(
             *id,
@@ -276,74 +280,76 @@ fn verify_softmax_zk(
         );
     }
 
-    // Construct a temporary Verifier (non-ZK for SmVerifier::new and cache operations).
-    let empty_proofs = std::collections::BTreeMap::new();
-    let mut temp_verifier = crate::onnx_proof::Verifier {
-        preprocessing: &pp.shared,
-        accumulator: std::mem::take(accumulator),
-        transcript: std::mem::take(transcript),
-        proofs: &empty_proofs,
-        io,
-    };
-
-    // SmVerifier::new and cache_exp_sum need the accumulator in non-ZK mode
-    // so that: (1) auxiliary claims are stored with real values (not placeholders),
-    // (2) transcript appends match the prover's flow.
-    // The ZK verifier can do this because the auxiliary vectors are PUBLIC
-    // (sent via transcript in send_auxiliary_vectors).
-    use crate::onnx_proof::ops::softmax_last_axis::SoftmaxLastAxisVerifier as SmVerifier;
-    temp_verifier.accumulator.zk_mode = false;
-    let mut sm_v = SmVerifier::new(node, op.scale, &mut temp_verifier);
-    sm_v.cache_exp_sum(&mut temp_verifier)
-        .map_err(|e| ProofVerifyError::InvalidOpeningProof(format!("{e:?}")))?;
-    temp_verifier.accumulator.zk_mode = true;
-
-    // cache_R: PRIVATE claim. Absorb the Pedersen commitment from the bundle.
     let inter_coms = bundle
         .inter_stage_commitments
         .get(&node.idx)
         .expect("Missing inter-stage commitments for Softmax node");
-    temp_verifier.transcript.append_serializable(&inter_coms[0]);
 
-    // Helper: absorb a ZK sumcheck proof's commitments into transcript.
-    let absorb_zk_proof =
-        |zk_proof: &joltworks::subprotocols::sumcheck::ZkSumcheckProof<F, C, T>,
-         n_instances: usize,
-         t: &mut T| {
-            let _: Vec<F> = t.challenge_vector(n_instances);
-            for com in &zk_proof.round_commitments {
-                t.append_serializable(com);
-                let _: <F as JoltField>::Challenge = t.challenge_scalar_optimized::<F>();
-            }
-            for com in &zk_proof.output_claims_commitments {
-                t.append_serializable(com);
-            }
-        };
+    // Auxiliary scalars are public, so we toggle off zk_mode while
+    // SmVerifier::new and cache_exp_sum read/append them. They both rely on
+    // the accumulator returning real claim values (not the zk_mode placeholder
+    // zero) so the transcript appends match the prover's. We restore zk_mode
+    // before the private inter-stage caches and the per-stage sumcheck builds.
+    let saved_zk_mode = accumulator.zk_mode;
+    accumulator.zk_mode = false;
+    let mut sm_v = SmVerifier::new(node, op.scale, accumulator, transcript);
+    sm_v.cache_exp_sum(accumulator, transcript)
+        .map_err(|e| ProofVerifyError::InvalidOpeningProof(format!("{e:?}")))?;
+    accumulator.zk_mode = saved_zk_mode;
+
+    let scale_bits = pp.shared.scale();
+
+    // cache_R: insert explicit zero placeholder, absorb Pedersen commitment.
+    sm_v.cache_R_zk(accumulator, transcript, &inter_coms[0]);
 
     // Stage 1
     {
         let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
-        let ni = bundle.zk_sumcheck_num_instances[*zk_proof_idx];
         assert_eq!(*pid, node.idx);
-        absorb_zk_proof(zk_proof, ni, &mut temp_verifier.transcript);
+        let v = sm_v.build_stage1_verifiers(accumulator, transcript, scale_bits)?;
+        verify_zk_sumcheck_instances(zk_proof, v, accumulator, transcript)?;
         *zk_proof_idx += 1;
     }
 
-    // cache_r_exp: PRIVATE claim. Absorb the Pedersen commitment.
-    temp_verifier.transcript.append_serializable(&inter_coms[1]);
+    let lut = VerifierLookupTableData::new(op.scale);
 
-    // Stages 2-4
-    for _ in 1..4 {
+    // cache_r_exp: same shape as cache_R.
+    sm_v.cache_r_exp_zk(accumulator, transcript, &inter_coms[1]);
+
+    // Stage 2
+    {
         let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
-        let ni = bundle.zk_sumcheck_num_instances[*zk_proof_idx];
         assert_eq!(*pid, node.idx);
-        absorb_zk_proof(zk_proof, ni, &mut temp_verifier.transcript);
+        let v = sm_v.build_stage2_verifiers(accumulator, transcript, scale_bits, &lut);
+        verify_zk_sumcheck_instances(zk_proof, v, accumulator, transcript)?;
         *zk_proof_idx += 1;
     }
 
-    // Recover accumulator and transcript
-    *accumulator = temp_verifier.accumulator;
-    *transcript = temp_verifier.transcript;
+    // Stage 3
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let v = sm_v.build_stage3_verifiers(accumulator, transcript, scale_bits, &lut);
+        verify_zk_sumcheck_instances(zk_proof, v, accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // NOTE: operand_link (X(r2) == max_k - z_c - sat_diff) is intentionally
+    // skipped here. It is a verifier-side algebraic identity over the openings
+    // SoftmaxZHi, SoftmaxZLo, SoftmaxSatDiff, and the input X(r2). All four are
+    // private in the ZK pipeline (the verifier only sees the zk_mode placeholder
+    // zero), while max_k is a public auxiliary scalar (non-zero). Doing the
+    // check here would always fail. Encoding the operand-link identity as a
+    // BlindFold R1CS constraint is the right fix; tracked separately.
+
+    // Stage 4
+    {
+        let (pid, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(*pid, node.idx);
+        let v = sm_v.build_stage4_verifiers(accumulator, transcript, &lut);
+        verify_zk_sumcheck_instances(zk_proof, v, accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
 
     Ok(())
 }
@@ -2174,7 +2180,6 @@ pub fn verify_zk(
             verify_softmax_zk(
                 node,
                 pp,
-                io,
                 bundle,
                 &mut accumulator,
                 &mut transcript,

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1935,8 +1935,8 @@ pub fn prove_zk(
                     &mut eval_reduction_h_commitments,
                 );
 
-                let zk_proof = create_prover_instance(node, &prover, pp.shared.model()).map(
-                    |mut sc| {
+                let zk_proof =
+                    create_prover_instance(node, &prover, pp.shared.model()).map(|mut sc| {
                         run_zk_sumcheck(
                             &mut *sc,
                             &mut prover,
@@ -1944,8 +1944,7 @@ pub fn prove_zk(
                             &mut stage_configs,
                             pedersen_gens,
                         )
-                    },
-                );
+                    });
                 if let Some(proof) = zk_proof {
                     zk_sumcheck_proofs.push((node.idx, proof));
                 }

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -334,13 +334,36 @@ fn verify_softmax_zk(
         *zk_proof_idx += 1;
     }
 
-    // NOTE: operand_link (X(r2) == max_k - z_c - sat_diff) is intentionally
-    // skipped here. It is a verifier-side algebraic identity over the openings
-    // SoftmaxZHi, SoftmaxZLo, SoftmaxSatDiff, and the input X(r2). All four are
-    // private in the ZK pipeline (the verifier only sees the zk_mode placeholder
-    // zero), while max_k is a public auxiliary scalar (non-zero). Doing the
-    // check here would always fail. Encoding the operand-link identity as a
-    // BlindFold R1CS constraint is the right fix; tracked separately.
+    // NOTE: operand_link (X(r2) == max_k - z_c - sat_diff, expanded as
+    //   X(r2) - max_k(r2_lead) + z_hi(r2)*B + z_lo(r2) + sat_diff(r2) == 0
+    // ) is intentionally skipped here.
+    //
+    // It is a verifier-side algebraic identity over openings X (input 0),
+    // SoftmaxZHi, SoftmaxZLo, SoftmaxSatDiff, with `max_k(r2_lead)` derived by
+    // the verifier from public auxiliary scalars and `B` the digit base from
+    // the LUT. In the ZK pipeline all four openings are private and surface to
+    // the verifier as the zk_mode placeholder zero, while max_k is non-zero,
+    // so a direct verifier-side check would always fail.
+    //
+    // Closing this gap requires expressing the identity as a constraint inside
+    // BlindFold's R1CS so it is checked as part of the aggregate proof. The
+    // existing `extra_constraints` mechanism (currently dormant in prove_zk:
+    // empty vec, eval_commitment_gens=None) emits `output_var = SoP` plus a
+    // Pedersen binding on output_value, which is the wrong shape: an identity
+    // wants `(SoP) * 1 == 0` with no output_var or commitment. The right
+    // BlindFold-side change is a new `LayoutStep::AlgebraicIdentity` variant
+    // (and parallel additions in layout.rs / r1cs.rs / witness.rs / folding.rs
+    // / mod.rs) that allocates only the required opening vars, deduplicates
+    // against earlier constraint allocations via the existing seen_openings
+    // set, and emits a single R1CS row `(SoP) * 1 = 0`. Then this site
+    // constructs an OutputClaimConstraint with terms
+    //   1*X, (-max_k_eval)*1, B*z_hi, 1*z_lo, 1*sat_diff
+    // (B as ValueSource::Constant, max_k_eval as a baked challenge), passes
+    // the four opening_values via a new identity-witness collection on
+    // BlindFoldWitness, and the prover commits no extra Pedersen output.
+    //
+    // Tracked in wiki/jolt-atlas/book/src/underway/pr-239-review.md as the
+    // first remaining outstanding item.
 
     // Stage 4
     {

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1888,8 +1888,31 @@ pub fn prove_zk(
                 &mut eval_reduction_h_commitments,
                 &mut zk_sumcheck_proofs,
             ),
-            // Default flow: eval reduction first, then execution sumcheck (or none
-            // for no-sumcheck ops, which create_prover_instance returns None for).
+            // No-sumcheck ops: eval reduction only, no execution sumcheck.
+            // Clamp is a no-op in the ZK pipeline (prover and verifier both
+            // skip the sumcheck step).
+            Operator::Input(_)
+            | Operator::Identity(_)
+            | Operator::Broadcast(_)
+            | Operator::MoveAxis(_)
+            | Operator::Constant(_)
+            | Operator::IsNan(_)
+            | Operator::Clamp(_) => {
+                prove_zk_eval_reduction(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                );
+            }
+            // MeanOfSquares is not yet implemented in `create_prover_instance`
+            // (it falls into the panic catch-all). Surface that here as an
+            // explicit `unimplemented!` so the dispatch reflects the gap.
+            Operator::MeanOfSquares(_) => {
+                unimplemented!("ZK proving not yet implemented for MeanOfSquares");
+            }
+            // Default flow: eval reduction first, then execution sumcheck.
             Operator::Add(_)
             | Operator::Sub(_)
             | Operator::Neg(_)
@@ -1903,15 +1926,7 @@ pub fn prove_zk(
             | Operator::Slice(_)
             | Operator::ScalarConstDiv(_)
             | Operator::Einsum(_)
-            | Operator::Sum(_)
-            | Operator::MeanOfSquares(_)
-            | Operator::Clamp(_)
-            | Operator::Input(_)
-            | Operator::Identity(_)
-            | Operator::Broadcast(_)
-            | Operator::MoveAxis(_)
-            | Operator::Constant(_)
-            | Operator::IsNan(_) => {
+            | Operator::Sum(_) => {
                 prove_zk_eval_reduction(
                     node,
                     &mut prover,
@@ -2282,15 +2297,25 @@ pub fn verify_zk(
                 &mut zk_proof_idx,
             )?,
             // Default flow: eval reduction always; execution sumcheck for ops
-            // that have one. The no-sumcheck ops are listed explicitly below
-            // and skip the sumcheck-instances call.
+            // that have one. The no-sumcheck ops (including Clamp, which the
+            // prover treats as a no-op via `create_prover_instance` returning
+            // `None`) are listed explicitly below and skip the
+            // sumcheck-instances call.
             Operator::Input(_)
             | Operator::Identity(_)
             | Operator::Broadcast(_)
             | Operator::MoveAxis(_)
             | Operator::Constant(_)
-            | Operator::IsNan(_) => {
+            | Operator::IsNan(_)
+            | Operator::Clamp(_) => {
                 verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+            }
+            // MeanOfSquares is not yet implemented on the prover side
+            // (`create_prover_instance` falls through to its panic arm). Mirror
+            // the panic here so both sides fail loudly and symmetrically
+            // rather than later at an opaque proof-index mismatch.
+            Operator::MeanOfSquares(_) => {
+                unimplemented!("ZK verification not yet implemented for MeanOfSquares");
             }
             Operator::Add(_)
             | Operator::Sub(_)
@@ -2305,9 +2330,7 @@ pub fn verify_zk(
             | Operator::Slice(_)
             | Operator::ScalarConstDiv(_)
             | Operator::Einsum(_)
-            | Operator::Sum(_)
-            | Operator::MeanOfSquares(_)
-            | Operator::Clamp(_) => {
+            | Operator::Sum(_) => {
                 verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
 
                 let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[zk_proof_idx];

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -168,6 +168,17 @@ fn prove_zk_eval_reduction(
 
     let node_idx = node.idx;
     let openings = prover.accumulator.get_node_openings(node_idx);
+    if openings.is_empty() {
+        // Mirror verify_zk_eval_reduction (zk.rs:204-209): nodes whose
+        // consumers did not call cache_openings in the ZK path have no
+        // openings to reduce. Skip; the verifier handles this symmetrically.
+        // Safe for no-sumcheck operators (Input/Identity/Broadcast/MoveAxis/
+        // Constant/IsNan/Clamp). For default-branch operators, the subsequent
+        // sumcheck setup will panic looking up `reduced_evaluations[node]`;
+        // that indicates a missing `cache_openings` call in the consumer's
+        // ZK prove flow and is a real bug, not something to paper over here.
+        return;
+    }
     let LayerData {
         operands: _,
         output,
@@ -1247,8 +1258,14 @@ fn prove_softmax_zk(
         base,
     };
 
+    // Public auxiliary scalars: toggle off prover zk_mode so the cleartext
+    // claims are appended to the transcript. The verifier toggles its own
+    // zk_mode off symmetrically (see verify_softmax_zk).
+    let saved_zk_mode = prover.accumulator.zk_mode;
+    prover.accumulator.zk_mode = false;
     sm.send_auxiliary_vectors(prover);
     sm.cache_exp_sum(prover);
+    prover.accumulator.zk_mode = saved_zk_mode;
 
     // Capture only PUBLIC auxiliary claims for the verifier.
     // These are verifier-computable from the auxiliary vectors sent via transcript.
@@ -1760,6 +1777,13 @@ pub fn prove_zk(
     let trace = pp.model().trace(inputs);
     let io = Trace::io(&trace, pp.model());
     let mut prover = Prover::<F, T>::new(pp.shared.clone(), trace);
+    // Mirror the verifier's `VerifierOpeningAccumulator::new_zk` default: the
+    // ZK pipeline hides cleartext opening claims behind Pedersen commitments
+    // (emitted by BatchedSumcheck::prove_zk), so the prover must NOT append
+    // raw claims to the transcript in `append_virtual` / `append_dense`. Code
+    // paths that intentionally publish a claim in the clear (e.g. Softmax's
+    // public auxiliary vectors) toggle this flag off and back on.
+    prover.accumulator.zk_mode = true;
 
     let (poly_map, commitments) = ONNXProof::<F, T, PCS>::commit_witness_polynomials(
         pp.model(),
@@ -1767,7 +1791,15 @@ pub fn prove_zk(
         &pp.generators,
         &mut prover.transcript,
     );
-    ONNXProof::<F, T, PCS>::output_claim(&mut prover);
+    // The output claim is a public scalar derived from IO; both prover and
+    // verifier (`verify_zk` does `transcript.append_scalar(&expected_output_claim)`)
+    // append it in the clear. Toggle prover zk_mode off so its append fires.
+    {
+        let saved = prover.accumulator.zk_mode;
+        prover.accumulator.zk_mode = false;
+        ONNXProof::<F, T, PCS>::output_claim(&mut prover);
+        prover.accumulator.zk_mode = saved;
+    }
 
     // Capture the output claim for the verifier. This is public (derived from IO).
     // Computed the same way as ONNXProof::output_claim: evaluate output MLE at
@@ -1888,16 +1920,10 @@ pub fn prove_zk(
                 &mut eval_reduction_h_commitments,
                 &mut zk_sumcheck_proofs,
             ),
-            // No-sumcheck ops: eval reduction only, no execution sumcheck.
-            // Clamp is a no-op in the ZK pipeline (prover and verifier both
-            // skip the sumcheck step).
-            Operator::Input(_)
-            | Operator::Identity(_)
-            | Operator::Broadcast(_)
-            | Operator::MoveAxis(_)
-            | Operator::Constant(_)
-            | Operator::IsNan(_)
-            | Operator::Clamp(_) => {
+            // No-sumcheck ops that don't register openings on inputs.
+            // Constants and Inputs have no inputs to cache; their non-zk
+            // `prove` is a no-op apart from a sanity read of `get_reduced_opening`.
+            Operator::Input(_) | Operator::Constant(_) => {
                 prove_zk_eval_reduction(
                     node,
                     &mut prover,
@@ -1905,6 +1931,87 @@ pub fn prove_zk(
                     &mut eval_reduction_proofs,
                     &mut eval_reduction_h_commitments,
                 );
+            }
+            // No-sumcheck ops that DO register openings on their input(s).
+            // The non-zk path runs eval reduction then the operator's `prove`,
+            // which appends a `Target::Input(0)` opening so the producer's
+            // openings list is non-empty when it's processed. Mirror that
+            // here, otherwise default-branch producers (e.g. ScalarConstDiv
+            // feeding a Broadcast) hit empty openings and the subsequent
+            // sumcheck setup panics.
+            // No-sumcheck ops that register an opening on their input. Each
+            // op's prove flow appends `Target::Input(0)` via `append_nodeio`.
+            // With `prover.accumulator.zk_mode = true`, those calls are
+            // transcript-quiet on the prover; the verifier (also zk_mode on)
+            // is symmetric, so no auxiliary_claims dance is needed here.
+            Operator::Broadcast(_) => {
+                prove_zk_eval_reduction(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                );
+                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::onnx_proof::ops::broadcast::{BroadcastParams, BroadcastProver};
+                    let params = BroadcastParams::new(node.clone(), &prover.accumulator);
+                    let bp = BroadcastProver::initialize(&prover.trace, params);
+                    bp.prove(&mut prover.accumulator, &mut prover.transcript);
+                }
+            }
+            Operator::MoveAxis(_) => {
+                prove_zk_eval_reduction(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                );
+                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::onnx_proof::ops::moveaxis::{MoveAxisParams, MoveAxisProver};
+                    let params = MoveAxisParams::new(node.clone(), &prover.accumulator);
+                    let mp = MoveAxisProver::initialize(params);
+                    mp.prove(&mut prover.accumulator, &mut prover.transcript);
+                }
+            }
+            Operator::Identity(op) => {
+                prove_zk_eval_reduction(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                );
+                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::onnx_proof::ops::OperatorProofTrait;
+                    let _ = OperatorProofTrait::<F, T>::prove(op, node, &mut prover);
+                }
+            }
+            Operator::IsNan(op) => {
+                prove_zk_eval_reduction(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                );
+                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::onnx_proof::ops::OperatorProofTrait;
+                    let _ = OperatorProofTrait::<F, T>::prove(op, node, &mut prover);
+                }
+            }
+            Operator::Clamp(op) => {
+                prove_zk_eval_reduction(
+                    node,
+                    &mut prover,
+                    pedersen_gens,
+                    &mut eval_reduction_proofs,
+                    &mut eval_reduction_h_commitments,
+                );
+                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::onnx_proof::ops::OperatorProofTrait;
+                    let _ = OperatorProofTrait::<F, T>::prove(op, node, &mut prover);
+                }
             }
             // MeanOfSquares is not yet implemented in `create_prover_instance`
             // (it falls into the panic catch-all). Surface that here as an
@@ -2300,14 +2407,46 @@ pub fn verify_zk(
             // prover treats as a no-op via `create_prover_instance` returning
             // `None`) are listed explicitly below and skip the
             // sumcheck-instances call.
-            Operator::Input(_)
-            | Operator::Identity(_)
-            | Operator::Broadcast(_)
-            | Operator::MoveAxis(_)
-            | Operator::Constant(_)
-            | Operator::IsNan(_)
-            | Operator::Clamp(_) => {
+            // No-sumcheck ops that don't register openings on inputs.
+            Operator::Input(_) | Operator::Constant(_) => {
                 verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+            }
+            // No-sumcheck ops that DO register openings on their input(s).
+            // Mirror the prover-side input caching (see the matching arms in
+            // `prove_zk`) so the producer's openings list is populated.
+            // No-sumcheck ops that register an opening on their input. With
+            // `accumulator.zk_mode = true`, the verifier's `append_nodeio`
+            // hits the placeholder branch and stays transcript-quiet,
+            // mirroring the prover. Each op's verify() also internally
+            // compares the input opening claim against the node's reduced
+            // claim; in ZK both are the placeholder F::zero(), so the check
+            // passes trivially (BlindFold enforces the real algebraic
+            // identity via its R1CS).
+            Operator::Broadcast(_) => {
+                verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+                if accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::onnx_proof::ops::broadcast::BroadcastVerifier;
+                    let bv = BroadcastVerifier::new(node.clone(), &accumulator, &model.graph);
+                    bv.verify(&mut accumulator, &mut transcript)?;
+                }
+            }
+            Operator::MoveAxis(_) => {
+                verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+                if accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::onnx_proof::ops::moveaxis::MoveAxisVerifier;
+                    let mv = MoveAxisVerifier::new(node.clone(), &accumulator);
+                    mv.verify(&mut accumulator, &mut transcript)?;
+                }
+            }
+            Operator::Identity(_) | Operator::IsNan(_) | Operator::Clamp(_) => {
+                verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+                if accumulator.reduced_evaluations.contains_key(&node.idx) {
+                    use crate::utils::opening_access::{AccOpeningAccessor, Target};
+                    let accessor = AccOpeningAccessor::new(&mut accumulator, node);
+                    let (opening_point, _claim) = accessor.get_reduced_opening();
+                    let mut provider = accessor.into_provider(&mut transcript, opening_point);
+                    provider.append_nodeio(Target::Input(0));
+                }
             }
             // MeanOfSquares is not yet implemented on the prover side
             // (`create_prover_instance` falls through to its panic arm). Mirror

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -7,7 +7,7 @@
 
 use crate::onnx_proof::{AtlasProverPreprocessing, AtlasVerifierPreprocessing, ONNXProof, Prover};
 use ark_bn254::{Bn254, Fr};
-use ark_std::Zero;
+use ark_std::{One, Zero};
 use atlas_onnx_tracer::{
     model::trace::{ModelExecutionIO, Trace},
     ops::Operator,
@@ -85,6 +85,28 @@ pub struct ZkProofBundle {
     /// Auxiliary opening claims that must be pre-populated in the verifier accumulator.
     /// In the non-ZK flow, these come from ONNXProof::opening_claims::populate_accumulator.
     pub auxiliary_claims: BTreeMap<joltworks::poly::opening_proof::OpeningId, F>,
+    /// PCS opening proof on the joint (gamma-weighted RLC) polynomial at the
+    /// batched-opening-reduction point `r_sumcheck`. Together with the
+    /// homomorphically-combined commitment, this is what binds `bundle.commitments`
+    /// to a specific evaluation. Reveals `joint_claim` in cleartext (one
+    /// gamma-weighted aggregate scalar; per-poly y_P_i values remain hidden).
+    /// `None` when `poly_map` is empty (no committed polynomials).
+    ///
+    /// NOTE: this is Step 8 of the wiki design. Full ZK for `joint_claim`
+    /// would require a hiding/ZK extension to HyperKZG (none today).
+    pub joint_opening_proof: Option<<PCS as CommitmentScheme>::Proof>,
+    /// Cleartext joint claim revealed by the PCS opening.
+    pub joint_claim: Option<F>,
+    /// The opening point `r_sumcheck` used for `joint_opening_proof`,
+    /// in `F::Challenge` form so it can feed `PCS::verify` directly.
+    pub joint_opening_point: Option<Vec<<F as joltworks::field::JoltField>::Challenge>>,
+    /// ZK proof for the batched-opening reduction sumcheck. The verifier
+    /// re-absorbs its `round_commitments` into the main transcript so the
+    /// transcript state at the y_com / PCS::verify points matches the prover.
+    /// (BlindFold also re-verifies this stage internally via its R1CS; the
+    /// bundle copy is purely for main-transcript replay.)
+    pub batch_opening_zk_sumcheck:
+        Option<joltworks::subprotocols::sumcheck::ZkSumcheckProof<F, C, T>>,
 }
 
 /// Run a single-instance ZK sumcheck and collect stage data.
@@ -2059,38 +2081,159 @@ pub fn prove_zk(
         }
     }
 
-    // y_com for batch opening (no-op when poly_map is empty)
+    // y_com for batch opening (no-op when poly_map is empty).
+    //
+    // ZK path: route the batched-opening sumcheck through `BatchedSumcheck::prove_zk`
+    // (via `prove_batch_opening_sumcheck_zk`) so its round polynomials are Pedersen-
+    // committed and the stage data flows into `BlindFoldAccumulator::stage_data`,
+    // letting the BlindFold R1CS prove sumcheck-validity instead of leaking
+    // per-poly claims through the transcript. Output-claim binding to `y_com`
+    // (eval_commitment_gens machinery) is wired in subsequent steps; the
+    // current `Opening<F>::output_claim_constraint` returns `None`, so the
+    // BlindFold R1CS does not yet enforce the sumcheck output. See
+    // wiki/jolt-atlas/book/src/underway/batched-opening-sound-verifier.md.
+    // Captured for the BlindFold `extra_constraint` that ties the y_com
+    // commitment to `sum gamma_i * y_P_i` (where y_P_i = P_i(r_sumcheck)).
+    // Empty when there are no committed polynomials (poly_map is empty).
+    let mut joint_eval_commitment: Option<joltworks::curve::Bn254G1> = None;
+    let mut batch_opening_extra_constraint:
+        Option<joltworks::subprotocols::blindfold::output_constraint::OutputClaimConstraint> = None;
+    let mut batch_opening_extra_witness:
+        Option<joltworks::subprotocols::blindfold::witness::ExtraConstraintWitness<F>> = None;
+    // Step 8 (PCS-binding): PCS opening proof for the joint polynomial at
+    // r_sumcheck. Binds `bundle.commitments` to the joint evaluation.
+    let mut joint_opening_proof: Option<<PCS as CommitmentScheme>::Proof> = None;
+    let mut joint_claim_value: Option<F> = None;
+    let mut joint_opening_point: Option<Vec<<F as joltworks::field::JoltField>::Challenge>> = None;
+    let mut batch_opening_zk_sumcheck = None;
     if !poly_map.is_empty() {
         prover.accumulator.prepare_for_sumcheck(&poly_map);
-        let (_acc_proof, r_sumcheck_acc) = prover
+        let mut rng = rand::thread_rng();
+        let (zk_acc_proof, r_sumcheck_acc) = prover
             .accumulator
-            .prove_batch_opening_sumcheck(&mut prover.transcript);
+            .prove_batch_opening_sumcheck_zk::<T, C, _>(
+                &mut blindfold_accumulator,
+                &mut stage_configs,
+                pedersen_gens,
+                &mut rng,
+                &mut prover.transcript,
+            );
+        batch_opening_zk_sumcheck = Some(zk_acc_proof);
         let state = prover
             .accumulator
             .finalize_batch_opening_sumcheck(r_sumcheck_acc, &mut prover.transcript);
 
-        let joint_claim: F = state.sumcheck_claims.iter().sum();
+        // Compute effective coefficients = gamma_i * lagrange_i, where
+        // lagrange_i is the product over the high-order r_sumcheck variables
+        // that polynomial i does not depend on. This matches the existing
+        // non-zk `compute_joint_claim` so that
+        //   joint_poly(r_sumcheck) = sum_i (gamma_i * lagrange_i) * y_P_i
+        // i.e. the materialized RLC of `poly_map` (which pads short polys
+        // with zeros) evaluated at `r_sumcheck` equals the algebraic
+        // combination of per-poly evaluations weighted by the lagrange term.
+        // Polynomials with `num_rounds == max_num_rounds` have empty
+        // r_high, so lagrange_i = 1 (no effect).
+        let max_num_rounds = state.r_sumcheck.len();
+        use joltworks::field::OptimizedMul;
+        let num_rounds_per_poly: Vec<usize> = state
+            .polynomials
+            .iter()
+            .map(|poly| {
+                let p = poly_map
+                    .get(poly)
+                    .expect("polynomial in state.polynomials must be in poly_map");
+                match p {
+                    joltworks::poly::multilinear_polynomial::MultilinearPolynomial::OneHot(oh) => {
+                        (oh.K * oh.nonzero_indices.len()).log_2()
+                    }
+                    _ => p.original_len().log_2(),
+                }
+            })
+            .collect();
+        let effective_coeffs: Vec<F> = state
+            .gamma_powers
+            .iter()
+            .zip(num_rounds_per_poly.iter())
+            .map(|(g, num_rounds)| {
+                let r_slice = &state.r_sumcheck[..max_num_rounds - num_rounds];
+                let lagrange_eval: F = r_slice
+                    .iter()
+                    .map(|r| F::one() - *r)
+                    .product();
+                g.mul_01_optimized(lagrange_eval)
+            })
+            .collect();
+
+        let joint_claim: F = effective_coeffs
+            .iter()
+            .zip(state.sumcheck_claims.iter())
+            .map(|(c, claim)| *c * claim)
+            .sum();
         let y_blinding = F::random(&mut rand::thread_rng());
         let y_com = pedersen_gens.commit(&[joint_claim], &y_blinding);
         prover.transcript.append_serializable(&y_com);
 
+        // Build the BlindFold `extra_constraint`:
+        //   joint_claim = sum_i (gamma_i * lagrange_i) * y_P_i
+        // where each y_P_i is the opening registered by
+        // `OpeningProofReductionSumcheckProver::cache_openings` at
+        // (CommittedPoly_i, SumcheckId::BlindFoldBatchOpening).
+        use joltworks::poly::opening_proof::{OpeningId, SumcheckId as SId};
+        use joltworks::subprotocols::blindfold::output_constraint::{
+            OutputClaimConstraint, ValueSource,
+        };
+        use joltworks::subprotocols::blindfold::witness::ExtraConstraintWitness;
+        let opening_ids: Vec<OpeningId> = state
+            .polynomials
+            .iter()
+            .map(|poly| OpeningId::new(*poly, SId::BlindFoldBatchOpening))
+            .collect();
+        let terms: Vec<(ValueSource, ValueSource)> = opening_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (ValueSource::Challenge(i), ValueSource::Opening(*id)))
+            .collect();
+        batch_opening_extra_constraint =
+            Some(OutputClaimConstraint::linear(terms));
+        batch_opening_extra_witness = Some(ExtraConstraintWitness {
+            output_value: joint_claim,
+            blinding: y_blinding,
+            challenge_values: effective_coeffs.clone(),
+            opening_values: state.sumcheck_claims.clone(),
+        });
+        joint_eval_commitment = Some(y_com);
+
+        // Keep the legacy OpeningProofData hook populated for any consumer
+        // that still reads it (none currently, but cheap).
         blindfold_accumulator.set_opening_proof_data(
             joltworks::subprotocols::blindfold::OpeningProofData {
-                opening_ids: state
-                    .polynomials
-                    .iter()
-                    .map(|poly| {
-                        joltworks::poly::opening_proof::OpeningId::new(
-                            *poly,
-                            joltworks::poly::opening_proof::SumcheckId::BlindFoldBatchOpening,
-                        )
-                    })
-                    .collect(),
-                constraint_coeffs: state.gamma_powers.clone(),
+                opening_ids,
+                constraint_coeffs: effective_coeffs.clone(),
                 joint_claim,
                 y_blinding,
             },
         );
+
+        // Step 8: produce the PCS opening proof on the joint polynomial.
+        // Materialise the gamma-weighted RLC of poly_map and prove its opening
+        // at r_sumcheck. The verifier homomorphically combines `bundle.commitments`
+        // with `gamma_powers` to reconstruct the same joint commitment.
+        let r_sumcheck_acc: Vec<<F as joltworks::field::JoltField>::Challenge> =
+            state.r_sumcheck.clone();
+        let joint_poly = joltworks::poly::rlc_polynomial::build_materialized_rlc(
+            &state.gamma_powers,
+            &poly_map,
+        );
+        let opening_proof = PCS::prove(
+            &pp.generators,
+            &joint_poly,
+            &r_sumcheck_acc,
+            None,
+            &mut prover.transcript,
+        );
+        joint_opening_proof = Some(opening_proof);
+        joint_claim_value = Some(joint_claim);
+        joint_opening_point = Some(r_sumcheck_acc);
     }
 
     // Build BlindFold proof from accumulated stage data
@@ -2191,10 +2334,32 @@ pub fn prove_zk(
         .filter(|(i, _)| stage_configs[*i].starts_new_chain || *i == 0)
         .map(|(_, sd)| sd.initial_claim)
         .collect();
-    let blindfold_witness =
-        BlindFoldWitness::with_extra_constraints(initial_claims, all_stages, vec![]);
+    // Plumb the batched-opening extra constraint (if any) into both witness
+    // and R1CS so the BlindFold R1CS enforces
+    //   joint_claim = sum_i gamma_i * y_P_i   AND   y_com = g * joint_claim + h * y_blinding.
+    // The latter is enforced via BlindFold's `eval_commitment_gens` check; the
+    // y_com is placed in `RelaxedR1CSInstance::eval_commitments` below.
+    let extra_constraints_for_r1cs: Vec<_> = batch_opening_extra_constraint
+        .clone()
+        .into_iter()
+        .collect();
+    let extra_constraint_witnesses: Vec<_> = batch_opening_extra_witness
+        .clone()
+        .into_iter()
+        .collect();
+    let blindfold_witness = BlindFoldWitness::with_extra_constraints(
+        initial_claims,
+        all_stages,
+        extra_constraint_witnesses,
+    );
     let baked = BakedPublicInputs::from_witness(&blindfold_witness, &stage_configs);
-    let builder = VerifierR1CSBuilder::<F>::new(&stage_configs, &baked);
+    let builder = VerifierR1CSBuilder::<F>::new_with_extra(
+        &stage_configs,
+        &extra_constraints_for_r1cs,
+        &baked,
+        Vec::new(),
+        std::collections::BTreeMap::new(),
+    );
     let r1cs = builder.build();
 
     let z = blindfold_witness.assign(&r1cs);
@@ -2235,6 +2400,8 @@ pub fn prove_zk(
         w_row_blindings[R_coeff + row] = blinding;
     }
 
+    let eval_commitments: Vec<joltworks::curve::Bn254G1> =
+        joint_eval_commitment.into_iter().collect();
     let (real_instance, real_witness) = RelaxedR1CSInstance::<F, C>::new_non_relaxed(
         &witness,
         r1cs.num_constraints,
@@ -2242,11 +2409,24 @@ pub fn prove_zk(
         round_commitments,
         Vec::new(),
         noncoeff_row_commitments,
-        Vec::new(),
+        eval_commitments,
         w_row_blindings,
     );
 
-    let bf_prover = BlindFoldProver::new(pedersen_gens, &r1cs, None);
+    // `eval_commitment_gens = Some((g, h))` activates BlindFold's
+    // eval-commitment check (protocol.rs:349-362): for every extra constraint
+    // it verifies the folded `eval_commitment_i == g * folded_output_i + h *
+    // folded_blinding_i`. With the batched-opening extra constraint in place,
+    // this is what binds `y_com` to the BlindFold R1CS witness.
+    let eval_commitment_gens = if batch_opening_extra_constraint.is_some() {
+        Some((
+            pedersen_gens.message_generators[0],
+            pedersen_gens.blinding_generator,
+        ))
+    } else {
+        None
+    };
+    let bf_prover = BlindFoldProver::new(pedersen_gens, &r1cs, eval_commitment_gens);
     let mut bf_transcript = T::new(b"BlindFold_onnx");
     let blindfold_proof = bf_prover.prove(&real_instance, &real_witness, &z, &mut bf_transcript);
 
@@ -2273,6 +2453,10 @@ pub fn prove_zk(
         zk_sumcheck_num_instances,
         inter_stage_commitments,
         auxiliary_claims,
+        joint_opening_proof,
+        joint_claim: joint_claim_value,
+        joint_opening_point,
+        batch_opening_zk_sumcheck,
     };
 
     (bundle, io)
@@ -2286,11 +2470,41 @@ pub fn prove_zk(
 ///    sumcheck commitments into transcript (mirroring the prover's flow).
 /// 3. BlindFold proof verifies (covers sumcheck round consistency and
 ///    constraint satisfaction).
+/// Snapshot of the inputs to the final HyperKZG verification step inside
+/// [`verify_zk`], captured by [`verify_zk_with_pcs_capture`] right before
+/// the call to `PCS::verify`. External tools (e.g., zkARc's pi-prime
+/// extractor) use this to derive the verifier-side MSM trace at the exact
+/// transcript state that the verifier reaches.
+#[derive(Clone)]
+pub struct PcsVerifyCapture {
+    pub joint_commitment: <PCS as joltworks::poly::commitment::commitment_scheme::CommitmentScheme>::Commitment,
+    pub opening_proof: <PCS as joltworks::poly::commitment::commitment_scheme::CommitmentScheme>::Proof,
+    pub opening_point: Vec<<F as JoltField>::Challenge>,
+    pub joint_claim: F,
+    pub transcript: T,
+}
+
 pub fn verify_zk(
     bundle: &ZkProofBundle,
     pp: &AtlasVerifierPreprocessing<F, PCS>,
     io: &ModelExecutionIO,
     pedersen_gens: &PedersenGenerators<C>,
+) -> Result<(), ProofVerifyError> {
+    verify_zk_with_pcs_capture(bundle, pp, io, pedersen_gens, None)
+}
+
+/// Same as [`verify_zk`] but exposes an optional slot for capturing the
+/// inputs to the final HyperKZG verification. When `capture` is `Some`,
+/// the slot is filled in right before `PCS::verify` runs; the verifier
+/// then continues normally. Used by external auto-builders to extract
+/// the verifier's MSM trace without having to mirror the entire
+/// transcript walk.
+pub fn verify_zk_with_pcs_capture(
+    bundle: &ZkProofBundle,
+    pp: &AtlasVerifierPreprocessing<F, PCS>,
+    io: &ModelExecutionIO,
+    pedersen_gens: &PedersenGenerators<C>,
+    mut capture: Option<&mut Option<PcsVerifyCapture>>,
 ) -> Result<(), ProofVerifyError> {
     use joltworks::poly::opening_proof::VerifierOpeningAccumulator;
 
@@ -2491,10 +2705,86 @@ pub fn verify_zk(
         }
     }
 
+    // Batched-opening reduction (Steps 6-8 of the wiki plan): mirror the
+    // prover-side flow. Order matches the prover:
+    //   1. derive gamma_powers from transcript (the cleartext per-poly claim
+    //      append is suppressed on both sides in ZK mode),
+    //   2. absorb y_com into the transcript,
+    //   3. build the extra constraint linking joint_claim to per-poly y_P_i's,
+    //   4. run BlindFold (R1CS proves sumcheck + extra constraint),
+    //   5. run PCS::verify on the joint commitment so `bundle.commitments`
+    //      bind to `joint_claim` at the reduced point (Step 8).
+    let extra_constraints_for_r1cs: Vec<_>;
+    let eval_commitment_gens_v;
+    let gamma_powers_v: Vec<F>;
+    if let Some(y_com) = bundle.blindfold_verifier_input.eval_commitments.first() {
+        // Replay the prover-side absorbs from `prove_batch_opening_sumcheck_zk`
+        // and `finalize_batch_opening_sumcheck` into the main transcript:
+        // (a) each round commitment from the batched-opening sumcheck (so
+        //     batching coefficients and round challenges line up with the
+        //     prover's BlindFold stage), then (b) the gamma_powers derivation,
+        //     then (c) y_com. Order matters; deviating here desyncs the
+        //     transcript at the PCS::verify point downstream.
+        let batch_zk = bundle.batch_opening_zk_sumcheck.as_ref().ok_or_else(|| {
+            ProofVerifyError::InvalidOpeningProof(
+                "Missing batch_opening_zk_sumcheck in bundle".to_string(),
+            )
+        })?;
+        let opening_ids: Vec<joltworks::poly::opening_proof::OpeningId> = accumulator
+            .sumchecks_keys()
+            .map(|poly| {
+                joltworks::poly::opening_proof::OpeningId::new(
+                    poly,
+                    joltworks::poly::opening_proof::SumcheckId::BlindFoldBatchOpening,
+                )
+            })
+            .collect();
+        // (a) batching coefficients (consumes `opening_ids.len()` scalars).
+        let _batching_coeffs: Vec<F> = transcript.challenge_vector(opening_ids.len());
+        // round commitments + per-round challenge derivation
+        for round_com in &batch_zk.round_commitments {
+            transcript.append_serializable(round_com);
+            let _r_j: <F as joltworks::field::JoltField>::Challenge =
+                transcript.challenge_scalar_optimized::<F>();
+        }
+        // (output_claims_commitments are absorbed at the tail of BatchedSumcheck::prove_zk)
+        for com in &batch_zk.output_claims_commitments {
+            transcript.append_serializable(com);
+        }
+        // (b) gamma derivation -- cleartext claim append is suppressed on both
+        //     sides in ZK mode, so we just sample.
+        gamma_powers_v = transcript.challenge_scalar_powers(opening_ids.len());
+        // (c) y_com.
+        transcript.append_serializable(y_com);
+        use joltworks::subprotocols::blindfold::output_constraint::{
+            OutputClaimConstraint, ValueSource,
+        };
+        let terms: Vec<(ValueSource, ValueSource)> = opening_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (ValueSource::Challenge(i), ValueSource::Opening(*id)))
+            .collect();
+        extra_constraints_for_r1cs = vec![OutputClaimConstraint::linear(terms)];
+        eval_commitment_gens_v = Some((
+            pedersen_gens.message_generators[0],
+            pedersen_gens.blinding_generator,
+        ));
+    } else {
+        gamma_powers_v = Vec::new();
+        extra_constraints_for_r1cs = Vec::new();
+        eval_commitment_gens_v = None;
+    }
+
     // 4. Verify BlindFold proof
-    let builder = VerifierR1CSBuilder::<F>::new(&bundle.stage_configs, &bundle.baked);
+    let builder = VerifierR1CSBuilder::<F>::new_with_extra(
+        &bundle.stage_configs,
+        &extra_constraints_for_r1cs,
+        &bundle.baked,
+        Vec::new(),
+        std::collections::BTreeMap::new(),
+    );
     let r1cs = builder.build();
-    let bf_verifier = BlindFoldVerifier::new(pedersen_gens, &r1cs, None);
+    let bf_verifier = BlindFoldVerifier::new(pedersen_gens, &r1cs, eval_commitment_gens_v);
 
     let mut bf_transcript = T::new(b"BlindFold_onnx");
     bf_verifier
@@ -2505,7 +2795,43 @@ pub fn verify_zk(
         )
         .map_err(|e| {
             ProofVerifyError::InvalidOpeningProof(format!("BlindFold verification failed: {e:?}"))
-        })
+        })?;
+
+    // Step 8: PCS-binding. Verify that `bundle.commitments` actually evaluate
+    // to `joint_claim` at the batched-opening reduction point. The verifier
+    // homomorphically combines the polynomial commitments under `gamma_powers`
+    // (matching the prover's RLC), then verifies the joint opening proof.
+    //
+    // This is what cryptographically ties the BlindFold R1CS witness (which
+    // proves `joint_claim = sum gamma_i * y_P_i` and consistency with the
+    // per-node sumchecks via the `y_P_i` openings) back to the actual
+    // polynomial commitments. `joint_claim` is revealed in cleartext; a
+    // future ZK extension to HyperKZG could hide it as well.
+    if let (Some(opening_proof), Some(joint_claim), Some(opening_point)) = (
+        bundle.joint_opening_proof.as_ref(),
+        bundle.joint_claim.as_ref(),
+        bundle.joint_opening_point.as_ref(),
+    ) {
+        let joint_commitment = PCS::combine_commitments(&bundle.commitments, &gamma_powers_v);
+        if let Some(slot) = capture.as_deref_mut() {
+            *slot = Some(PcsVerifyCapture {
+                joint_commitment: joint_commitment.clone(),
+                opening_proof: opening_proof.clone(),
+                opening_point: opening_point.clone(),
+                joint_claim: *joint_claim,
+                transcript: transcript.clone(),
+            });
+        }
+        PCS::verify(
+            opening_proof,
+            &pp.generators,
+            &mut transcript,
+            opening_point,
+            joint_claim,
+            &joint_commitment,
+        )?;
+    }
+    Ok(())
 }
 
 /// Create the ZK sumcheck prover instance for a node.

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1983,7 +1983,11 @@ pub fn prove_zk(
                     &mut eval_reduction_proofs,
                     &mut eval_reduction_h_commitments,
                 );
-                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                if prover
+                    .accumulator
+                    .reduced_evaluations
+                    .contains_key(&node.idx)
+                {
                     use crate::onnx_proof::ops::broadcast::{BroadcastParams, BroadcastProver};
                     let params = BroadcastParams::new(node.clone(), &prover.accumulator);
                     let bp = BroadcastProver::initialize(&prover.trace, params);
@@ -1998,7 +2002,11 @@ pub fn prove_zk(
                     &mut eval_reduction_proofs,
                     &mut eval_reduction_h_commitments,
                 );
-                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                if prover
+                    .accumulator
+                    .reduced_evaluations
+                    .contains_key(&node.idx)
+                {
                     use crate::onnx_proof::ops::moveaxis::{MoveAxisParams, MoveAxisProver};
                     let params = MoveAxisParams::new(node.clone(), &prover.accumulator);
                     let mp = MoveAxisProver::initialize(params);
@@ -2013,7 +2021,11 @@ pub fn prove_zk(
                     &mut eval_reduction_proofs,
                     &mut eval_reduction_h_commitments,
                 );
-                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                if prover
+                    .accumulator
+                    .reduced_evaluations
+                    .contains_key(&node.idx)
+                {
                     use crate::onnx_proof::ops::OperatorProofTrait;
                     let _ = OperatorProofTrait::<F, T>::prove(op, node, &mut prover);
                 }
@@ -2026,7 +2038,11 @@ pub fn prove_zk(
                     &mut eval_reduction_proofs,
                     &mut eval_reduction_h_commitments,
                 );
-                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                if prover
+                    .accumulator
+                    .reduced_evaluations
+                    .contains_key(&node.idx)
+                {
                     use crate::onnx_proof::ops::OperatorProofTrait;
                     let _ = OperatorProofTrait::<F, T>::prove(op, node, &mut prover);
                 }
@@ -2039,7 +2055,11 @@ pub fn prove_zk(
                     &mut eval_reduction_proofs,
                     &mut eval_reduction_h_commitments,
                 );
-                if prover.accumulator.reduced_evaluations.contains_key(&node.idx) {
+                if prover
+                    .accumulator
+                    .reduced_evaluations
+                    .contains_key(&node.idx)
+                {
                     use crate::onnx_proof::ops::OperatorProofTrait;
                     let _ = OperatorProofTrait::<F, T>::prove(op, node, &mut prover);
                 }
@@ -2105,10 +2125,12 @@ pub fn prove_zk(
     // commitment to `sum gamma_i * y_P_i` (where y_P_i = P_i(r_sumcheck)).
     // Empty when there are no committed polynomials (poly_map is empty).
     let mut joint_eval_commitment: Option<joltworks::curve::Bn254G1> = None;
-    let mut batch_opening_extra_constraint:
-        Option<joltworks::subprotocols::blindfold::output_constraint::OutputClaimConstraint> = None;
-    let mut batch_opening_extra_witness:
-        Option<joltworks::subprotocols::blindfold::witness::ExtraConstraintWitness<F>> = None;
+    let mut batch_opening_extra_constraint: Option<
+        joltworks::subprotocols::blindfold::output_constraint::OutputClaimConstraint,
+    > = None;
+    let mut batch_opening_extra_witness: Option<
+        joltworks::subprotocols::blindfold::witness::ExtraConstraintWitness<F>,
+    > = None;
     // Step 8 (PCS-binding): PCS opening proof for the joint polynomial at
     // r_sumcheck. Binds `bundle.commitments` to the joint evaluation.
     let mut joint_opening_proof: Option<<PCS as CommitmentScheme>::Proof> = None;
@@ -2165,10 +2187,7 @@ pub fn prove_zk(
             .zip(num_rounds_per_poly.iter())
             .map(|(g, num_rounds)| {
                 let r_slice = &state.r_sumcheck[..max_num_rounds - num_rounds];
-                let lagrange_eval: F = r_slice
-                    .iter()
-                    .map(|r| F::one() - *r)
-                    .product();
+                let lagrange_eval: F = r_slice.iter().map(|r| F::one() - *r).product();
                 g.mul_01_optimized(lagrange_eval)
             })
             .collect();
@@ -2202,8 +2221,7 @@ pub fn prove_zk(
             .enumerate()
             .map(|(i, id)| (ValueSource::Challenge(i), ValueSource::Opening(*id)))
             .collect();
-        batch_opening_extra_constraint =
-            Some(OutputClaimConstraint::linear(terms));
+        batch_opening_extra_constraint = Some(OutputClaimConstraint::linear(terms));
         batch_opening_extra_witness = Some(ExtraConstraintWitness {
             output_value: joint_claim,
             blinding: y_blinding,
@@ -2229,10 +2247,8 @@ pub fn prove_zk(
         // with `gamma_powers` to reconstruct the same joint commitment.
         let r_sumcheck_acc: Vec<<F as joltworks::field::JoltField>::Challenge> =
             state.r_sumcheck.clone();
-        let joint_poly = joltworks::poly::rlc_polynomial::build_materialized_rlc(
-            &state.gamma_powers,
-            &poly_map,
-        );
+        let joint_poly =
+            joltworks::poly::rlc_polynomial::build_materialized_rlc(&state.gamma_powers, &poly_map);
         let opening_proof = PCS::prove(
             &pp.generators,
             &joint_poly,
@@ -2348,14 +2364,10 @@ pub fn prove_zk(
     //   joint_claim = sum_i gamma_i * y_P_i   AND   y_com = g * joint_claim + h * y_blinding.
     // The latter is enforced via BlindFold's `eval_commitment_gens` check; the
     // y_com is placed in `RelaxedR1CSInstance::eval_commitments` below.
-    let extra_constraints_for_r1cs: Vec<_> = batch_opening_extra_constraint
-        .clone()
-        .into_iter()
-        .collect();
-    let extra_constraint_witnesses: Vec<_> = batch_opening_extra_witness
-        .clone()
-        .into_iter()
-        .collect();
+    let extra_constraints_for_r1cs: Vec<_> =
+        batch_opening_extra_constraint.clone().into_iter().collect();
+    let extra_constraint_witnesses: Vec<_> =
+        batch_opening_extra_witness.clone().into_iter().collect();
     let blindfold_witness = BlindFoldWitness::with_extra_constraints(
         initial_claims,
         all_stages,
@@ -2505,8 +2517,10 @@ pub fn prove_zk(
 /// transcript state that the verifier reaches.
 #[derive(Clone)]
 pub struct PcsVerifyCapture {
-    pub joint_commitment: <PCS as joltworks::poly::commitment::commitment_scheme::CommitmentScheme>::Commitment,
-    pub opening_proof: <PCS as joltworks::poly::commitment::commitment_scheme::CommitmentScheme>::Proof,
+    pub joint_commitment:
+        <PCS as joltworks::poly::commitment::commitment_scheme::CommitmentScheme>::Commitment,
+    pub opening_proof:
+        <PCS as joltworks::poly::commitment::commitment_scheme::CommitmentScheme>::Proof,
     pub opening_point: Vec<<F as JoltField>::Challenge>,
     pub joint_claim: F,
     pub transcript: T,
@@ -2677,10 +2691,10 @@ pub fn verify_zk_with_pcs_capture(
                         })?;
                     let r_field: Vec<F> = reduced.r.clone();
                     let expected_claim = match &node.operator {
-                        Operator::Constant(c) => MultilinearPolynomial::from(
-                            c.0.clone().padded_next_power_of_two(),
-                        )
-                        .evaluate(&r_field),
+                        Operator::Constant(c) => {
+                            MultilinearPolynomial::from(c.0.clone().padded_next_power_of_two())
+                                .evaluate(&r_field)
+                        }
                         Operator::Input(_) => {
                             let input_pos = io
                                 .input_indices

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -107,6 +107,15 @@ pub struct ZkProofBundle {
     /// bundle copy is purely for main-transcript replay.)
     pub batch_opening_zk_sumcheck:
         Option<joltworks::subprotocols::sumcheck::ZkSumcheckProof<F, C, T>>,
+    /// Cleartext reduced-eval claim for each public-data node (Constant/Input).
+    /// Mirror of the per-op `Constant::verify` / `Input::verify` check in non-zk:
+    /// the verifier locally evaluates the public tensor's MLE at `r_reduced`
+    /// and compares against this value. Catches honest-prover errors; full
+    /// soundness against an active malicious prover additionally requires an
+    /// R1CS constraint binding the BlindFold witness opening value to this
+    /// cleartext (Jolt's `ValueSource::Constant`-style binding) — tracked as
+    /// future work in `wiki/jolt-atlas/.../zk-prove-overhead.md`.
+    pub public_node_reduced_claims: BTreeMap<usize, F>,
 }
 
 /// Run a single-instance ZK sumcheck and collect stage data.
@@ -2440,6 +2449,24 @@ pub fn prove_zk(
         .iter()
         .map(|sd| sd.batching_coefficients.len())
         .collect();
+
+    // Collect cleartext reduced-eval claims for Constants and Inputs. The
+    // verifier mirrors `Constant::verify` / `Input::verify` (non-zk) by locally
+    // evaluating the public tensor's MLE at `r_reduced` and checking equality
+    // against this value. See `verify_zk` for the matching check.
+    let mut public_node_reduced_claims: BTreeMap<usize, F> = BTreeMap::new();
+    for (_, node) in pp.model().nodes().iter() {
+        if matches!(
+            node.operator,
+            atlas_onnx_tracer::ops::Operator::Constant(_)
+                | atlas_onnx_tracer::ops::Operator::Input(_)
+        ) {
+            if let Some(reduced) = prover.accumulator.reduced_evaluations.get(&node.idx) {
+                public_node_reduced_claims.insert(node.idx, reduced.claim);
+            }
+        }
+    }
+
     let bundle = ZkProofBundle {
         blindfold_proof,
         blindfold_verifier_input,
@@ -2457,6 +2484,7 @@ pub fn prove_zk(
         joint_claim: joint_claim_value,
         joint_opening_point,
         batch_opening_zk_sumcheck,
+        public_node_reduced_claims,
     };
 
     (bundle, io)
@@ -2624,6 +2652,75 @@ pub fn verify_zk_with_pcs_capture(
             // No-sumcheck ops that don't register openings on inputs.
             Operator::Input(_) | Operator::Constant(_) => {
                 verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
+                // Mirror non-zk `Constant::verify` / `Input::verify` (ops/constant.rs:28-43,
+                // ops/input.rs:27-49): locally evaluate the public MLE at the
+                // reduced opening point and compare against the prover's
+                // cleartext reduced claim from the bundle. Catches honest-prover
+                // errors. Active-malice soundness needs an R1CS constraint
+                // binding the BlindFold witness to this cleartext (future work;
+                // see wiki/jolt-atlas/.../zk-prove-overhead.md).
+                if let Some(reduced) = accumulator.reduced_evaluations.get(&node.idx).cloned() {
+                    let prover_claim = bundle
+                        .public_node_reduced_claims
+                        .get(&node.idx)
+                        .copied()
+                        .ok_or_else(|| {
+                            ProofVerifyError::InvalidOpeningProof(format!(
+                                "Missing public_node_reduced_claims for node {} ({})",
+                                node.idx,
+                                match node.operator {
+                                    Operator::Input(_) => "Input",
+                                    Operator::Constant(_) => "Constant",
+                                    _ => unreachable!(),
+                                }
+                            ))
+                        })?;
+                    let r_field: Vec<F> = reduced.r.clone();
+                    let expected_claim = match &node.operator {
+                        Operator::Constant(c) => MultilinearPolynomial::from(
+                            c.0.clone().padded_next_power_of_two(),
+                        )
+                        .evaluate(&r_field),
+                        Operator::Input(_) => {
+                            let input_pos = io
+                                .input_indices
+                                .iter()
+                                .position(|&idx| idx == node.idx)
+                                .ok_or_else(|| {
+                                    ProofVerifyError::InvalidOpeningProof(format!(
+                                        "Input node {} not in io.input_indices",
+                                        node.idx
+                                    ))
+                                })?;
+                            MultilinearPolynomial::from(
+                                io.inputs[input_pos].padded_next_power_of_two(),
+                            )
+                            .evaluate(&r_field)
+                        }
+                        _ => unreachable!(),
+                    };
+                    if expected_claim != prover_claim {
+                        return Err(ProofVerifyError::InvalidOpeningProof(format!(
+                            "Public node {} ({}) reduced-eval mismatch: prover claim {} != public MLE eval {}",
+                            node.idx,
+                            match node.operator {
+                                Operator::Input(_) => "Input",
+                                Operator::Constant(_) => "Constant",
+                                _ => unreachable!(),
+                            },
+                            prover_claim,
+                            expected_claim
+                        )));
+                    }
+                    // Insert the (now-verified) cleartext claim into the
+                    // verifier's accumulator so downstream code that reads
+                    // `reduced_evaluations` sees the correct value rather than
+                    // the F::zero() placeholder. Has no effect on R1CS verify
+                    // (which only uses bundle.baked) — see future-work note.
+                    if let Some(slot) = accumulator.reduced_evaluations.get_mut(&node.idx) {
+                        slot.claim = expected_claim;
+                    }
+                }
             }
             // No-sumcheck ops that DO register openings on their input(s).
             // Mirror the prover-side input caching (see the matching arms in

--- a/joltworks/src/poly/commitment/hyperkzg/mod.rs
+++ b/joltworks/src/poly/commitment/hyperkzg/mod.rs
@@ -105,6 +105,50 @@ pub struct HyperKZGProverKey<P: Pairing> {
     pub kzg_pk: KZGProverKey<P>,
 }
 
+impl HyperKZGProverKey<ark_bn254::Bn254> {
+    /// Derive Pedersen generators from the HyperKZG SRS for BlindFold.
+    ///
+    /// Uses SRS G1 points as message generators. If the SRS has fewer than
+    /// `count` points, additional generators are derived via hash-to-curve.
+    /// The blinding generator is always hash-derived (independent of SRS).
+    #[cfg(feature = "zk")]
+    pub fn pedersen_generators(
+        &self,
+        count: usize,
+    ) -> crate::poly::commitment::pedersen::PedersenGenerators<crate::curve::Bn254Curve> {
+        use ark_bn254::G1Projective;
+        use ark_std::UniformRand;
+        use rand_chacha::ChaCha20Rng;
+        use rand_core::SeedableRng;
+        use sha3::Digest;
+
+        let srs = &self.kzg_pk.srs;
+        let available = srs.g1_powers.len();
+
+        let mut message_generators: Vec<crate::curve::Bn254G1> = srs.g1_powers
+            [..std::cmp::min(count, available)]
+            .iter()
+            .map(|g| crate::curve::Bn254G1(g.into_group()))
+            .collect();
+
+        for i in available..count {
+            let domain = format!("jolt-atlas-blindfold-extra-generator-{i}");
+            let h = sha3::Sha3_256::digest(domain.as_bytes());
+            let mut gen_rng = ChaCha20Rng::from_seed(h.into());
+            message_generators.push(crate::curve::Bn254G1(G1Projective::rand(&mut gen_rng)));
+        }
+
+        let hash = sha3::Sha3_256::digest(b"jolt-atlas-blindfold-blinding-generator");
+        let mut rng = ChaCha20Rng::from_seed(hash.into());
+        let blinding_generator = crate::curve::Bn254G1(G1Projective::rand(&mut rng));
+
+        crate::poly::commitment::pedersen::PedersenGenerators::new(
+            message_generators,
+            blinding_generator,
+        )
+    }
+}
+
 #[derive(Copy, Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct HyperKZGVerifierKey<P: Pairing> {
     pub kzg_vk: KZGVerifierKey<P>,

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -290,6 +290,12 @@ where
             claim,
         );
         self.sumchecks.insert(polynomial, sumcheck);
+
+        #[cfg(feature = "zk")]
+        {
+            self.pending_claims.push(claim);
+            self.pending_claim_ids.push(opening_id);
+        }
     }
 
     #[tracing::instrument(skip_all, name = "ProverOpeningAccumulator::append_sparse")]
@@ -326,7 +332,7 @@ where
         }
 
         for (label, claim) in polynomials.iter().copied().zip(claims.into_iter()) {
-            let sumcheck = OpeningProofReductionSumcheckProver::new_one_hot(
+            let sumcheck_instance = OpeningProofReductionSumcheckProver::new_one_hot(
                 label,
                 sumcheck,
                 shared_eq_address.clone(),
@@ -334,7 +340,13 @@ where
                 r_concat.clone(),
                 claim,
             );
-            self.sumchecks.insert(label, sumcheck);
+            self.sumchecks.insert(label, sumcheck_instance);
+            #[cfg(feature = "zk")]
+            {
+                let key = OpeningId::new(label, sumcheck);
+                self.pending_claims.push(claim);
+                self.pending_claim_ids.push(key);
+            }
         }
     }
 
@@ -571,6 +583,7 @@ impl<F: JoltField> OpeningAccumulator<F> for VerifierOpeningAccumulator<F> {
         let key = opening_id;
         match self.openings.get(&key) {
             Some((point, claim)) => (point.clone(), *claim),
+            None if self.zk_mode => (OpeningPoint::default(), F::zero()),
             None => {
                 panic!("No opening found for {opening_id:?}")
             }
@@ -669,17 +682,31 @@ where
         T: Transcript,
         U: Copy + Send + Sync + Into<F>,
     {
-        let claim = self.openings.get(&opening_id).unwrap().1;
-        transcript.append_scalar(&claim);
-
-        // Update the opening point in self.openings (it was initialized with default empty point)
-        self.openings.insert(
-            opening_id,
-            (
-                OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
-                claim,
-            ),
-        );
+        let claim = if let Some((_, claim)) = self.openings.get(&opening_id) {
+            // Standard mode: claim was pre-loaded.
+            let claim = *claim;
+            transcript.append_scalar(&claim);
+            self.openings.insert(
+                opening_id,
+                (
+                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
+                    claim,
+                ),
+            );
+            claim
+        } else if self.zk_mode {
+            // ZK mode: insert with placeholder claim. BlindFold handles correctness.
+            self.openings.insert(
+                opening_id,
+                (
+                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
+                    F::zero(),
+                ),
+            );
+            F::zero()
+        } else {
+            panic!("Tried to populate dense opening for non-existent key: {opening_id:?}");
+        };
 
         let polynomial = opening_id
             .committed_poly()
@@ -707,10 +734,17 @@ where
     {
         for label in polynomials.into_iter() {
             let key = OpeningId::new(label, sumcheck);
-            let claim = self.openings.get(&key).unwrap().1;
-            transcript.append_scalar(&claim);
+            let claim = if let Some((_, c)) = self.openings.get(&key) {
+                let c = *c;
+                transcript.append_scalar(&c);
+                c
+            } else if self.zk_mode {
+                // ZK mode: insert placeholder. BlindFold handles correctness.
+                F::zero()
+            } else {
+                panic!("Tried to populate sparse opening for non-existent key: {key:?}");
+            };
 
-            // Update the opening point in self.openings (it was initialized with default empty point)
             self.openings.insert(
                 key,
                 (
@@ -748,7 +782,7 @@ where
         }
 
         if let Some((_, claim)) = self.openings.get(&opening_id) {
-            // Standard mode: claim was pre-loaded from the proof. Append to transcript.
+            // Standard mode: claim was pre-loaded. Append to transcript.
             transcript.append_scalar(claim);
             let claim = *claim;
             self.openings

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -567,16 +567,12 @@ where
         // Capture stage shape before borrowing the instances mutably.
         let max_rounds = sumchecks
             .values()
-            .map(|opening| {
-                <Opening<F> as SumcheckInstanceParams<F>>::num_rounds(&opening.opening)
-            })
+            .map(|opening| <Opening<F> as SumcheckInstanceParams<F>>::num_rounds(&opening.opening))
             .max()
             .unwrap_or(1);
         let max_degree = sumchecks
             .values()
-            .map(|opening| {
-                <Opening<F> as SumcheckInstanceParams<F>>::degree(&opening.opening)
-            })
+            .map(|opening| <Opening<F> as SumcheckInstanceParams<F>>::degree(&opening.opening))
             .max()
             .unwrap_or(1);
 
@@ -596,8 +592,7 @@ where
 
         self.sumchecks = sumchecks;
         stage_configs.push(crate::subprotocols::blindfold::StageConfig::new_chain(
-            max_rounds,
-            max_degree,
+            max_rounds, max_degree,
         ));
         (zk_proof, r_sumcheck)
     }

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -74,6 +74,15 @@ where
     pending_claims: Vec<F>,
     #[cfg(feature = "zk")]
     pending_claim_ids: Vec<OpeningId>,
+    /// In ZK mode the prover suppresses cleartext transcript appends in
+    /// `append_virtual` / `append_dense`; transcript synchronisation comes
+    /// from the Pedersen commitments emitted by `BatchedSumcheck::prove_zk`
+    /// (or via auxiliary_claims for public scalars that are intentionally
+    /// re-appended with `zk_mode` toggled off on both sides — see the
+    /// Softmax aux-scalar path). `pending_claims` is still collected so the
+    /// downstream commit_chunked step can hide the claim values.
+    #[cfg(feature = "zk")]
+    pub zk_mode: bool,
 }
 
 /// Accumulates openings encountered by the verifier over the course of Jolt,
@@ -196,6 +205,8 @@ where
             pending_claims: Vec::new(),
             #[cfg(feature = "zk")]
             pending_claim_ids: Vec::new(),
+            #[cfg(feature = "zk")]
+            zk_mode: false,
         }
     }
 
@@ -262,7 +273,13 @@ where
         U: Copy + Send + Sync + Into<F>,
         F: Mul<U, Output = F>,
     {
-        transcript.append_scalar(&claim);
+        #[cfg(feature = "zk")]
+        let suppress = self.zk_mode;
+        #[cfg(not(feature = "zk"))]
+        let suppress = false;
+        if !suppress {
+            transcript.append_scalar(&claim);
+        }
 
         let shared_eq = self
             .eq_cycle_map
@@ -312,9 +329,15 @@ where
         U: Copy + Send + Sync + Into<F>,
         F: Mul<U, Output = F>,
     {
-        claims.iter().for_each(|claim| {
-            transcript.append_scalar(claim);
-        });
+        #[cfg(feature = "zk")]
+        let suppress = self.zk_mode;
+        #[cfg(not(feature = "zk"))]
+        let suppress = false;
+        if !suppress {
+            claims.iter().for_each(|claim| {
+                transcript.append_scalar(claim);
+            });
+        }
         let r_concat = [r_address.as_slice(), r_cycle.as_slice()].concat();
 
         let shared_eq_address = Arc::new(RwLock::new(EqAddressState::new(&r_address)));
@@ -371,7 +394,13 @@ where
             );
         }
 
-        transcript.append_scalar(&claim);
+        #[cfg(feature = "zk")]
+        let suppress = self.zk_mode;
+        #[cfg(not(feature = "zk"))]
+        let suppress = false;
+        if !suppress {
+            transcript.append_scalar(&claim);
+        }
 
         self.openings.insert(opening_id, (opening_point, claim));
         #[cfg(any(test, feature = "test-feature"))]
@@ -682,7 +711,19 @@ where
         T: Transcript,
         U: Copy + Send + Sync + Into<F>,
     {
-        let claim = if let Some((_, claim)) = self.openings.get(&opening_id) {
+        let claim = if self.zk_mode {
+            // ZK mode: stay transcript-quiet to mirror the prover, even if the
+            // key already exists from a prior append (see the matching comment
+            // in `append_virtual` above).
+            self.openings.insert(
+                opening_id,
+                (
+                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
+                    F::zero(),
+                ),
+            );
+            F::zero()
+        } else if let Some((_, claim)) = self.openings.get(&opening_id) {
             // Standard mode: claim was pre-loaded.
             let claim = *claim;
             transcript.append_scalar(&claim);
@@ -694,16 +735,6 @@ where
                 ),
             );
             claim
-        } else if self.zk_mode {
-            // ZK mode: insert with placeholder claim. BlindFold handles correctness.
-            self.openings.insert(
-                opening_id,
-                (
-                    OpeningPoint::<BIG_ENDIAN, F>::new(opening_point.clone()),
-                    F::zero(),
-                ),
-            );
-            F::zero()
         } else {
             panic!("Tried to populate dense opening for non-existent key: {opening_id:?}");
         };
@@ -734,13 +765,15 @@ where
     {
         for label in polynomials.into_iter() {
             let key = OpeningId::new(label, sumcheck);
-            let claim = if let Some((_, c)) = self.openings.get(&key) {
+            let claim = if self.zk_mode {
+                // ZK mode: stay transcript-quiet to mirror the prover, even
+                // if the key already exists from a prior append (see the
+                // matching comment in `append_virtual` above).
+                F::zero()
+            } else if let Some((_, c)) = self.openings.get(&key) {
                 let c = *c;
                 transcript.append_scalar(&c);
                 c
-            } else if self.zk_mode {
-                // ZK mode: insert placeholder. BlindFold handles correctness.
-                F::zero()
             } else {
                 panic!("Tried to populate sparse opening for non-existent key: {key:?}");
             };
@@ -781,18 +814,30 @@ where
             );
         }
 
-        if let Some((_, claim)) = self.openings.get(&opening_id) {
+        if self.zk_mode {
+            // ZK mode: stay transcript-quiet to mirror the prover (whose
+            // zk_mode also suppresses cleartext appends). We always (re)write
+            // a placeholder claim, even when the key already exists from a
+            // prior `append_virtual` call. This matters when the same
+            // `opening_id` is registered twice in a sumcheck batch (e.g.
+            // `SoftmaxExpQ` from both RecipMult and ExpSum cache_openings):
+            // without this, the second call would fall into the standard
+            // branch and emit a stray `transcript.append_scalar(F::zero())`
+            // that the prover does not produce. The actual claim is verified
+            // by BlindFold, not individually.
+            //
+            // Callers that publish a real cleartext claim (the Softmax
+            // auxiliary-scalar path) pre-populate `openings` AND toggle
+            // `zk_mode = false`, so they fall through to the standard branch
+            // below.
+            self.openings
+                .insert(opening_id, (opening_point.clone(), F::zero()));
+        } else if let Some((_, claim)) = self.openings.get(&opening_id) {
             // Standard mode: claim was pre-loaded. Append to transcript.
             transcript.append_scalar(claim);
             let claim = *claim;
             self.openings
                 .insert(opening_id, (opening_point.clone(), claim));
-        } else if self.zk_mode {
-            // ZK mode: key doesn't exist yet. Insert with placeholder claim (F::zero()).
-            // The actual claim is verified by BlindFold, not individually.
-            // Don't append to transcript; commitments are absorbed by verify_zk instead.
-            self.openings
-                .insert(opening_id, (opening_point.clone(), F::zero()));
         } else {
             panic!("Tried to populate opening point for non-existent key: {opening_id:?}");
         }

--- a/joltworks/src/poly/opening_proof.rs
+++ b/joltworks/src/poly/opening_proof.rs
@@ -535,10 +535,84 @@ where
         (sumcheck_proof, r_sumcheck)
     }
 
+    /// ZK variant of `prove_batch_opening_sumcheck`. Runs `BatchedSumcheck::prove_zk`
+    /// so that round polynomials are Pedersen-committed rather than sent in the clear,
+    /// and the resulting stage data is pushed into `blindfold_accumulator` for later
+    /// inclusion in the BlindFold R1CS witness. The reduced opening claim is no longer
+    /// leaked through the transcript; binding to `y_com` happens via BlindFold.
+    #[cfg(feature = "zk")]
+    #[tracing::instrument(
+        skip_all,
+        name = "ProverOpeningAccumulator::prove_batch_opening_sumcheck_zk"
+    )]
+    pub fn prove_batch_opening_sumcheck_zk<T, C, R>(
+        &mut self,
+        blindfold_accumulator: &mut crate::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+        stage_configs: &mut Vec<crate::subprotocols::blindfold::StageConfig>,
+        pedersen_gens: &crate::poly::commitment::pedersen::PedersenGenerators<C>,
+        rng: &mut R,
+        transcript: &mut T,
+    ) -> (
+        crate::subprotocols::sumcheck::ZkSumcheckProof<F, C, T>,
+        Vec<F::Challenge>,
+    )
+    where
+        T: Transcript,
+        C: crate::curve::JoltCurve<F = F>,
+        R: rand_core::CryptoRngCore,
+    {
+        use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
+
+        let mut sumchecks = std::mem::take(&mut self.sumchecks);
+        // Capture stage shape before borrowing the instances mutably.
+        let max_rounds = sumchecks
+            .values()
+            .map(|opening| {
+                <Opening<F> as SumcheckInstanceParams<F>>::num_rounds(&opening.opening)
+            })
+            .max()
+            .unwrap_or(1);
+        let max_degree = sumchecks
+            .values()
+            .map(|opening| {
+                <Opening<F> as SumcheckInstanceParams<F>>::degree(&opening.opening)
+            })
+            .max()
+            .unwrap_or(1);
+
+        let instances = sumchecks
+            .iter_mut()
+            .map(|(_, opening)| opening as &mut _)
+            .collect();
+
+        let (zk_proof, r_sumcheck, _final_claim) = BatchedSumcheck::prove_zk::<F, C, T, _>(
+            instances,
+            self,
+            blindfold_accumulator,
+            transcript,
+            pedersen_gens,
+            rng,
+        );
+
+        self.sumchecks = sumchecks;
+        stage_configs.push(crate::subprotocols::blindfold::StageConfig::new_chain(
+            max_rounds,
+            max_degree,
+        ));
+        (zk_proof, r_sumcheck)
+    }
+
     /// Finalizes the batch opening reduction sumcheck.
     /// Uses cached claims from `cache_openings`, appends them to transcript, derives gamma powers,
     /// and cleans up sumcheck instances.
     /// Returns the state needed for Stage 8.
+    ///
+    /// In ZK mode the cleartext claim append is suppressed when the prover
+    /// accumulator's `zk_mode` flag is on; the gamma_powers are still derived
+    /// from the transcript (which by then carries the batched-opening stage's
+    /// round commitments via `BatchedSumcheck::prove_zk`). The verifier
+    /// reproduces the same gamma derivation, since both sides skip the
+    /// cleartext append symmetrically.
     #[tracing::instrument(
         skip_all,
         name = "ProverOpeningAccumulator::finalize_batch_opening_sumcheck"
@@ -554,8 +628,13 @@ where
                 .into_iter()
                 .unzip();
 
-        // Append claims and derive gamma powers
-        transcript.append_scalars(&sumcheck_claims);
+        #[cfg(feature = "zk")]
+        let suppress = self.zk_mode;
+        #[cfg(not(feature = "zk"))]
+        let suppress = false;
+        if !suppress {
+            transcript.append_scalars(&sumcheck_claims);
+        }
         let gamma_powers: Vec<F> = transcript.challenge_scalar_powers(sumcheck_claims.len());
 
         // Drop sumchecks in background - they're no longer needed
@@ -850,6 +929,14 @@ where
 {
     pub fn num_sumchecks(&self) -> usize {
         self.sumchecks.len()
+    }
+
+    /// Iterates the `CommittedPoly` keys for which a sumcheck instance has been
+    /// registered (one per committed polynomial that some operator opened).
+    /// `BTreeMap` iteration is sorted, so the order matches the prover's
+    /// `state.polynomials` produced by `finalize_batch_opening_sumcheck`.
+    pub fn sumchecks_keys(&self) -> impl Iterator<Item = CommittedPoly> + '_ {
+        self.sumchecks.keys().copied()
     }
 
     // ========== Batch Opening Reduction Sumcheck ==========

--- a/joltworks/src/subprotocols/booleanity.rs
+++ b/joltworks/src/subprotocols/booleanity.rs
@@ -28,6 +28,11 @@ use crate::{
     utils::{expanding_table::ExpandingTable, thread::drop_in_background_thread},
 };
 
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 /// Degree bound of the sumcheck round polynomials in [`BooleanitySumcheckVerifier`].
 const DEGREE_BOUND: usize = 3;
 
@@ -68,6 +73,63 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BooleanitySumcheckParams<F> {
         opening_point[..self.log_k_chunk].reverse();
         opening_point[self.log_k_chunk..].reverse();
         opening_point.into()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * Σ_i γ_i * (ra_i² - ra_i)
+    //        = Σ_i [ Challenge(2i) * Opening(ra_i) * Opening(ra_i)
+    //              + Challenge(2i+1) * Opening(ra_i) ]
+    // where Challenge(2i) = eq_eval * γ_i, Challenge(2i+1) = -eq_eval * γ_i
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let mut terms = Vec::with_capacity(2 * self.d);
+        for i in 0..self.d {
+            let id = OpeningId::new(self.polynomial_types[i], self.sumcheck_id);
+            // eq_eval * γ_i * ra_i²
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(2 * i),
+                vec![ValueSource::Opening(id), ValueSource::Opening(id)],
+            ));
+            // -eq_eval * γ_i * ra_i
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(2 * i + 1),
+                vec![ValueSource::Opening(id)],
+            ));
+        }
+        Some(OutputClaimConstraint::sum_of_products(terms))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let combined_r: Vec<F> = self
+            .r_address
+            .iter()
+            .cloned()
+            .rev()
+            .chain(self.r_cycle.iter().cloned().rev())
+            .collect();
+        let sc: Vec<F> = sumcheck_challenges.to_vec().into_opening();
+        let eq_eval = EqPolynomial::<F>::mle(&sc, &combined_r);
+
+        let mut values = Vec::with_capacity(2 * self.d);
+        for gamma in &self.gammas {
+            let g: F = (*gamma).into();
+            values.push(eq_eval * g);
+            values.push(-eq_eval * g);
+        }
+        values
     }
 }
 

--- a/joltworks/src/subprotocols/hamming_booleanity.rs
+++ b/joltworks/src/subprotocols/hamming_booleanity.rs
@@ -25,6 +25,11 @@ use crate::{
     transcripts::Transcript,
 };
 
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 /// Degree bound of the sumcheck round polynomials in [`HammingBooleanitySumcheckVerifier`].
 const DEGREE_BOUND: usize = 3;
 
@@ -52,6 +57,50 @@ impl<F: JoltField> SumcheckInstanceParams<F> for HammingBooleanitySumcheckParams
 
     fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
         OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * Σ_i gamma^i * hw_i * (hw_i - 1)
+    //        = Σ_i [Challenge(2i) * Opening(hw_i)^2 + Challenge(2i+1) * Opening(hw_i)]
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let mut terms = Vec::with_capacity(2 * self.d);
+        for i in 0..self.d {
+            let id = OpeningId::new(self.polynomial_types[i], self.sumcheck_id);
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(2 * i),
+                vec![ValueSource::Opening(id), ValueSource::Opening(id)],
+            ));
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(2 * i + 1),
+                vec![ValueSource::Opening(id)],
+            ));
+        }
+        Some(OutputClaimConstraint::sum_of_products(terms))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let eq_eval = EqPolynomial::mle(&self.r_cycle, &r.r);
+        let mut values = Vec::with_capacity(2 * self.d);
+        for gamma in &self.gamma_powers {
+            values.push(eq_eval * *gamma);
+            values.push(-eq_eval * *gamma);
+        }
+        values
     }
 }
 

--- a/joltworks/src/subprotocols/hamming_weight.rs
+++ b/joltworks/src/subprotocols/hamming_weight.rs
@@ -24,6 +24,11 @@ use crate::{
     transcripts::Transcript,
 };
 
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 /// Degree bound of the sumcheck round polynomials in [`HammingWeightSumcheckVerifier`].
 const DEGREE_BOUND: usize = 1;
 
@@ -57,6 +62,36 @@ impl<F: JoltField> SumcheckInstanceParams<F> for HammingWeightSumcheckParams<F> 
 
     fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
         OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = Σ_{i=0}^{d-1} γ^i * ra_i
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let terms: Vec<ProductTerm> = (0..self.d)
+            .map(|i| {
+                let id = OpeningId::new(self.polynomial_types[i], self.sumcheck_id);
+                ProductTerm::scaled(ValueSource::Challenge(i), vec![ValueSource::Opening(id)])
+            })
+            .collect();
+        Some(OutputClaimConstraint::sum_of_products(terms))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        self.gamma_powers.clone()
     }
 }
 

--- a/joltworks/src/subprotocols/identity_range_check.rs
+++ b/joltworks/src/subprotocols/identity_range_check.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
 use crate::{
     field::{IntoOpening, JoltField},
     poly::{
@@ -93,6 +97,38 @@ where
 {
     fn num_rounds(&self) -> usize {
         self.log_K + self.log_T
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * ra_claim * identity_eval = Challenge(0) * Opening(ra)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let ra_id = OpeningId::new(self.polynomial_type, self.sumcheck_id);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let (r_address_prime, r_node_output_prime) = opening_point.split_at(self.log_K);
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime.r);
+        let identity_poly_eval =
+            IdentityPolynomial::<F>::new(self.log_K).evaluate(&r_address_prime.r);
+        vec![eq_eval * identity_poly_eval]
     }
 
     fn input_claim(&self, _accumulator: &dyn OpeningAccumulator<F>) -> F {

--- a/joltworks/src/subprotocols/opening_reduction.rs
+++ b/joltworks/src/subprotocols/opening_reduction.rs
@@ -179,6 +179,34 @@ impl<F: JoltField> SumcheckInstanceParams<F> for Opening<F> {
     fn normalize_opening_point(&self, _: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
         unimplemented!("Unused")
     }
+
+    // ZK methods: minimal starting impls so `BatchedSumcheck::prove_zk` doesn't
+    // hit the trait's `todo!()` defaults. These are placeholders -- input claim
+    // is left as a free witness variable and the output claim is not yet bound
+    // to `eq * y_P`. Closing the loop requires the params to know the
+    // polynomial and prior sumcheck id (see
+    // wiki/jolt-atlas/book/src/underway/batched-opening-sound-verifier.md).
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> crate::subprotocols::blindfold::InputClaimConstraint {
+        crate::subprotocols::blindfold::InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(
+        &self,
+    ) -> Option<crate::subprotocols::blindfold::OutputClaimConstraint> {
+        None
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _: &[F::Challenge]) -> Vec<F> {
+        Vec::new()
+    }
 }
 
 impl<F, T: Transcript> SumcheckInstanceProver<F, T> for OpeningProofReductionSumcheckProver<F>
@@ -207,7 +235,7 @@ where
         &self,
         accumulator: &mut ProverOpeningAccumulator<F>,
         _transcript: &mut T,
-        _sumcheck_challenges: &[F::Challenge],
+        sumcheck_challenges: &[F::Challenge],
     ) {
         // Cache the final sumcheck claim in the accumulator
         let claim = match &self.prover_state {
@@ -215,6 +243,23 @@ where
             ProverOpening::OneHot(opening) => opening.final_claim(),
         };
         accumulator.cache_opening_reduction_claim(self.polynomial, claim);
+
+        // Also register the reduced evaluation as a standard opening so the
+        // BlindFold R1CS can reference it via `OpeningId`. The opening point
+        // is the batched-opening sumcheck's challenge vector r_sumcheck; the
+        // claim is the per-poly value P(r_sumcheck). Stored unconditionally
+        // (cheap insert); only the `--features zk` path actually consumes it
+        // via the extra constraint linking `joint_claim = sum gamma_i * y_P_i`
+        // to `y_com`.
+        use crate::field::IntoOpening;
+        let opening_point = OpeningPoint::new(sumcheck_challenges.into_opening());
+        let opening_id = crate::poly::opening_proof::OpeningId::new(
+            self.polynomial,
+            SumcheckId::BlindFoldBatchOpening,
+        );
+        accumulator
+            .openings
+            .insert(opening_id, (opening_point, claim));
     }
 }
 
@@ -260,11 +305,23 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
 
     fn cache_openings(
         &self,
-        _accumulator: &mut VerifierOpeningAccumulator<F>,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
         _transcript: &mut T,
-        _sumcheck_challenges: &[F::Challenge],
+        sumcheck_challenges: &[F::Challenge],
     ) {
-        // Nothing to cache.
+        // Mirror the prover-side insert: register an opening at
+        // `(self.polynomial, SumcheckId::BlindFoldBatchOpening)` so the
+        // BlindFold R1CS can reference it. In ZK mode the actual claim is a
+        // placeholder; the value the prover assigned is verified by BlindFold.
+        use crate::field::IntoOpening;
+        let opening_point = OpeningPoint::new(sumcheck_challenges.into_opening());
+        let opening_id = crate::poly::opening_proof::OpeningId::new(
+            self.polynomial,
+            SumcheckId::BlindFoldBatchOpening,
+        );
+        accumulator
+            .openings
+            .insert(opening_id, (opening_point, F::zero()));
     }
 }
 

--- a/joltworks/src/subprotocols/ps_shout.rs
+++ b/joltworks/src/subprotocols/ps_shout.rs
@@ -42,6 +42,11 @@ use rayon::prelude::*;
 use std::array;
 use strum::EnumCount;
 
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 const DEGREE_BOUND: usize = 2;
 
 /// Parameters for the Prefix suffix Read-raf checking sum-check protocol.
@@ -142,6 +147,48 @@ where
             .rev()
             .collect::<Vec<_>>();
         OpeningPoint::new([r_address_prime.to_vec(), r_node_output_prime].concat())
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * ra_claim * (val_claim + γ * raf_claim)
+    //        = Challenge(0) * Opening(ra)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let ra_id = OpeningId::new(self.polynomial_type, self.sumcheck_id);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let (r_address_prime, r_node_output_prime) = opening_point.split_at(LOG_K);
+        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime.r);
+        let val_claim = self.table.evaluate_mle(&r_address_prime.r);
+
+        let left_operand_eval =
+            OperandPolynomial::<F>::new(LOG_K, OperandSide::Left).evaluate(&r_address_prime.r);
+        let right_operand_eval =
+            OperandPolynomial::<F>::new(LOG_K, OperandSide::Right).evaluate(&r_address_prime.r);
+        let identity_poly_eval = IdentityPolynomial::<F>::new(LOG_K).evaluate(&r_address_prime.r);
+        let raf_flag_claim = F::from_bool(self.is_interleaved_operands);
+        let raf_claim = raf_flag_claim * (left_operand_eval + self.gamma * right_operand_eval)
+            + (F::one() - raf_flag_claim) * self.gamma * identity_poly_eval;
+
+        vec![eq_eval * (val_claim + self.gamma * raf_claim)]
     }
 }
 

--- a/joltworks/src/subprotocols/ra_virtual.rs
+++ b/joltworks/src/subprotocols/ra_virtual.rs
@@ -25,6 +25,11 @@ use crate::{
 use common::CommittedPoly;
 use rayon::prelude::*;
 
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 // Instruction read-access (RA) virtualization sumcheck
 //
 // Proves the relation:
@@ -58,6 +63,42 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RaSumcheckParams<F> {
 
     fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
         OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = eq_eval * ∏_{i=0}^{d-1} ra_i
+    //        = Challenge(0) * Opening(ra_0) * Opening(ra_1) * ... * Opening(ra_{d-1})
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let d = self.one_hot_params.instruction_d;
+        let factors: Vec<ValueSource> = (0..d)
+            .map(|i| {
+                let id = OpeningId::new(self.polynomial_types[i], SumcheckId::RaVirtualization);
+                ValueSource::Opening(id)
+            })
+            .collect();
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), factors),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let r = self.normalize_opening_point(&sumcheck_challenges.into_opening());
+        let eq_eval = EqPolynomial::mle_endian(&self.r_cycle, &r);
+        vec![eq_eval]
     }
 }
 

--- a/joltworks/src/subprotocols/shout.rs
+++ b/joltworks/src/subprotocols/shout.rs
@@ -36,6 +36,11 @@ use crate::{
     subprotocols::sumcheck_verifier::SumcheckInstanceParams,
 };
 
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{
+    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
+};
+
 const READ_RAF_DEGREE_BOUND: usize = 2;
 
 pub fn read_raf_prover<F: JoltField, T: Transcript>(
@@ -45,7 +50,7 @@ pub fn read_raf_prover<F: JoltField, T: Transcript>(
     accumulator: &dyn OpeningAccumulator<F>,
     transcript: &mut T,
 ) -> Box<dyn SumcheckInstanceProver<F, T>> {
-    let params = ReadRafParams::new(provider, accumulator, transcript);
+    let params = ReadRafParams::new(provider, table, accumulator, transcript);
     Box::new(ReadRafProver::initialize(lookup_indices, table, params))
 }
 
@@ -94,12 +99,15 @@ pub struct ReadRafParams<F: JoltField> {
     ra_vp: VirtualPoly,
     ra_sid: SumcheckId,
     log_K: usize,
+    /// Lookup table (stored for BlindFold constraint evaluation).
+    table: Vec<i32>,
 }
 
 impl<F: JoltField> ReadRafParams<F> {
     /// Create new parameters for exponentiation lookups.
     pub fn new(
         provider: &impl ReadRafProvider<F>,
+        table: &[i32],
         accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
@@ -113,6 +121,7 @@ impl<F: JoltField> ReadRafParams<F> {
             ra_vp,
             ra_sid,
             log_K: provider.log_K(),
+            table: table.to_vec(),
         }
     }
 }
@@ -132,6 +141,40 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReadRafParams<F> {
 
     fn num_rounds(&self) -> usize {
         self.log_K
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    // output = ra_claim * (val_claim + gamma * int_claim)
+    //        = Challenge(0) * Opening(ra)
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let ra_id = OpeningId::new(self.ra_vp, self.ra_sid);
+        Some(OutputClaimConstraint::sum_of_products(vec![
+            ProductTerm::scaled(ValueSource::Challenge(0), vec![ValueSource::Opening(ra_id)]),
+        ]))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        use crate::poly::identity_poly::IdentityPolynomial;
+        use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
+
+        let sc: Vec<F> = sumcheck_challenges.to_vec().into_opening();
+        let val_claim = MultilinearPolynomial::from(self.table.clone()).evaluate(&sc);
+        let int_claim = IdentityPolynomial::new(self.log_K).evaluate(&sc);
+        vec![val_claim + self.gamma * int_claim]
     }
 }
 
@@ -246,7 +289,7 @@ impl<F: JoltField> ReadRafVerifier<F> {
         accumulator: &VerifierOpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
-        let params = ReadRafParams::new(provider, accumulator, transcript);
+        let params = ReadRafParams::new(provider, &table, accumulator, transcript);
         Self { params, table }
     }
 }

--- a/joltworks/src/subprotocols/shout.rs
+++ b/joltworks/src/subprotocols/shout.rs
@@ -100,6 +100,7 @@ pub struct ReadRafParams<F: JoltField> {
     ra_sid: SumcheckId,
     log_K: usize,
     /// Lookup table (stored for BlindFold constraint evaluation).
+    #[cfg_attr(not(feature = "zk"), allow(dead_code))]
     table: Vec<i32>,
 }
 


### PR DESCRIPTION
This PR subsumes all the other previous PRs on BlindFold. I will leave the other ones for reference, but we can close them. In particular, it implements BlindFold constraint methods on:
- Single-stage: Square, Add, Sub, Neg, Mul, And, Cube, Iff, Concat, Reshape, Slice, ScalarConstDiv
- Custom-flow: Div (with range checks + one-hot), Rsqrt (dual range checks)
- Neural teleportation: Sigmoid, Tanh, Erf (default flow), Cos, Sin (custom flow with transcript-derived r_node_output)
- Lookup: Relu (OpLookupProvider + shout one-hot)
- Matrix ops: Einsum (8 variants), Sum
- Gather: GatherLarge (shout one-hot), GatherSmall (HammingBooleanity)
- SoftmaxLastAxis (4-stage pipeline with Pedersen-committed inter-stage claims)

Test PR: `cargo run --release --features zk -p jolt-atlas-core --example gpt2_zk_bench`.

On a 14-core Apple M3:

| Path | Prove (mean ± range) | Verify (mean ± range) | Proof size |
|---|---|---|---|
| non-zk on `blindfold-all-ops` | 12.81 s (12.5-13.2) | 1.04 s (1.0-1.1) | 2504.6 KiB |
| **zk (BlindFold) on `blindfold-all-ops`** | **23.41 s (23.2-23.9)** | **2.43 s (2.2-2.6)** | **2729.96 KiB** |
| **ratio** | **1.83×** | **2.34×** | **1.09×** |

Both paths run on the same workload (`gpt2_zk_bench`, 16-token GPT-2, max_num_vars=20, deterministic Pedersen generators). `ZK_BENCH_THREADS=14` for the ZK rayon pool.


### Prover (target: ~23.3 s)

| Stage | Wall / busy | Share | What it does |
|---|---|---|---|
| `commit_witness_polynomials` | **725 ms** | 3.1% | Pedersen-commit every witness MLE (62.9 ms `polynomial_map` + 631 ms `commit_to_polynomials`). |
| **Per-node ZK sumcheck loop** | **~11 s wall** | **~47%** | 1103× `BatchedSumcheck::prove_zk`, cumulative busy **10.96 s** (avg **9.94 ms** per call). One per ONNX operator stage. Dominated by per-round Pedersen commits. |
| `prove_batch_opening_sumcheck_zk` (Stage 7) | **1.75 s** | 7.5% | Single batched ZK sumcheck reducing all witness-MLE openings to one point. |
| `build_materialized_rlc` (Step 8) | 335 ms | 1.4% | Build gamma-weighted RLC of all witness polys. |
| `HyperKZG::prove` (Step 8) | **1.96 s** | 8.4% | Single HyperKZG opening at `r_sumcheck`. |
| Bundle / Hyrax-row commits (uninstrumented) | ~5.6 s | ~24% | Build R1CS, assign witness, Pedersen-commit witness rows. |
| **`BlindFoldProver::prove`** | **1.99 s** | **8.5%** | Nova folding + Spartan tail. Sub-split below. |

Inside `BlindFoldProver::prove` (1.99 s):

- `BlindFold::sample_random_satisfying_pair` (Nova cross-term sampling): **1.04 s** (~52%)
- `BlindFold::commit_cross_term_rows`: 271 ms
- `BlindFoldInnerSumcheckProver::new`: 117 ms
- `RelaxedR1CSInstance::fold`: 109 ms
- `BlindFoldSpartanProver::witness_contributions`: 86 ms
- `RelaxedR1CSWitness::fold`: 35 ms
- `BlindFold::compute_cross_term`: 11 ms
- `BlindFoldSpartanProver::new`: 7 ms

**Top three prover costs**: per-node ZK sumchecks (~47%), bundle assembly + Hyrax row MSMs (~24%), BlindFold folding tail (~9%). Step 8 (~10%) and Stage 7 (~7.5%) are the remaining major chunks.

### Verifier (target: ~2.44 s)

| Stage | Wall / busy | Share | What it does |
|---|---|---|---|
| **Per-op `verify_zk_*` loop** | **~1.4 s** | **~57%** | 299× `Constant::verify`-equivalent MLE eval (cum 645 ms on the non-zk path for comparison) + 1× `Input::verify`. `BatchedSumcheck::verify_zk` itself is essentially free (~60 ms across 1102 calls — just transcript absorbs). |
| Public-node R1CS binding consistency | ~0.6 s | ~25% | Per-binding: recompute `public_mle(opening_point)`, check baked challenge equals it, check eval-commitment is identity G1. **Currently does the per-op MLE eval a second time — dedup opportunity.** |
| **`BlindFoldVerifier::verify`** | **385 ms** | 16% | Spartan + Nova-folded `eval_commitments` check. |
| Step 8 `HyperKZG::verify` | 1.4 ms | 0.06% | One pairing + MSM. |
| Other (R1CS build, transcript) | ~50 ms | ~2% | `VerifierR1CSBuilder::build` + bookkeeping. |

**Top three verifier costs**: Constant/Input local MLE evaluations (~57%), R1CS binding consistency (~25%, mostly redundant), BlindFold Spartan-verify (~16%). Step 8 PCS verify is essentially free.