### PR TITLE
fix(soundness): bind public inputs into the transcript (#230)

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -976,6 +976,100 @@ fn test_zk_constant_binding_rejects_cross_model_attack() {
     );
 }
 
+/// Regression for issue #230 (the input-binding soundness bug).
+/// `verify_zk` once accepted a proof for `output =
+/// square(input)` when `ModelExecutionIO.inputs[0]` was rebound from `x` to
+/// `-x` with the output left unchanged (square(x) == square(-x)). With public
+/// inputs now absorbed into the transcript before any challenge
+/// (`append_inputs_to_transcript`), swapping `io.inputs` diverges the
+/// verifier's transcript from the proof, so verification rejects — and it does
+/// so for *any* rebound input, including ones an attacker would adaptively
+/// craft to satisfy the per-node evaluation check (issue #230), because the
+/// opening points now depend on the input.
+#[cfg(feature = "zk")]
+#[test]
+fn test_zk_rejects_rebound_input_for_square_model() {
+    use atlas_onnx_tracer::model::test::ModelBuilder;
+
+    let size = 1 << 4;
+    let mut rng = StdRng::seed_from_u64(0x5EED);
+    let input_data = Tensor::<i32>::random_small(&mut rng, &[size]);
+
+    let build = || {
+        let mut b = ModelBuilder::new();
+        let i = b.input(vec![size]);
+        let res = b.square(i);
+        b.mark_output(res);
+        b.build()
+    };
+
+    let prover_pp = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(
+        AtlasSharedPreprocessing::preprocess(build()),
+    );
+    let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
+
+    let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
+        joltworks::curve::Bn254Curve,
+    >::deterministic(16);
+
+    // Honest proof for input x.
+    let (bundle, mut io) =
+        crate::onnx_proof::zk::prove_zk(&prover_pp, &[input_data.clone()], &gens);
+
+    // Sanity: the honest bundle verifies against the honest io.
+    crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
+        .expect("honest square proof should verify");
+
+    // Attack: rebind the verifier-facing input from x to -x, leave the
+    // output (x^2 == (-x)^2) unchanged. Must be rejected.
+    let neg_data: Vec<i32> = io.inputs[0].iter().map(|v| -v).collect();
+    io.inputs[0] = Tensor::new(Some(&neg_data), io.inputs[0].dims())
+        .expect("negated input tensor should be valid");
+
+    let rebound = crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens);
+    assert!(
+        rebound.is_err(),
+        "rebound input (x -> -x) must be rejected; got Ok (#230)"
+    );
+}
+
+/// Unit test for the issue #230 fix mechanism: absorbing the public inputs
+/// makes every subsequent Fiat-Shamir challenge depend on the input values.
+/// This is what removes the adaptive forge's precondition (input-independent,
+/// prover-known opening points).
+#[test]
+fn test_input_binding_changes_transcript() {
+    use crate::onnx_proof::append_inputs_to_transcript;
+    use atlas_onnx_tracer::model::trace::ModelExecutionIO;
+    use joltworks::transcripts::{Blake2bTranscript, Transcript};
+
+    let io = |vals: &[i32]| ModelExecutionIO {
+        inputs: vec![Tensor::new(Some(vals), &[vals.len()]).unwrap()],
+        outputs: vec![],
+        input_indices: vec![0],
+        output_indices: vec![],
+    };
+
+    let challenge_for = |vals: &[i32]| -> Fr {
+        let mut t = Blake2bTranscript::new(b"ONNXProof");
+        append_inputs_to_transcript(&mut t, &io(vals));
+        t.challenge_scalar::<Fr>()
+    };
+
+    let base = [3, 1, 4, 1, 5, 9, 2, 6];
+    let mut flipped = base;
+    flipped[0] = -flipped[0];
+
+    // Identical inputs -> identical challenge (determinism / honest case).
+    assert_eq!(challenge_for(&base), challenge_for(&base));
+    // A single changed input element -> different challenge.
+    assert_ne!(
+        challenge_for(&base),
+        challenge_for(&flipped),
+        "changing an input must change the derived challenge (issue #230)"
+    );
+}
+
 #[cfg(feature = "zk")]
 #[test]
 fn test_reshape_zk() {

--- a/jolt-atlas-core/src/onnx_proof/malicious_prover.rs
+++ b/jolt-atlas-core/src/onnx_proof/malicious_prover.rs
@@ -24,6 +24,7 @@ use joltworks::{
 };
 
 use crate::onnx_proof::{
+    append_inputs_to_transcript,
     ops::{malicious_sub::malicious_sub_prove, OperatorProver},
     AtlasProverPreprocessing, ONNXProof, ProofId, Prover, ProverDebugInfo,
 };
@@ -58,6 +59,11 @@ impl MaliciousONNXProof {
         // Initialize prover state
         let mut prover: Prover<F, T> = Prover::new(pp.shared.clone(), trace);
         let mut proofs = BTreeMap::new();
+
+        // Mirror the honest protocol: bind public inputs into the transcript
+        // first (issue #230). A faithful attacker follows the protocol and only
+        // deviates in the specific forgery under test.
+        append_inputs_to_transcript(&mut prover.transcript, &io);
 
         // Commit to witness polynomials and append commitments to transcript
         let (poly_map, commitments) = ONNXProof::<F, T, PCS>::commit_witness_polynomials(
@@ -108,6 +114,9 @@ impl MaliciousONNXProof {
 
         let mut prover: Prover<F, T> = Prover::new(pp.shared.clone(), trace);
         let mut proofs = BTreeMap::new();
+
+        // Mirror the honest protocol: bind public inputs first (issue #230).
+        append_inputs_to_transcript(&mut prover.transcript, &io);
 
         let (poly_map, commitments) = ONNXProof::<F, T, PCS>::commit_witness_polynomials(
             pp.model(),

--- a/jolt-atlas-core/src/onnx_proof/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/mod.rs
@@ -58,6 +58,51 @@ pub use verifier::Verifier;
 pub use ark_bn254::{Bn254, Fr};
 pub use joltworks::{poly::commitment::hyperkzg::HyperKZG, transcripts::Blake2bTranscript};
 
+// ── Public-input transcript binding (soundness, issue #230) ──────────────
+
+/// Bind the model's public input tensors into the Fiat-Shamir transcript
+/// *before* any challenge is derived.
+///
+/// The input tensors are supplied by the prover through [`ModelExecutionIO`]
+/// and are not otherwise committed. If they are absent from the transcript,
+/// every challenge (hence every sumcheck/opening point) is independent of the
+/// inputs. A malicious prover can then run the honest prover on a real input,
+/// read the (input-independent) opening points, and swap `io.inputs` for any
+/// `Input'` that matches the baked evaluation claims at those points,
+/// producing an accepted proof of the false statement `out = Model(Input')`.
+/// See issue #230 (the adaptive forge that defeats the per-node evaluation
+/// check alone); #244 closed the naive instantiation via the per-node binding.
+///
+/// Absorbing the inputs here forces the opening points to depend on the input,
+/// so any change to `io.inputs` diverges the verifier's transcript from the
+/// proof and the IOP rejects before the evaluation check is even reached. The
+/// prover and verifier must call this at the same position (first append, right
+/// after the transcript is created) so their transcripts stay in lockstep.
+///
+/// Outputs are already bound (the output claim is checked against `io.outputs`
+/// at a transcript-derived point and the IOP ties the output to the trace), so
+/// only inputs need binding here.
+pub(crate) fn append_inputs_to_transcript<T: Transcript>(
+    transcript: &mut T,
+    io: &ModelExecutionIO,
+) {
+    transcript.append_message(b"model_inputs");
+    transcript.append_u64(io.inputs.len() as u64);
+    // `io.inputs[i]` corresponds to `io.input_indices[i]` (same order on both
+    // sides). Bind the node index, the shape, and every value so that any
+    // change to which-node / shape / contents perturbs all later challenges.
+    for (tensor, node_idx) in io.inputs.iter().zip(io.input_indices.iter()) {
+        transcript.append_u64(*node_idx as u64);
+        let dims = tensor.dims();
+        transcript.append_u64(dims.len() as u64);
+        for d in dims {
+            transcript.append_u64(*d as u64);
+        }
+        let bytes: Vec<u8> = tensor.iter().copied().flat_map(i32::to_le_bytes).collect();
+        transcript.append_bytes(&bytes);
+    }
+}
+
 // ── Core proof structures ────────────────────────────────────────────────
 
 /// Proof for an ONNX neural network computation.
@@ -99,6 +144,9 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
         // TODO: Deduplicate shared preprocessing, which is present in both AtlasProverPreprocessing and Prover state
         let mut prover: Prover<F, T> = Prover::new(pp.shared.clone(), trace);
         let mut proofs = BTreeMap::new();
+
+        // Bind public inputs into the transcript before any challenge (issue #230).
+        append_inputs_to_transcript(&mut prover.transcript, &io);
 
         // Commit to witness polynomials and append commitments to transcript
         let (poly_map, commitments) = Self::commit_witness_polynomials(
@@ -155,6 +203,11 @@ impl<F: JoltField, T: Transcript, PCS: CommitmentScheme<Field = F>> ONNXProof<F,
                     .compare_to(debug_info.opening_accumulator);
             }
         }
+
+        // Bind public inputs into the transcript before any challenge (issue #230).
+        // Must mirror the prover's first append, after `compare_to` installs the
+        // expected state history and before any commitment is absorbed.
+        append_inputs_to_transcript(&mut verifier.transcript, io);
 
         // Populate claims and commitments in the verifier accumulator.
         self.populate_accumulator(&mut verifier);

--- a/jolt-atlas-core/src/onnx_proof/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/mod.rs
@@ -88,20 +88,32 @@ pub(crate) fn append_inputs_to_transcript<T: Transcript>(
 ) {
     transcript.append_message(b"model_inputs");
     transcript.append_u64(io.inputs.len() as u64);
-    // `io.inputs[i]` corresponds to `io.input_indices[i]` (same order on both
-    // sides). Bind the node index, the shape, and every value so that any
-    // change to which-node / shape / contents perturbs all later challenges.
-    for (tensor, node_idx) in io.inputs.iter().zip(io.input_indices.iter()) {
-        transcript.append_u64(*node_idx as u64);
+    transcript.append_u64(io.input_indices.len() as u64);
+
+    // Bind all inputs (and all indices) even if a malformed `ModelExecutionIO` is provided.
+    for (i, tensor) in io.inputs.iter().enumerate() {
+        let node_idx = io.input_indices.get(i).copied().unwrap_or(usize::MAX);
+        transcript.append_u64(node_idx as u64);
+
         let dims = tensor.dims();
         transcript.append_u64(dims.len() as u64);
         for d in dims {
             transcript.append_u64(*d as u64);
         }
-        let bytes: Vec<u8> = tensor.iter().copied().flat_map(i32::to_le_bytes).collect();
+
+        // Encode values explicitly in LE for cross-platform determinism.
+        let mut bytes = Vec::with_capacity(tensor.inner.len() * 4);
+        for v in &tensor.inner {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
         transcript.append_bytes(&bytes);
     }
-}
+
+    // Ensure any extra indices also perturb the transcript.
+    for node_idx in io.input_indices.iter().skip(io.inputs.len()) {
+        transcript.append_u64(*node_idx as u64);
+        transcript.append_message(b"missing_tensor");
+    }
 
 // ── Core proof structures ────────────────────────────────────────────────
 

--- a/jolt-atlas-core/src/onnx_proof/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/mod.rs
@@ -114,6 +114,7 @@ pub(crate) fn append_inputs_to_transcript<T: Transcript>(
         transcript.append_u64(*node_idx as u64);
         transcript.append_message(b"missing_tensor");
     }
+}
 
 // ── Core proof structures ────────────────────────────────────────────────
 

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1808,6 +1808,9 @@ pub fn prove_zk(
     let trace = pp.model().trace(inputs);
     let io = Trace::io(&trace, pp.model());
     let mut prover = Prover::<F, T>::new(pp.shared.clone(), trace);
+    // Bind public inputs into the transcript before any challenge (issue #230);
+    // mirrored in `verify_zk_with_pcs_capture_and_extract`.
+    super::append_inputs_to_transcript(&mut prover.transcript, &io);
     // Mirror the verifier's `VerifierOpeningAccumulator::new_zk` default: the
     // ZK pipeline hides cleartext opening claims behind Pedersen commitments
     // (emitted by BatchedSumcheck::prove_zk), so the prover must NOT append
@@ -2675,6 +2678,10 @@ fn verify_zk_with_pcs_capture_and_extract(
     let model = pp.shared.model();
     let mut accumulator = VerifierOpeningAccumulator::<F>::new_zk();
     let mut transcript = T::new(b"ONNXProof");
+
+    // 0. Bind public inputs into the transcript before any challenge (issue
+    //    #230); must mirror `prove_zk`'s first append.
+    super::append_inputs_to_transcript(&mut transcript, io);
 
     // 1. Absorb witness commitments into transcript
     for commitment in &bundle.commitments {


### PR DESCRIPTION
Fix: absorb the public input tensors (node index, shape, values) into the transcript before any challenge is derived, symmetrically on prover and verifier, in both the standard and zk paths. Any change to `io.inputs` now diverges the verifier's transcript from the proof and the IOP rejects before the evaluation check is reached, so the opening points can no longer be predicted and there is no fixed target to craft a colliding `Input'` against.

- mod.rs: `append_inputs_to_transcript`; called in `ONNXProof::prove`/`verify`.
- zk.rs: called in `prove_zk` and `verify_zk_with_pcs_capture_and_extract`.
- malicious_prover.rs: both variants mirror the absorption (a faithful attacker follows the protocol; only the forgery deviates) so the soundness tests still exercise their intended defense rather than transcript divergence.
- e2e_tests.rs: rebound-input regression now caught by transcript binding; new `test_input_binding_changes_transcript` unit test.

Outputs are already bound (output-claim check + IOP), so only inputs need binding here.