### PR TITLE
chore: refactor prefix checkpoints handling

### DIFF
--- a/joltworks/src/lookup_tables/prefixes/and.rs
+++ b/joltworks/src/lookup_tables/prefixes/and.rs
@@ -1,4 +1,4 @@
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     utils::lookup_bits::LookupBits,
@@ -9,7 +9,7 @@ pub enum AndPrefix<const XLEN: usize> {}
 
 impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for AndPrefix<XLEN> {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut b: LookupBits,
@@ -40,7 +40,7 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for AndPrefix<XLEN> {
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/prefixes/eq.rs
+++ b/joltworks/src/lookup_tables/prefixes/eq.rs
@@ -3,14 +3,14 @@ use crate::{
     utils::lookup_bits::LookupBits,
 };
 
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 
 /// Prefix component for equality comparison lookup table decomposition.
 pub enum EqPrefix {}
 
 impl<F: JoltField> SparseDensePrefix<F> for EqPrefix {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut b: LookupBits,
@@ -40,7 +40,7 @@ impl<F: JoltField> SparseDensePrefix<F> for EqPrefix {
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         _: usize,

--- a/joltworks/src/lookup_tables/prefixes/less_than.rs
+++ b/joltworks/src/lookup_tables/prefixes/less_than.rs
@@ -3,14 +3,14 @@ use crate::{
     utils::lookup_bits::LookupBits,
 };
 
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 
 /// Prefix component for less-than comparison lookup table decomposition.
 pub enum LessThanPrefix {}
 
 impl<F: JoltField> SparseDensePrefix<F> for LessThanPrefix {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut b: LookupBits,
@@ -46,7 +46,7 @@ impl<F: JoltField> SparseDensePrefix<F> for LessThanPrefix {
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         _: usize,

--- a/joltworks/src/lookup_tables/prefixes/lower_word_no_msb.rs
+++ b/joltworks/src/lookup_tables/prefixes/lower_word_no_msb.rs
@@ -1,4 +1,4 @@
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     utils::lookup_bits::LookupBits,
@@ -9,7 +9,7 @@ pub enum LowerWordNoMsbPrefix<const XLEN: usize> {}
 
 impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for LowerWordNoMsbPrefix<XLEN> {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut b: LookupBits,
@@ -54,7 +54,7 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for LowerWordNoMsbPre
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/prefixes/mod.rs
+++ b/joltworks/src/lookup_tables/prefixes/mod.rs
@@ -180,13 +180,13 @@ impl<F: JoltField> Index<usize> for PrefixCheckpoints<F> {
     type Output = Option<F>;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.0.get(index).unwrap().0
+        &self.0[index].0
     }
 }
 
 impl<F: JoltField> IndexMut<usize> for PrefixCheckpoints<F> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0.get_mut(index).unwrap().0
+        &mut self.0[index].0
     }
 }
 

--- a/joltworks/src/lookup_tables/prefixes/mod.rs
+++ b/joltworks/src/lookup_tables/prefixes/mod.rs
@@ -18,7 +18,10 @@ use common::parallel::par_enabled;
 use num::FromPrimitive;
 use num_derive::FromPrimitive;
 use rayon::prelude::*;
-use std::{fmt::Display, ops::Index};
+use std::{
+    fmt::Display,
+    ops::{Index, IndexMut},
+};
 use strum::EnumCount;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
@@ -62,7 +65,7 @@ pub trait SparseDensePrefix<F: JoltField>: 'static + Sync {
     /// over these variables as they range over the Boolean hypercube, so
     /// they can be represented by a single bitvector.
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         b: LookupBits,
@@ -78,7 +81,7 @@ pub trait SparseDensePrefix<F: JoltField>: 'static + Sync {
     /// A checkpoint update may depend on the values of the other prefix checkpoints,
     /// so we pass in all such `checkpoints` to this function.
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,
@@ -119,6 +122,26 @@ pub struct PrefixEval<F>(F);
 /// Optional prefix evaluation cached after each pair of address-binding rounds (r_x, r_y).
 pub type PrefixCheckpoint<F: JoltField> = PrefixEval<Option<F>>;
 
+#[derive(Clone)]
+// Stores the checkpoints for all prefixes, updated every two rounds of sumcheck.
+pub struct PrefixCheckpoints<F: JoltField>([PrefixCheckpoint<F>; Prefixes::COUNT]);
+
+impl<F: JoltField> PrefixCheckpoints<F> {
+    pub fn new() -> Self {
+        Self(std::array::from_fn(|_| None.into()))
+    }
+
+    pub fn len(&self) -> usize {
+        Prefixes::COUNT
+    }
+}
+
+impl<F: JoltField> Default for PrefixCheckpoints<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<F: JoltField> std::ops::Mul<F> for PrefixEval<F> {
     type Output = F;
 
@@ -153,6 +176,34 @@ impl<F> PrefixCheckpoint<F> {
     }
 }
 
+impl<F: JoltField> Index<usize> for PrefixCheckpoints<F> {
+    type Output = Option<F>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0.get(index).unwrap().0
+    }
+}
+
+impl<F: JoltField> IndexMut<usize> for PrefixCheckpoints<F> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0.get_mut(index).unwrap().0
+    }
+}
+
+impl<F: JoltField> Index<Prefixes> for PrefixCheckpoints<F> {
+    type Output = Option<F>;
+
+    fn index(&self, prefix: Prefixes) -> &Self::Output {
+        &self[prefix as usize]
+    }
+}
+
+impl<F: JoltField> IndexMut<Prefixes> for PrefixCheckpoints<F> {
+    fn index_mut(&mut self, prefix: Prefixes) -> &mut Self::Output {
+        &mut self[prefix as usize]
+    }
+}
+
 impl<F> Index<Prefixes> for &[PrefixEval<F>] {
     type Output = F;
 
@@ -179,7 +230,7 @@ impl Prefixes {
     /// they can be represented by a single bitvector.
     pub fn prefix_mle<const XLEN: usize, F, C>(
         &self,
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         b: LookupBits,
@@ -213,7 +264,7 @@ impl Prefixes {
     /// This function updates all the prefix checkpoints.
     #[tracing::instrument(skip_all)]
     pub fn update_checkpoints<const XLEN: usize, F, C>(
-        checkpoints: &mut [PrefixCheckpoint<F>],
+        checkpoints: &mut PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,
@@ -223,8 +274,9 @@ impl Prefixes {
         F: JoltField + FieldChallengeOps<C>,
     {
         debug_assert_eq!(checkpoints.len(), Self::COUNT);
-        let previous_checkpoints = checkpoints.to_vec();
+        let previous_checkpoints = checkpoints.clone();
         checkpoints
+            .0
             .par_iter_mut()
             .with_min_len(par_enabled())
             .enumerate()
@@ -248,7 +300,7 @@ impl Prefixes {
     /// so we pass in all such `checkpoints` to this function.
     fn update_prefix_checkpoint<const XLEN: usize, F, C>(
         &self,
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/prefixes/mod.rs
+++ b/joltworks/src/lookup_tables/prefixes/mod.rs
@@ -273,7 +273,6 @@ impl Prefixes {
         C: ChallengeFieldOps<F>,
         F: JoltField + FieldChallengeOps<C>,
     {
-        debug_assert_eq!(checkpoints.len(), Self::COUNT);
         let previous_checkpoints = checkpoints.clone();
         checkpoints
             .0

--- a/joltworks/src/lookup_tables/prefixes/msb.rs
+++ b/joltworks/src/lookup_tables/prefixes/msb.rs
@@ -1,4 +1,4 @@
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     utils::lookup_bits::LookupBits,
@@ -9,7 +9,7 @@ pub enum MsbPrefix<const XLEN: usize> {}
 
 impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for MsbPrefix<XLEN> {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut _b: LookupBits,
@@ -32,7 +32,7 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for MsbPrefix<XLEN> {
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         _r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/prefixes/nlw.rs
+++ b/joltworks/src/lookup_tables/prefixes/nlw.rs
@@ -1,4 +1,4 @@
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     utils::lookup_bits::LookupBits,
@@ -12,7 +12,7 @@ pub enum NotLowerWordPrefix<const XLEN: usize> {}
 
 impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for NotLowerWordPrefix<XLEN> {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut b: LookupBits,
@@ -57,7 +57,7 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for NotLowerWordPrefi
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/prefixes/not_msb.rs
+++ b/joltworks/src/lookup_tables/prefixes/not_msb.rs
@@ -1,4 +1,4 @@
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     utils::lookup_bits::LookupBits,
@@ -9,7 +9,7 @@ pub enum NotMsbPrefix<const XLEN: usize> {}
 
 impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for NotMsbPrefix<XLEN> {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut _b: LookupBits,
@@ -32,7 +32,7 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for NotMsbPrefix<XLEN
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         _r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/prefixes/or.rs
+++ b/joltworks/src/lookup_tables/prefixes/or.rs
@@ -1,4 +1,4 @@
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     utils::lookup_bits::LookupBits,
@@ -9,7 +9,7 @@ pub enum OrPrefix<const XLEN: usize> {}
 
 impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for OrPrefix<XLEN> {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut b: LookupBits,
@@ -40,7 +40,7 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for OrPrefix<XLEN> {
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/prefixes/xor.rs
+++ b/joltworks/src/lookup_tables/prefixes/xor.rs
@@ -1,4 +1,4 @@
-use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+use super::{PrefixCheckpoint, PrefixCheckpoints, Prefixes, SparseDensePrefix};
 use crate::{
     field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
     utils::lookup_bits::LookupBits,
@@ -9,7 +9,7 @@ pub enum XorPrefix<const XLEN: usize> {}
 
 impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for XorPrefix<XLEN> {
     fn prefix_mle<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: Option<C>,
         c: u32,
         mut b: LookupBits,
@@ -41,7 +41,7 @@ impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for XorPrefix<XLEN> {
     }
 
     fn update_prefix_checkpoint<C>(
-        checkpoints: &[PrefixCheckpoint<F>],
+        checkpoints: &PrefixCheckpoints<F>,
         r_x: C,
         r_y: C,
         j: usize,

--- a/joltworks/src/lookup_tables/test.rs
+++ b/joltworks/src/lookup_tables/test.rs
@@ -5,10 +5,10 @@ use crate::{
 use common::consts::XLEN;
 use num::Integer;
 use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
-use strum::{EnumCount, IntoEnumIterator};
+use strum::IntoEnumIterator;
 
 use super::{
-    prefixes::{PrefixCheckpoint, Prefixes},
+    prefixes::{PrefixCheckpoints, Prefixes},
     suffixes::SuffixEval,
     JoltLookupTable, PrefixSuffixDecompositionTrait,
 };
@@ -68,7 +68,7 @@ pub fn prefix_suffix_test<
     let mut rng = StdRng::seed_from_u64(12345);
 
     for _ in 0..300 {
-        let mut prefix_checkpoints: Vec<PrefixCheckpoint<F>> = vec![None.into(); Prefixes::COUNT];
+        let mut prefix_checkpoints = PrefixCheckpoints::new();
         let lookup_index = T::random_lookup_index(&mut rng);
         let mut j = 0;
         let mut r: Vec<F> = vec![];

--- a/joltworks/src/subprotocols/ps_shout.rs
+++ b/joltworks/src/subprotocols/ps_shout.rs
@@ -1,7 +1,7 @@
 use crate::{
     field::{IntoOpening, JoltField, MulTrunc},
     lookup_tables::{
-        prefixes::{PrefixCheckpoint, PrefixEval, Prefixes},
+        prefixes::{PrefixCheckpoints, PrefixEval, Prefixes},
         JoltLookupTable, PrefixSuffixDecompositionTrait,
     },
     poly::{
@@ -41,7 +41,6 @@ use common::{
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::array;
-use strum::EnumCount;
 
 #[cfg(feature = "zk")]
 use crate::subprotocols::blindfold::{
@@ -235,7 +234,7 @@ where
     /// u_evals for read-checking and RAF: eq(r_node_output, j).
     u_evals: Vec<F>,
     /// Prefix checkpoints for each registered `Prefix` variant, updated every two rounds.
-    prefix_checkpoints: Vec<PrefixCheckpoint<F>>,
+    prefix_checkpoints: PrefixCheckpoints<F>,
     /// For each lookup table, dense polynomials holding suffix contributions in the current phase.
     suffix_polys: Vec<DensePolynomial<F>>,
     /// Precomputed lookup keys k (bit-packed) per cycle j.
@@ -277,7 +276,7 @@ where
         let phases = NUM_PHASES;
         let log_m = LOG_K / phases;
         let u_evals = EqPolynomial::evals(&params.r_node_output.r);
-        let prefix_checkpoints = vec![None.into(); Prefixes::COUNT];
+        let prefix_checkpoints = PrefixCheckpoints::new();
         let suffix_polys: Vec<DensePolynomial<F>> = params
             .table
             .suffixes()
@@ -730,7 +729,7 @@ where
                     .table
                     .prefixes()
                     .into_iter()
-                    .map(|p| self.prefix_checkpoints[p as usize].unwrap())
+                    .map(|p| PrefixEval::from(self.prefix_checkpoints[p as usize].unwrap()))
                     .collect();
                 let suffixes: Vec<_> = self
                     .params

--- a/joltworks/src/subprotocols/ps_shout.rs
+++ b/joltworks/src/subprotocols/ps_shout.rs
@@ -729,7 +729,7 @@ where
                     .table
                     .prefixes()
                     .into_iter()
-                    .map(|p| PrefixEval::from(self.prefix_checkpoints[p as usize].unwrap()))
+                    .map(|p| PrefixEval::from(self.prefix_checkpoints[p].unwrap()))
                     .collect();
                 let suffixes: Vec<_> = self
                     .params


### PR DESCRIPTION
Refactors the structure used to hold checkpoint values for each Prefix of the Prefixes enum, used to prove table lookups. 
Concretely, the new structure now allows to have a consistent behavior when indexing the checkpoint array by `usize` and `Prefixes`.

This refactor was conducted while implementing #250, to allow defining a generic Prefix, and have several implementations with different concrete behavior.