### PR TITLE
feat: reduce quant error for qwen

### DIFF
--- a/atlas-onnx-tracer/examples/quant_error_analysis_qwen.rs
+++ b/atlas-onnx-tracer/examples/quant_error_analysis_qwen.rs
@@ -14,7 +14,7 @@ use atlas_onnx_tracer::{
 use tokenizers::Tokenizer;
 use tracing::{debug, info};
 
-const SCALE: i32 = 20; // 2^20 = 1,048,576 multiplier for fixed-point representation (roughly 6 decimal digits of precision)
+const SCALE: i32 = 14;
 const ONNX_PATH: &str = "atlas-onnx-tracer/models/qwen/network.onnx";
 const TOKENIZER_PATH: &str = "atlas-onnx-tracer/models/qwen/tokenizer.json";
 const VOCAB_SIZE: usize = 151936;

--- a/atlas-onnx-tracer/examples/quant_error_analysis_qwen.rs
+++ b/atlas-onnx-tracer/examples/quant_error_analysis_qwen.rs
@@ -3,9 +3,10 @@ use atlas_onnx_tracer::{
     tensor::Tensor,
     utils::{
         qea::{
-            self, ShadowResult, extract_shadow_logits, init_logging, last_position_logits_f32,
-            last_position_logits_i32, make_f64_inputs, make_run_args, print_comparison_metrics,
-            print_step, run_tract_f32, top_k_entries, tract_greedy_generate,
+            self, ShadowResult, THIN, extract_shadow_logits, init_logging,
+            last_position_logits_f32, last_position_logits_i32, make_f64_inputs,
+            make_qwen_i32_inputs, make_run_args, print_comparison_metrics, print_step,
+            run_tract_f32, top_k_entries, tract_greedy_generate,
         },
         quantize,
     },
@@ -13,15 +14,12 @@ use atlas_onnx_tracer::{
 use tokenizers::Tokenizer;
 use tracing::{debug, info};
 
-const ONNX_PATH: &str = "atlas-onnx-tracer/models/gpt2/network.onnx";
-const TOKENIZER_PATH: &str = "atlas-onnx-tracer/models/gpt2/tokenizer.json";
-const VOCAB_SIZE: usize = 50257;
-#[cfg(feature = "fused-ops")]
-const SCALE: i32 = 12;
-#[cfg(not(feature = "fused-ops"))]
-const SCALE: i32 = 8;
+const SCALE: i32 = 20; // 2^20 = 1,048,576 multiplier for fixed-point representation (roughly 6 decimal digits of precision)
+const ONNX_PATH: &str = "atlas-onnx-tracer/models/qwen/network.onnx";
+const TOKENIZER_PATH: &str = "atlas-onnx-tracer/models/qwen/tokenizer.json";
+const VOCAB_SIZE: usize = 151936;
 
-/// Quantization error analysis for GPT-2.
+/// Quantization error analysis for Qwen2-0.5B.
 ///
 /// Compares four views of the same forward pass (see GLOSSARY in the output):
 ///
@@ -43,29 +41,23 @@ const SCALE: i32 = 8;
 /// # Setup
 ///
 /// ```sh
-/// pip install 'optimum[exporters]' 'optimum[onnxruntime]'
-/// python -m optimum.exporters.onnx --model gpt2 atlas-onnx-tracer/models/gpt2
+/// python atlas-onnx-tracer/.venv/bin/python scripts/download_qwen.py
 /// ```
 ///
 /// # Usage
 ///
 /// Default (info-level output, tract logs silenced):
 /// ```sh
-/// cargo run -r -p atlas-onnx-tracer --features fused-ops --example quant_error_analysis
+/// cargo run -r -p atlas-onnx-tracer --features fused-ops --example quant_error_analysis_qwen
 /// ```
 ///
 /// Show debug output (shapes, token details):
 /// ```sh
-/// RUST_LOG=debug cargo run -r -p atlas-onnx-tracer --features fused-ops --example quant_error_analysis
-/// ```
-///
-/// Show everything *including* tract internals:
-/// ```sh
-/// RUST_LOG=trace cargo run -r -p atlas-onnx-tracer --features fused-ops --example quant_error_analysis
+/// RUST_LOG=debug cargo run -r -p atlas-onnx-tracer --features fused-ops --example quant_error_analysis_qwen
 /// ```
 fn main() {
     init_logging();
-    let ctx = setup("The white man worked as a");
+    let ctx = setup("The quick brown fox jumps over the lazy dog");
 
     print_glossary(&ctx);
     step1_quant_vs_tract(&ctx);
@@ -94,7 +86,7 @@ struct Ctx {
 
 fn setup(text: &str) -> Ctx {
     let tokenizer = Tokenizer::from_file(TOKENIZER_PATH)
-        .expect("failed to load tokenizer.json – see doc-comment for setup");
+        .expect("failed to load tokenizer.json – run scripts/download_qwen.py first");
 
     info!("Input text : \"{text}\"");
     let encoding = tokenizer.encode(text, false).expect("tokenization failed");
@@ -104,7 +96,7 @@ fn setup(text: &str) -> Ctx {
     debug!(?token_ids, "Token IDs");
     debug!(seq_len, "Sequence length");
 
-    let run_args = local_make_run_args(seq_len);
+    let run_args = make_run_args(seq_len, SCALE);
     let scale = run_args.scale;
     let scale_mult = quantize::scale_to_multiplier(scale);
 
@@ -114,8 +106,10 @@ fn setup(text: &str) -> Ctx {
 
     info!("Running QUANT (i32 fixed-point, scale=2^{scale}) …");
     let model = Model::load(ONNX_PATH, &run_args);
-    let quant_inputs = make_gpt2_i32_inputs(&token_ids, seq_len, scale);
+
+    let quant_inputs = make_qwen_i32_inputs(&token_ids, seq_len, scale);
     let i32_outputs = model.forward(&quant_inputs);
+
     debug!(shape = ?i32_outputs[0].dims(), "QUANT output shape");
 
     let last_pos_start = (seq_len - 1) * VOCAB_SIZE;
@@ -143,7 +137,7 @@ fn setup(text: &str) -> Ctx {
 
 fn print_glossary(ctx: &Ctx) {
     qea::print_section("GLOSSARY");
-    info!("  This analysis compares four views of the same GPT-2 forward pass:");
+    info!("  This analysis compares four views of the same Qwen2-0.5B forward pass:");
     info!("");
     info!("    TRACT     ONNX model evaluated by Tract at f32 precision.");
     info!("              This is the ground-truth reference.");
@@ -182,7 +176,6 @@ fn step1_quant_vs_tract(ctx: &Ctx) {
 }
 
 fn step2_per_node_drift(ctx: &Ctx) -> ShadowResult {
-    use atlas_onnx_tracer::utils::qea::THIN;
     print_step(2, "SHADOW vs QUANT — per-node drift");
     info!("  Each row compares the dequantized i32 output against the f64 shadow");
     info!("  after every graph node. Shows where rounding error accumulates.");
@@ -222,7 +215,6 @@ fn step3_shadow_vs_tract(ctx: &Ctx, sr: &ShadowResult) {
 }
 
 fn step4_weight_quant_effect(ctx: &Ctx, sr: &ShadowResult) {
-    use atlas_onnx_tracer::utils::qea::THIN;
     print_step(4, "TRUE-F64 vs TRACT — weight quantization effect");
     info!("  TRUE-F64 uses original f32 weights + f64 arithmetic.");
     info!("  Comparing TRUE-F64 to TRACT should show near-zero error (just f64↔f32).");
@@ -263,6 +255,73 @@ fn step4_weight_quant_effect(ctx: &Ctx, sr: &ShadowResult) {
     info!("  [4b] SHADOW vs TRUE-F64  (difference = weight quantization error)");
     info!("{THIN}");
     print_comparison_metrics(&sr.logits, &true_logits, "  ");
+
+    info!("");
+    info!("{THIN}");
+    info!("  [4c] Per-node SHADOW vs TRUE-F64 (worst 20 nodes by CosSim)");
+    info!("{THIN}");
+    let mut diffs: Vec<(usize, String, f64, f64)> = sr
+        .trace
+        .f64_outputs
+        .iter()
+        .filter_map(|(node_idx, shadow_out)| {
+            let true_out = true_shadow.f64_outputs.get(node_idx)?;
+            if shadow_out.len() != true_out.len() || shadow_out.is_empty() {
+                return None;
+            }
+            let cos = atlas_onnx_tracer::utils::metrics::cosine_similarity(
+                shadow_out.data(),
+                true_out.data(),
+            );
+            let rel_mse =
+                atlas_onnx_tracer::utils::metrics::relative_mse(true_out.data(), shadow_out.data());
+            if cos.is_nan() || cos > 0.9999 {
+                return None;
+            }
+            let op_name = sr
+                .trace
+                .node_metrics
+                .iter()
+                .find(|m| m.idx == *node_idx)
+                .map(|m| m.op_name.clone())
+                .unwrap_or_else(|| "?".to_string());
+            Some((*node_idx, op_name, cos, rel_mse))
+        })
+        .collect();
+    diffs.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal));
+    if diffs.is_empty() {
+        info!("  No nodes with CosSim < 0.9999 between SHADOW and TRUE-F64.");
+    } else {
+        info!(
+            "  {:<6} {:<20} {:<12} {:<12}",
+            "Node", "Op", "CosSim", "RelMSE"
+        );
+        info!("  {}", "-".repeat(54));
+        for (idx, op, cos, relmse) in diffs.iter().take(20) {
+            info!("  {:<6} {:<20} {:<12.6} {:<12.6}", idx, op, cos, relmse);
+        }
+        let mut by_idx = diffs.clone();
+        by_idx.sort_by_key(|x| x.0);
+        info!("");
+        info!("  First 5 diverging nodes (sorted by node index):");
+        for (idx, op, cos, relmse) in by_idx.iter().take(5) {
+            info!("  {:<6} {:<20} {:<12.6} {:<12.6}", idx, op, cos, relmse);
+        }
+        let mut by_op: std::collections::BTreeMap<String, (usize, f64)> =
+            std::collections::BTreeMap::new();
+        for (_, op, cos, _) in &diffs {
+            let e = by_op.entry(op.clone()).or_insert((0, 1.0f64));
+            e.0 += 1;
+            e.1 = e.1.min(*cos);
+        }
+        info!("");
+        info!("  Count by op type (nodes with CosSim < 0.9999):");
+        for (op, (cnt, worst)) in &by_op {
+            info!("  {:<20} count={:<4} worst_cos={:.6}", op, cnt, worst);
+        }
+        info!("");
+        info!("  Total diverging nodes: {}", diffs.len());
+    }
 }
 
 fn step5_greedy_generation(ctx: &Ctx) {
@@ -275,31 +334,6 @@ fn step5_greedy_generation(ctx: &Ctx) {
         .decode(&generated, false)
         .unwrap_or_else(|_| "<decode error>".to_string());
     info!("  \"{text}\"");
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-//  GPT-2-specific helpers
-// ═══════════════════════════════════════════════════════════════════════════
-
-fn local_make_run_args(seq_len: usize) -> RunArgs {
-    let mut args = make_run_args(seq_len, SCALE);
-    #[cfg(not(feature = "fused-ops"))]
-    {
-        args = args.with_pre_rebase_nonlinear(true);
-    }
-    args
-}
-
-/// GPT-2 quantized inputs: position IDs are NOT scaled (unlike Qwen).
-fn make_gpt2_i32_inputs(token_ids: &[u32], seq_len: usize, scale: i32) -> Vec<Tensor<i32>> {
-    let ids: Vec<i32> = token_ids.iter().map(|&id| id as i32).collect();
-    let pos: Vec<i32> = (0..seq_len as i32).collect();
-    let mask: Vec<i32> = vec![1 << scale; seq_len];
-    vec![
-        Tensor::new(Some(&ids), &[1, seq_len]).unwrap(),
-        Tensor::new(Some(&pos), &[1, seq_len]).unwrap(),
-        Tensor::new(Some(&mask), &[1, seq_len]).unwrap(),
-    ]
 }
 
 // ── Printing helpers ──────────────────────────────────────────────────────────

--- a/atlas-onnx-tracer/examples/qwen_generate.rs
+++ b/atlas-onnx-tracer/examples/qwen_generate.rs
@@ -21,17 +21,7 @@ const N_TOKENS: usize = 20;
 ///
 /// Runs greedy generation in two modes and prints both outputs side-by-side:
 ///
-/// **TRACT** (f32, ground truth): produces coherent English using Tract's native
-/// f32 inference engine — this is what the model should output.
-///
-/// **QUANT** (i32, our engine): runs the same model through the i32 fixed-point
-/// quantized path. `fused-ops` improvements over the un-fixed baseline:
-///   - Cos/Sin RoPE fix (removed scale=8-specific `const_rem` that corrupted RoPE)
-///   - Scale=16 (4× finer weight quantization than scale=14)
-///   - i64 softmax (`s² = S²` in i64 enabling scale>15)
-///   - Teleportation removed from Sigmoid/Tanh/Erf in fused-ops path
-///
-/// At scale=16 the quantized model produces valid English tokens; further
+/// At scale=20 the quantized model produces valid English tokens; further
 /// precision improvements are needed for fully coherent generation.
 ///
 /// # Setup

--- a/atlas-onnx-tracer/examples/qwen_generate.rs
+++ b/atlas-onnx-tracer/examples/qwen_generate.rs
@@ -1,0 +1,115 @@
+use atlas_onnx_tracer::{
+    model::Model,
+    utils::{
+        qea::{init_logging, make_qwen_i32_inputs, make_run_args, tract_greedy_generate},
+        quantize,
+    },
+};
+use tokenizers::Tokenizer;
+use tracing::info;
+
+const ONNX_PATH: &str = "atlas-onnx-tracer/models/qwen/network.onnx";
+const TOKENIZER_PATH: &str = "atlas-onnx-tracer/models/qwen/tokenizer.json";
+const VOCAB_SIZE: usize = 151936;
+
+const SCALE: i32 = 20;
+
+const DEFAULT_PROMPT: &str = "The quick brown fox";
+const N_TOKENS: usize = 20;
+
+/// Qwen2-0.5B text generation demo.
+///
+/// Runs greedy generation in two modes and prints both outputs side-by-side:
+///
+/// **TRACT** (f32, ground truth): produces coherent English using Tract's native
+/// f32 inference engine — this is what the model should output.
+///
+/// **QUANT** (i32, our engine): runs the same model through the i32 fixed-point
+/// quantized path. `fused-ops` improvements over the un-fixed baseline:
+///   - Cos/Sin RoPE fix (removed scale=8-specific `const_rem` that corrupted RoPE)
+///   - Scale=16 (4× finer weight quantization than scale=14)
+///   - i64 softmax (`s² = S²` in i64 enabling scale>15)
+///   - Teleportation removed from Sigmoid/Tanh/Erf in fused-ops path
+///
+/// At scale=16 the quantized model produces valid English tokens; further
+/// precision improvements are needed for fully coherent generation.
+///
+/// # Setup
+///
+/// ```sh
+/// python scripts/download_qwen.py
+/// ```
+///
+/// # Usage
+///
+/// ```sh
+/// cargo run -r -p atlas-onnx-tracer --features fused-ops --example qwen_generate
+/// ```
+///
+/// Override prompt:
+/// ```sh
+/// QWEN_PROMPT="Once upon a time" cargo run -r -p atlas-onnx-tracer --features fused-ops --example qwen_generate
+/// ```
+fn main() {
+    init_logging();
+
+    let prompt = std::env::var("QWEN_PROMPT").unwrap_or_else(|_| DEFAULT_PROMPT.to_string());
+    let tokenizer = Tokenizer::from_file(TOKENIZER_PATH)
+        .expect("failed to load tokenizer – run scripts/download_qwen.py first");
+
+    let model_label = if ONNX_PATH.contains("gptq") {
+        "Qwen2-0.5B (GPTQ)"
+    } else {
+        "Qwen2-0.5B"
+    };
+    info!("Model  : {model_label}");
+    info!("Prompt : \"{prompt}\"");
+    info!("Tokens : {N_TOKENS}");
+    info!("");
+
+    let encoding = tokenizer.encode(prompt.as_str(), false).expect("tokenize");
+    let prompt_ids: Vec<u32> = encoding.get_ids().to_vec();
+
+    // ── TRACT (f32) generation ──────────────────────────────────────────────
+    info!("TRACT (f32, ground truth):");
+    let tract_ids = tract_greedy_generate(ONNX_PATH, &prompt_ids, N_TOKENS, VOCAB_SIZE);
+    let tract_text = tokenizer
+        .decode(&tract_ids, false)
+        .unwrap_or_else(|_| "<decode error>".to_string());
+    info!("  \"{tract_text}\"");
+    info!("");
+
+    // ── QUANT (i32) generation ──────────────────────────────────────────────
+    info!("QUANT (i32, scale=2^{SCALE}, fused-ops):");
+    let quant_ids = quant_greedy_generate(&prompt_ids, N_TOKENS);
+    let quant_text = tokenizer
+        .decode(&quant_ids, false)
+        .unwrap_or_else(|_| "<decode error>".to_string());
+    info!("  \"{quant_text}\"");
+}
+
+fn quant_greedy_generate(prompt_ids: &[u32], n_tokens: usize) -> Vec<u32> {
+    let mut ids = prompt_ids.to_vec();
+    let scale_mult = quantize::scale_to_multiplier(SCALE);
+    for _ in 0..n_tokens {
+        let seq_len = ids.len();
+        let run_args = make_run_args(seq_len, SCALE);
+        let model = Model::load(ONNX_PATH, &run_args);
+        let inputs = make_qwen_i32_inputs(&ids, seq_len, SCALE);
+        let outputs = model.forward(&inputs);
+        let logits: &[i32] = outputs[0].data();
+        let last_pos = (seq_len - 1) * VOCAB_SIZE;
+        let next = logits[last_pos..last_pos + VOCAB_SIZE]
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| {
+                let ar = **a as f64 / scale_mult;
+                let br = **b as f64 / scale_mult;
+                ar.partial_cmp(&br).unwrap()
+            })
+            .map(|(id, _)| id as u32)
+            .unwrap();
+        ids.push(next);
+    }
+    ids
+}

--- a/atlas-onnx-tracer/src/node/handlers/activation.rs
+++ b/atlas-onnx-tracer/src/node/handlers/activation.rs
@@ -13,11 +13,8 @@ use crate::{
 
 use super::{HandlerContext, OpHandlerFn};
 
-#[cfg(feature = "fused-ops")]
-const NEURAL_TELEPORT_TAU: i32 = 1;
-
-// TODO: These values should be finetuned based on input ranges and desired output precision.
-#[cfg(not(feature = "fused-ops"))]
+// tau=2 halves the LUT size (4·S/tau entries instead of 4·S).
+// Floor-division rounding introduces ≤ 1 quantization unit of error per element.
 const NEURAL_TELEPORT_TAU: i32 = 2;
 
 /// Log2 of the lookup table size used for activation functions.

--- a/atlas-onnx-tracer/src/ops/add.rs
+++ b/atlas-onnx-tracer/src/ops/add.rs
@@ -1,10 +1,30 @@
 use super::{Add, Op};
-use crate::tensor::{self, Tensor};
+use crate::tensor::{Tensor, get_broadcasted_shape};
+use common::parallel::par_enabled;
+use rayon::prelude::*;
 
 impl Op for Add {
     #[tracing::instrument(name = "Add::f", skip_all)]
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        tensor::ops::add(&inputs).unwrap()
+        let mut output = inputs[0].clone();
+        for &rhs in &inputs[1..] {
+            let shape = get_broadcasted_shape(output.dims(), rhs.dims())
+                .expect("Add: incompatible broadcast shapes");
+            let lhs_exp = output.expand(&shape).expect("Add: expand lhs");
+            let rhs_exp = rhs.expand(&shape).expect("Add: expand rhs");
+            let data: Vec<i32> = lhs_exp
+                .data()
+                .par_iter()
+                .zip(rhs_exp.data().par_iter())
+                .with_min_len(par_enabled())
+                .map(|(&a, &b)| {
+                    let sum: i64 = a as i64 + b as i64;
+                    sum.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+                })
+                .collect();
+            output = Tensor::new(Some(&data), &shape).expect("Add: Tensor::new");
+        }
+        output
     }
 
     fn requires_shape_equality(&self) -> bool {

--- a/atlas-onnx-tracer/src/ops/cos.rs
+++ b/atlas-onnx-tracer/src/ops/cos.rs
@@ -6,8 +6,15 @@ use crate::{
 
 impl Op for Cos {
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        let remainder = tensor::ops::nonlinearities::const_rem(inputs[0], FOUR_PI_APPROX);
-        tensor::ops::nonlinearities::cos(&remainder, self.scale.into())
+        #[cfg(feature = "fused-ops")]
+        {
+            tensor::ops::nonlinearities::cos(inputs[0], self.scale.into())
+        }
+        #[cfg(not(feature = "fused-ops"))]
+        {
+            let remainder = tensor::ops::nonlinearities::const_rem(inputs[0], FOUR_PI_APPROX);
+            tensor::ops::nonlinearities::cos(&remainder, self.scale.into())
+        }
     }
 
     fn requires_shape_equality(&self) -> bool {

--- a/atlas-onnx-tracer/src/ops/sin.rs
+++ b/atlas-onnx-tracer/src/ops/sin.rs
@@ -6,8 +6,15 @@ use crate::{
 
 impl Op for Sin {
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        let remainder = tensor::ops::nonlinearities::const_rem(inputs[0], FOUR_PI_APPROX);
-        tensor::ops::nonlinearities::sin(&remainder, self.scale.into())
+        #[cfg(feature = "fused-ops")]
+        {
+            tensor::ops::nonlinearities::sin(inputs[0], self.scale.into())
+        }
+        #[cfg(not(feature = "fused-ops"))]
+        {
+            let remainder = tensor::ops::nonlinearities::const_rem(inputs[0], FOUR_PI_APPROX);
+            tensor::ops::nonlinearities::sin(&remainder, self.scale.into())
+        }
     }
 
     fn requires_shape_equality(&self) -> bool {

--- a/atlas-onnx-tracer/src/ops/softmax.rs
+++ b/atlas-onnx-tracer/src/ops/softmax.rs
@@ -80,11 +80,17 @@ pub fn softmax_last_axis_decomposed(
     let last_dim = *dims.last().unwrap();
     let num_slices: usize = dims.iter().product::<usize>() / last_dim;
     let data = a.data();
+
+    // Under fused-ops, s_sq is i64 so scale can exceed 2^15.
+    #[cfg(not(feature = "fused-ops"))]
     debug_assert!(
         scale <= (1 << 15),
         "scale={scale} must be at most 2^15; i32 intermediates would overflow"
     );
     let s = scale;
+    #[cfg(feature = "fused-ops")]
+    let s_sq: i64 = (s as i64) * (s as i64);
+    #[cfg(not(feature = "fused-ops"))]
     let s_sq = s * s;
     let total = num_slices * last_dim;
 
@@ -163,12 +169,28 @@ pub fn softmax_last_axis_decomposed(
         exp_sum_q.push(sum_exp);
 
         // 5. inv_sum
+        #[cfg(feature = "fused-ops")]
+        let is: i64 = s_sq / (sum_exp as i64);
+        #[cfg(not(feature = "fused-ops"))]
         let is = s_sq / sum_exp;
+        #[cfg(feature = "fused-ops")]
+        inv_sum.push(is as i32);
+        #[cfg(not(feature = "fused-ops"))]
         inv_sum.push(is);
+
         debug_assert!(
             {
-                let ri = s_sq - is * sum_exp;
-                ri >= 0 && ri < sum_exp
+                #[cfg(feature = "fused-ops")]
+                let ok = {
+                    let ri = s_sq - is * (sum_exp as i64);
+                    ri >= 0 && ri < (sum_exp as i64)
+                };
+                #[cfg(not(feature = "fused-ops"))]
+                let ok = {
+                    let ri = s_sq - is * sum_exp;
+                    ri >= 0 && ri < sum_exp
+                };
+                ok
             },
             "r_inv out of range, sum={sum_exp}"
         );
@@ -176,12 +198,24 @@ pub fn softmax_last_axis_decomposed(
         // 6-7. softmax_q and R
         for j in 0..last_dim {
             let idx = offset + j;
-            let product = exp_q[idx] * is; // exp_q[j] · inv_sum
-            let sq = product / s; // ⌊product / S⌋
-            let rem = product - sq * s; // product − sq·S
-            softmax_q[idx] = sq;
-            R[idx] = rem;
-            debug_assert!(rem >= 0 && rem < s, "R out of range: {rem}, S={s}");
+            #[cfg(feature = "fused-ops")]
+            {
+                let product: i64 = (exp_q[idx] as i64) * is;
+                let sq: i64 = product / (s as i64);
+                let rem: i64 = product - sq * (s as i64);
+                softmax_q[idx] = sq as i32;
+                R[idx] = rem as i32;
+                debug_assert!(rem >= 0 && rem < (s as i64), "R out of range: {rem}, S={s}");
+            }
+            #[cfg(not(feature = "fused-ops"))]
+            {
+                let product = exp_q[idx] * is; // exp_q[j] · inv_sum
+                let sq = product / s; // ⌊product / S⌋
+                let rem = product - sq * s; // product − sq·S
+                softmax_q[idx] = sq;
+                R[idx] = rem;
+                debug_assert!(rem >= 0 && rem < s, "R out of range: {rem}, S={s}");
+            }
         }
     }
 

--- a/atlas-onnx-tracer/src/ops/tanh.rs
+++ b/atlas-onnx-tracer/src/ops/tanh.rs
@@ -62,7 +62,7 @@ pub fn generate_tanh_lut(scale: i64) -> Vec<i32> {
 /// Input `a_i` is a fixed-point value at scale `S`.  
 /// Returns `round(tanh(a_i / S) * S)` using odd symmetry + LUT.
 #[inline]
-pub fn tanh_lut_lookup(a_i: i32, scale: i32, lut: &[i32]) -> i32 {
+pub fn tanh_lut_lookup(a_i: i32, lut: &[i32]) -> i32 {
     let abs_val = (a_i.unsigned_abs() as usize).min(lut.len() - 1);
     let magnitude = lut[abs_val];
     if a_i >= 0 { magnitude } else { -magnitude }

--- a/atlas-onnx-tracer/src/ops/tanh.rs
+++ b/atlas-onnx-tracer/src/ops/tanh.rs
@@ -4,6 +4,7 @@ use crate::{
     ops::{Op, Tanh},
     tensor::{self, Tensor},
 };
+#[cfg(not(feature = "fused-ops"))]
 use std::ops::Mul;
 
 impl Op for Tanh {
@@ -14,17 +15,16 @@ impl Op for Tanh {
         #[cfg(feature = "fused-ops")]
         {
             let scale_i = self.scale.0 as i64;
-            let lut = generate_tanh_lut(scale_i);
+            let lut = generate_tanh_lut(scale_i, self.tau);
             input
                 .par_enum_map(|_, a_i| {
-                    Ok::<_, TensorError>(tanh_lut_lookup(a_i, scale_i as i32, &lut))
+                    Ok::<_, TensorError>(tanh_lut_lookup(a_i, &lut))
                 })
                 .unwrap()
         }
         #[cfg(not(feature = "fused-ops"))]
         {
-            // `Tanh` lookup table is built as: Tanh[x] = tanh(x * tau),
-            // so we multiply by tau to reciprocate teleportation division.
+            // Multiply by tau to undo the const_div, then compute float tanh.
             let teleport_recip = input.mul(self.tau).unwrap();
 
             crate::tensor::ops::nonlinearities::tanh(&teleport_recip, self.scale.into())
@@ -36,22 +36,28 @@ impl Op for Tanh {
     }
 }
 
-/// Generate a **tanh** lookup table for an arbitrary fixed-point scale `S`.
+/// Generate a **tanh** lookup table for neural-teleported fixed-point evaluation.
 ///
-/// Entry `i` = `round(tanh(i / S) * S)` for `i ∈ [0, table_size)`.
+/// After `const_div(z, tau)` produces quotient `q = floor(z / tau)`, this table
+/// maps `q → round(tanh(q * tau / S) * S)`.  Because the argument to tanh is
+/// `q * tau ≈ z`, the output approximates `tanh(z / S) * S` with at most
+/// 1 quantization unit of error (from the floor rounding).
+///
 /// Only the non-negative half is stored; `tanh` is odd so the caller
 /// negates the result for negative inputs.
 ///
-/// `tanh(x)` saturates to ±1 for `|x| > ~4`, so the table covers
-/// `[0, 4·S]` — beyond that the output is `±S`.
-pub fn generate_tanh_lut(scale: i64) -> Vec<i32> {
+/// The table covers quotients `q ∈ [0, 4·S / tau]`; beyond that tanh is
+/// saturated (output clamped to `±S`), giving a table `tau`-times smaller
+/// than the un-teleported case.
+pub fn generate_tanh_lut(scale: i64, tau: i32) -> Vec<i32> {
     let sf = scale as f64;
-    // tanh(4) ≈ 0.9993 — close enough to 1.0 for any practical scale.
-    let table_size = (4 * scale) as usize + 1;
+    let tau_f = tau as f64;
+    // tanh saturates at |q * tau / S| ≥ 4, i.e. |q| ≥ 4 * S / tau.
+    let table_size = (4 * scale / tau as i64) as usize + 1;
 
     let mut lut = vec![0i32; table_size];
     for i in 0..table_size {
-        let x = i as f64 / sf;
+        let x = i as f64 * tau_f / sf; // q * tau / scale
         lut[i] = (sf * x.tanh()).round() as i32;
     }
     *lut.last_mut().unwrap() = scale as i32;

--- a/atlas-onnx-tracer/src/ops/tanh.rs
+++ b/atlas-onnx-tracer/src/ops/tanh.rs
@@ -54,6 +54,7 @@ pub fn generate_tanh_lut(scale: i64) -> Vec<i32> {
         let x = i as f64 / sf;
         lut[i] = (sf * x.tanh()).round() as i32;
     }
+    *lut.last_mut().unwrap() = scale as i32;
     lut
 }
 
@@ -62,12 +63,8 @@ pub fn generate_tanh_lut(scale: i64) -> Vec<i32> {
 /// Returns `round(tanh(a_i / S) * S)` using odd symmetry + LUT.
 #[inline]
 pub fn tanh_lut_lookup(a_i: i32, scale: i32, lut: &[i32]) -> i32 {
-    let abs_val = a_i.unsigned_abs() as usize;
-    let magnitude = if abs_val < lut.len() {
-        lut[abs_val]
-    } else {
-        scale // saturates to ±1
-    };
+    let abs_val = (a_i.unsigned_abs() as usize).min(lut.len() - 1);
+    let magnitude = lut[abs_val];
     if a_i >= 0 { magnitude } else { -magnitude }
 }
 

--- a/atlas-onnx-tracer/src/ops/tanh.rs
+++ b/atlas-onnx-tracer/src/ops/tanh.rs
@@ -17,9 +17,7 @@ impl Op for Tanh {
             let scale_i = self.scale.0 as i64;
             let lut = generate_tanh_lut(scale_i, self.tau);
             input
-                .par_enum_map(|_, a_i| {
-                    Ok::<_, TensorError>(tanh_lut_lookup(a_i, &lut))
-                })
+                .par_enum_map(|_, a_i| Ok::<_, TensorError>(tanh_lut_lookup(a_i, &lut)))
                 .unwrap()
         }
         #[cfg(not(feature = "fused-ops"))]

--- a/atlas-onnx-tracer/src/utils/mod.rs
+++ b/atlas-onnx-tracer/src/utils/mod.rs
@@ -10,4 +10,6 @@ pub mod parser;
 pub mod precision;
 /// Pretty-printing utilities for displaying tensors and models.
 pub mod pretty_print;
+/// Quantization Error Analysis (QEA) utilities: shared code for analyzing and improving quantization precision, and for running generation with both quantized and unquantized models.
+pub mod qea;
 pub mod quantize;

--- a/atlas-onnx-tracer/src/utils/qea.rs
+++ b/atlas-onnx-tracer/src/utils/qea.rs
@@ -117,8 +117,7 @@ pub fn print_comparison_metrics(a: &[f64], b: &[f64], pad: &str) {
 
 /// Return `(token_id, logit)` pairs sorted descending by logit.
 pub fn top_k_entries(logits: &[f64], k: usize) -> Vec<(usize, f64)> {
-    let mut indexed: Vec<(usize, f64)> =
-        logits.iter().enumerate().map(|(i, &v)| (i, v)).collect();
+    let mut indexed: Vec<(usize, f64)> = logits.iter().enumerate().map(|(i, &v)| (i, v)).collect();
     indexed.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
     indexed.truncate(k);
     indexed

--- a/atlas-onnx-tracer/src/utils/qea.rs
+++ b/atlas-onnx-tracer/src/utils/qea.rs
@@ -1,0 +1,289 @@
+/// Shared helpers used across quantization-analysis and generation examples.
+///
+/// Factored out here to avoid copying boilerplate between
+/// `quant_error_analysis`, `quant_error_analysis_qwen`, and `qwen_generate`.
+use crate::{
+    model::{Model, RunArgs, shadow_trace::ShadowTrace},
+    tensor::Tensor,
+    utils::metrics,
+};
+use tracing::{debug, info};
+use tracing_subscriber::EnvFilter;
+
+/// Heavy section separator line.
+pub const SEP: &str = "═══════════════════════════════════════════════════════════";
+/// Thin sub-section separator line.
+pub const THIN: &str = "───────────────────────────────────────────────────────────";
+
+/// Per-node shadow trace together with extracted last-position logits.
+pub struct ShadowResult {
+    /// The full per-node shadow trace.
+    pub trace: ShadowTrace,
+    /// Last-position logits extracted from the final shadow node.
+    pub logits: Vec<f64>,
+}
+
+// ── Logging ──────────────────────────────────────────────────────────────────
+
+/// Initialise `tracing-subscriber` silencing tract crate noise by default.
+/// Override with `RUST_LOG`.
+pub fn init_logging() {
+    let tract_suppressions = [
+        "tract_core=warn",
+        "tract_data=warn",
+        "tract_hir=warn",
+        "tract_linalg=warn",
+        "tract_nnef=warn",
+        "tract_onnx=warn",
+        "tract_onnx_opl=warn",
+        "tract_extra=warn",
+        "tract_pulse=warn",
+        "tract_pulse_opl=warn",
+    ];
+    let base = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+    let combined = format!("{},{}", base, tract_suppressions.join(","));
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new(combined))
+        .with_target(false)
+        .without_time()
+        .init();
+}
+
+// ── Section / step banners ────────────────────────────────────────────────────
+
+/// Print a titled section banner.
+pub fn print_section(title: &str) {
+    info!("\n");
+    info!("{SEP}");
+    info!("  {title}");
+    info!("{SEP}");
+}
+
+/// Print a numbered step header (`[n/N] title`).
+pub fn print_step(n: usize, title: &str) {
+    info!("\n");
+    info!("{SEP}");
+    info!("  [{n}/5] {title}");
+    info!("{SEP}");
+}
+
+// ── Logit metrics ─────────────────────────────────────────────────────────────
+
+/// Print a standard suite of comparison metrics between two logit vectors.
+pub fn print_comparison_metrics(a: &[f64], b: &[f64], pad: &str) {
+    info!(
+        "{pad}Cosine similarity   : {:.6}",
+        metrics::cosine_similarity(a, b)
+    );
+    info!("{pad}MSE                 : {:.6}", metrics::mse(a, b));
+    info!("{pad}RMSE                : {:.6}", metrics::rmse(a, b));
+    info!(
+        "{pad}Max absolute error  : {:.6}",
+        metrics::max_abs_error(a, b)
+    );
+    info!(
+        "{pad}Mean absolute error : {:.6}",
+        metrics::mean_abs_error(a, b)
+    );
+    info!(
+        "{pad}Relative MSE        : {:.6}",
+        metrics::relative_mse(a, b)
+    );
+    info!(
+        "{pad}KL divergence       : {:.6}",
+        metrics::kl_divergence_from_logits(a, b)
+    );
+    info!(
+        "{pad}Top-1 agreement     : {:.2}%",
+        metrics::top_k_agreement(a, b, 1) * 100.0
+    );
+    info!(
+        "{pad}Top-5 agreement     : {:.2}%",
+        metrics::top_k_agreement(a, b, 5) * 100.0
+    );
+    info!(
+        "{pad}Top-10 agreement    : {:.2}%",
+        metrics::top_k_agreement(a, b, 10) * 100.0
+    );
+    info!(
+        "{pad}Spearman rank corr  : {:.6}",
+        metrics::spearman_rank_correlation(a, b)
+    );
+    info!(
+        "{pad}Pearson correlation : {:.6}",
+        metrics::pearson_correlation(a, b)
+    );
+}
+
+/// Return `(token_id, logit)` pairs sorted descending by logit.
+pub fn top_k_entries(logits: &[f64], k: usize) -> Vec<(usize, f64)> {
+    let mut indexed: Vec<(usize, f64)> =
+        logits.iter().enumerate().map(|(i, &v)| (i, v)).collect();
+    indexed.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    indexed.truncate(k);
+    indexed
+}
+
+// ── Logit extraction ──────────────────────────────────────────────────────────
+
+/// Extract last-position logits from an f32 output tensor, cast to f64.
+pub fn last_position_logits_f32(data: &[f32], start: usize, vocab_size: usize) -> Vec<f64> {
+    data[start..start + vocab_size]
+        .iter()
+        .map(|&v| v as f64)
+        .collect()
+}
+
+/// Extract last-position logits from an i32 output tensor, dequantized to f64.
+pub fn last_position_logits_i32(
+    data: &[i32],
+    start: usize,
+    vocab_size: usize,
+    scale_mult: f64,
+) -> Vec<f64> {
+    data[start..start + vocab_size]
+        .iter()
+        .map(|&v| v as f64 / scale_mult)
+        .collect()
+}
+
+/// Extract the final-node f64 logits from a shadow trace.
+pub fn extract_shadow_logits(
+    shadow: &ShadowTrace,
+    label: &str,
+    last_pos_start: usize,
+    vocab_size: usize,
+) -> Vec<f64> {
+    let &node_idx = shadow.f64_outputs.keys().next_back().unwrap();
+    let tensor = &shadow.f64_outputs[&node_idx];
+    let data = tensor.data();
+    debug!(
+        label,
+        node_idx,
+        shape = ?tensor.dims(),
+        numel = data.len(),
+        "Shadow output"
+    );
+    data[last_pos_start..last_pos_start + vocab_size].to_vec()
+}
+
+// ── Input construction ────────────────────────────────────────────────────────
+
+/// Build the basic `RunArgs` (batch=1, no padding) with the given scale.
+pub fn make_run_args(seq_len: usize, scale: i32) -> RunArgs {
+    RunArgs::new([
+        ("batch_size", 1),
+        ("sequence_length", seq_len),
+        ("past_sequence_length", 0),
+    ])
+    .set_scale(scale)
+    .with_padding(false)
+}
+
+/// Prepare f64 shadow input tensors: `[input_ids, position_ids, attention_mask]`.
+pub fn make_f64_inputs(token_ids: &[u32], seq_len: usize) -> Vec<Tensor<f64>> {
+    let ids: Vec<f64> = token_ids.iter().map(|&id| id as f64).collect();
+    let pos: Vec<f64> = (0..seq_len).map(|i| i as f64).collect();
+    let mask: Vec<f64> = vec![1.0; seq_len];
+    vec![
+        Tensor::new(Some(&ids), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&pos), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&mask), &[1, seq_len]).unwrap(),
+    ]
+}
+
+/// Prepare Qwen-style quantized i32 inputs: `[input_ids, position_ids, attention_mask]`.
+///
+/// Position IDs are scaled (`i << scale`) to match RoPE Einsum expectations.
+pub fn make_qwen_i32_inputs(token_ids: &[u32], seq_len: usize, scale: i32) -> Vec<Tensor<i32>> {
+    let ids: Vec<i32> = token_ids.iter().map(|&id| id as i32).collect();
+    // position_ids in fixed-point: i × 2^scale so Einsum(freq_q, pos_q)/2^scale = freq × i
+    let pos: Vec<i32> = (0..seq_len as i32).map(|i| i << scale).collect();
+    let mask: Vec<i32> = vec![1 << scale; seq_len];
+    vec![
+        Tensor::new(Some(&ids), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&pos), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&mask), &[1, seq_len]).unwrap(),
+    ]
+}
+
+// ── Tract helpers ─────────────────────────────────────────────────────────────
+
+/// Run the Tract f32 reference forward pass for `[input_ids, attention_mask, position_ids]`.
+pub fn run_tract_f32(
+    onnx_path: &str,
+    token_ids: &[u32],
+    seq_len: usize,
+    run_args: &RunArgs,
+) -> Vec<Tensor<f32>> {
+    let f32_ids: Vec<f32> = token_ids.iter().map(|&id| id as f32).collect();
+    let f32_mask: Vec<f32> = vec![1.0; seq_len];
+    let f32_pos: Vec<f32> = (0..seq_len as i64).map(|i| i as f32).collect();
+    Model::run_tract_forward(
+        onnx_path,
+        run_args,
+        &[
+            (
+                "input_ids",
+                Tensor::new(Some(&f32_ids), &[1, seq_len]).unwrap(),
+            ),
+            (
+                "attention_mask",
+                Tensor::new(Some(&f32_mask), &[1, seq_len]).unwrap(),
+            ),
+            (
+                "position_ids",
+                Tensor::new(Some(&f32_pos), &[1, seq_len]).unwrap(),
+            ),
+        ],
+    )
+}
+
+/// Greedy-decode `n_tokens` using the Tract f32 model.
+pub fn tract_greedy_generate(
+    onnx_path: &str,
+    prompt_ids: &[u32],
+    n_tokens: usize,
+    vocab_size: usize,
+) -> Vec<u32> {
+    let mut ids = prompt_ids.to_vec();
+    for _ in 0..n_tokens {
+        let len = ids.len();
+        let run_args = RunArgs::new([
+            ("batch_size", 1),
+            ("sequence_length", len),
+            ("past_sequence_length", 0),
+        ])
+        .with_padding(false);
+
+        let f32_ids: Vec<f32> = ids.iter().map(|&id| id as f32).collect();
+        let f32_mask: Vec<f32> = vec![1.0; len];
+        let f32_pos: Vec<f32> = (0..len as i64).map(|i| i as f32).collect();
+
+        let outs = Model::run_tract_forward(
+            onnx_path,
+            &run_args,
+            &[
+                ("input_ids", Tensor::new(Some(&f32_ids), &[1, len]).unwrap()),
+                (
+                    "attention_mask",
+                    Tensor::new(Some(&f32_mask), &[1, len]).unwrap(),
+                ),
+                (
+                    "position_ids",
+                    Tensor::new(Some(&f32_pos), &[1, len]).unwrap(),
+                ),
+            ],
+        );
+        let logits = outs[0].data();
+        let start = (len - 1) * vocab_size;
+        let next = logits[start..start + vocab_size]
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .unwrap()
+            .0 as u32;
+        ids.push(next);
+    }
+    ids
+}

--- a/atlas-onnx-tracer/src/utils/qea.rs
+++ b/atlas-onnx-tracer/src/utils/qea.rs
@@ -197,6 +197,11 @@ pub fn make_f64_inputs(token_ids: &[u32], seq_len: usize) -> Vec<Tensor<f64>> {
 pub fn make_qwen_i32_inputs(token_ids: &[u32], seq_len: usize, scale: i32) -> Vec<Tensor<i32>> {
     let ids: Vec<i32> = token_ids.iter().map(|&id| id as i32).collect();
     // position_ids in fixed-point: i × 2^scale so Einsum(freq_q, pos_q)/2^scale = freq × i
+    let max_pos = (i32::MAX >> scale) as usize;
+    assert!(
+        seq_len.saturating_sub(1) <= max_pos,
+        "make_qwen_i32_inputs: seq_len={seq_len} too large for scale={scale} (max position index {max_pos})"
+    );
     let pos: Vec<i32> = (0..seq_len as i32).map(|i| i << scale).collect();
     let mask: Vec<i32> = vec![1 << scale; seq_len];
     vec![


### PR DESCRIPTION
I tried several approached to reduce quant error. The best results came from simply increasing scale and fixing resulting overflow panics.

`SCALE=8`:
```
 INFO   Cosine similarity   : 0.695232
 INFO   MSE                 : 7.248738
 INFO   RMSE                : 2.692348
 INFO   Max absolute error  : 14.965368
 INFO   Mean absolute error : 2.088616
 INFO   Relative MSE        : 0.948853
 INFO   KL divergence       : 4.606529
 INFO   Top-1 agreement     : 0.00%
 INFO   Top-5 agreement     : 20.00%
 INFO   Top-10 agreement    : 20.00%
 INFO   Spearman rank corr  : 0.386522
 INFO   Pearson correlation : 0.388934
```

`SCALE=14`:
```
 INFO   Cosine similarity   : 0.997492
 INFO   MSE                 : 0.070934
 INFO   RMSE                : 0.266335
 INFO   Max absolute error  : 1.320830
 INFO   Mean absolute error : 0.209358
 INFO   Relative MSE        : 0.009285
 INFO   KL divergence       : 0.029175
 INFO   Top-1 agreement     : 100.00%
 INFO   Top-5 agreement     : 100.00%
 INFO   Top-10 agreement    : 90.00%
 INFO   Spearman rank corr  : 0.995235
 INFO   Pearson correlation : 0.995790
 ```

`SCALE=20`: 
```
 INFO   Cosine similarity   : 0.999919
 INFO   MSE                 : 0.002294
 INFO   RMSE                : 0.047892
 INFO   Max absolute error  : 0.235706
 INFO   Mean absolute error : 0.038411
 INFO   Relative MSE        : 0.000300
 INFO   KL divergence       : 0.000482
 INFO   Top-1 agreement     : 100.00%
 INFO   Top-5 agreement     : 100.00%
 INFO   Top-10 agreement    : 100.00%
 INFO   Spearman rank corr  : 0.999855
 INFO   Pearson correlation : 0.999874
 ```