### PR TITLE
chore: dedup Sin/Cos Op::f via shared eval_trig helper (#186)

### DIFF
--- a/atlas-onnx-tracer/src/ops/cos.rs
+++ b/atlas-onnx-tracer/src/ops/cos.rs
@@ -1,13 +1,11 @@
 use crate::{
-    model::consts::FOUR_PI_APPROX,
-    ops::{Cos, Op},
+    ops::{Cos, Op, eval_trig},
     tensor::{self, Tensor},
 };
 
 impl Op for Cos {
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        let remainder = tensor::ops::nonlinearities::const_rem(inputs[0], FOUR_PI_APPROX);
-        tensor::ops::nonlinearities::cos(&remainder, self.scale.into())
+        eval_trig(inputs[0], self.scale, tensor::ops::nonlinearities::cos)
     }
 
     fn requires_shape_equality(&self) -> bool {

--- a/atlas-onnx-tracer/src/ops/mod.rs
+++ b/atlas-onnx-tracer/src/ops/mod.rs
@@ -180,6 +180,21 @@ pub trait Op {
     }
 }
 
+/// Shared evaluation for the periodic trig operators ([`Sin`], [`Cos`]).
+///
+/// Both reduce the input modulo a `4π` approximation before applying their
+/// nonlinearity at the operator's scale, so the only thing that differs
+/// between them is the `nonlinearity` function itself.
+pub(crate) fn eval_trig(
+    input: &Tensor<i32>,
+    scale: F32,
+    nonlinearity: fn(&Tensor<i32>, f64) -> Tensor<i32>,
+) -> Tensor<i32> {
+    use crate::{model::consts::FOUR_PI_APPROX, tensor::ops::nonlinearities::const_rem};
+    let remainder = const_rem(input, FOUR_PI_APPROX);
+    nonlinearity(&remainder, scale.into())
+}
+
 impl Op for Operator {
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
         self.inner().f(inputs)

--- a/atlas-onnx-tracer/src/ops/sin.rs
+++ b/atlas-onnx-tracer/src/ops/sin.rs
@@ -1,13 +1,11 @@
 use crate::{
-    model::consts::FOUR_PI_APPROX,
-    ops::{Op, Sin},
+    ops::{Op, Sin, eval_trig},
     tensor::{self, Tensor},
 };
 
 impl Op for Sin {
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        let remainder = tensor::ops::nonlinearities::const_rem(inputs[0], FOUR_PI_APPROX);
-        tensor::ops::nonlinearities::sin(&remainder, self.scale.into())
+        eval_trig(inputs[0], self.scale, tensor::ops::nonlinearities::sin)
     }
 
     fn requires_shape_equality(&self) -> bool {


### PR DESCRIPTION
Closes #186 

Sin and Cos had identical Op::f bodies apart from the nonlinearity called. Extract the shared modulo-4pi reduction into a pub(crate) eval_trig helper and have both ops delegate to it. Output is unchanged (verified by the existing sin/cos precision tests).