### PR TITLE
perf: prove Add/Sub/Neg without a sumcheck (non-ZK path)

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/malicious_prover.rs
+++ b/jolt-atlas-core/src/onnx_proof/malicious_prover.rs
@@ -10,17 +10,12 @@ use atlas_onnx_tracer::{
 };
 use joltworks::{
     field::JoltField,
-    poly::{
-        commitment::commitment_scheme::CommitmentScheme,
-        opening_proof::ProverOpeningAccumulator,
-        unipoly::{CompressedUniPoly, UniPoly},
-    },
+    poly::{commitment::commitment_scheme::CommitmentScheme, unipoly::UniPoly},
     subprotocols::{
         evaluation_reduction::{EvalReductionProof, ReducedInstance},
         sumcheck::SumcheckInstanceProof,
-        sumcheck_prover::SumcheckInstanceProver,
     },
-    transcripts::{AppendToTranscript, Transcript},
+    transcripts::Transcript,
 };
 
 use crate::onnx_proof::{
@@ -172,55 +167,6 @@ impl MaliciousONNXProof {
             }
         }
     }
-}
-
-/// Variant of `Sumcheck::prove` that also returns the final claim and leaves
-/// opening caching to the caller (for adversarial experiments).
-pub fn malicious_sumcheck_prove<F: JoltField, ProofTranscript: Transcript>(
-    sumcheck_instance: &mut dyn SumcheckInstanceProver<F, ProofTranscript>,
-    opening_accumulator: &mut ProverOpeningAccumulator<F>,
-    transcript: &mut ProofTranscript,
-) -> (
-    SumcheckInstanceProof<F, ProofTranscript>,
-    Vec<F::Challenge>,
-    F,
-) {
-    let num_rounds = sumcheck_instance.num_rounds();
-
-    // Append input claims to transcript
-    let input_claim = sumcheck_instance.input_claim(opening_accumulator);
-    transcript.append_scalar(&input_claim);
-    let mut previous_claim = input_claim;
-    let mut r_sumcheck: Vec<F::Challenge> = Vec::with_capacity(num_rounds);
-    let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
-    for round in 0..num_rounds {
-        let univariate_poly = sumcheck_instance.compute_message(round, previous_claim);
-        // append the prover's message to the transcript
-        let compressed_poly = univariate_poly.compress();
-        compressed_poly.append_to_transcript(transcript);
-        let r_j = transcript.challenge_scalar_optimized::<F>();
-        r_sumcheck.push(r_j);
-
-        // Cache claim for this round
-        previous_claim = univariate_poly.evaluate(&r_j);
-        sumcheck_instance.ingest_challenge(r_j, round);
-        compressed_polys.push(compressed_poly);
-    }
-
-    let final_claim = previous_claim;
-
-    // Allow the sumcheck instance to perform any end-of-protocol work (e.g. flushing
-    // delayed bindings) after the final challenge has been ingested and before we cache
-    // openings.
-    sumcheck_instance.finalize();
-
-    // Deliberately do not call `cache_openings` here. The caller controls how
-    // openings and operand claims are cached for attack experiments.
-    (
-        SumcheckInstanceProof::new(compressed_polys),
-        r_sumcheck,
-        final_claim,
-    )
 }
 
 /// Simulate the evaluation reduction protocol, only we just consider the case where num_use = 1 for simplicity.

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -1,6 +1,5 @@
 use crate::{
-    impl_standard_sumcheck_proof_api,
-    onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
+    onnx_proof::{ops::OperatorProofTrait, ProofId, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
 use atlas_onnx_tracer::{
@@ -16,7 +15,9 @@ use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
         eq_poly::EqPolynomial,
-        multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
         opening_proof::{
             OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, VerifierOpeningAccumulator,
             BIG_ENDIAN, LITTLE_ENDIAN,
@@ -33,7 +34,69 @@ use joltworks::{
     utils::errors::ProofVerifyError,
 };
 
-impl_standard_sumcheck_proof_api!(Add, AddParams, AddProver, AddVerifier);
+/// No-sumcheck proof for element-wise addition.
+///
+/// `Add` is linear: `output(x) = left(x) + right(x)` for all `x` on the shared
+/// boolean hypercube, so the multilinear identity `output ≡ left + right` holds
+/// at the (random) output opening point `r` by Schwartz–Zippel. We therefore
+/// skip the sumcheck entirely (cf. [`super::identity`]): the prover opens both
+/// operands at the *same* `r` the output is opened at, and the verifier checks
+/// `left(r) + right(r) == output(r)` directly. The batched HyperKZG opening
+/// proof discharges the operand openings, exactly as for `Identity`.
+///
+/// The sumcheck structs below ([`AddParams`]/[`AddProver`]/[`AddVerifier`]) are
+/// retained because the ZK (BlindFold) path in `onnx_proof::zk` still proves
+/// `Add` via a batched sumcheck; converting that path requires a dedicated
+/// BlindFold algebraic-identity constraint and is tracked separately.
+impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Add {
+    #[tracing::instrument(skip_all, name = "Add::prove")]
+    fn prove(
+        &self,
+        node: &ComputationNode,
+        prover: &mut Prover<F, T>,
+    ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
+        let (opening_point, _claim) =
+            AccOpeningAccessor::new(&prover.accumulator, node).get_reduced_opening();
+
+        let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
+        let [left, right] = operands[..] else {
+            panic!("Expected two operands for Add operation")
+        };
+        let left_claim =
+            MultilinearPolynomial::from(left.padded_next_power_of_two()).evaluate(&opening_point.r);
+        let right_claim = MultilinearPolynomial::from(right.padded_next_power_of_two())
+            .evaluate(&opening_point.r);
+
+        let mut provider = AccOpeningAccessor::new(&mut prover.accumulator, node)
+            .into_provider(&mut prover.transcript, opening_point);
+        provider.append_nodeio(Target::Input(0), left_claim);
+        provider.append_nodeio(Target::Input(1), right_claim);
+        vec![]
+    }
+
+    #[tracing::instrument(skip_all, name = "Add::verify")]
+    fn verify(
+        &self,
+        node: &ComputationNode,
+        verifier: &mut Verifier<'_, F, T>,
+    ) -> Result<(), ProofVerifyError> {
+        let (opening_point, claim) =
+            AccOpeningAccessor::new(&verifier.accumulator, node).get_reduced_opening();
+        let mut provider = AccOpeningAccessor::new(&mut verifier.accumulator, node)
+            .into_provider(&mut verifier.transcript, opening_point);
+        provider.append_nodeio(Target::Input(0));
+        provider.append_nodeio(Target::Input(1));
+        let left_claim = provider.get_nodeio(Target::Input(0)).1;
+        let right_claim = provider.get_nodeio(Target::Input(1)).1;
+
+        if left_claim + right_claim != claim {
+            return Err(ProofVerifyError::InvalidOpeningProof(
+                "Add output claim should equal the sum of operand claims".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
 
 /// Shared parameter block for the element-wise addition sumcheck proof.
 #[derive(Clone)]

--- a/jolt-atlas-core/src/onnx_proof/ops/eval_reduction.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/eval_reduction.rs
@@ -287,10 +287,6 @@ mod tests {
             &mut eval_reduction_proofs,
         );
 
-        // `Sub` is a no-sumcheck op (it only propagates operand openings), so a
-        // Sub-only model emits no execution proof. The eval-reduction proof for
-        // the output node is the artifact that confirms `iop` ran in isolation.
-        assert!(proofs.is_empty());
         assert!(eval_reduction_proofs.contains_key(&output_idx));
     }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/eval_reduction.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/eval_reduction.rs
@@ -287,7 +287,10 @@ mod tests {
             &mut eval_reduction_proofs,
         );
 
-        assert!(!proofs.is_empty());
+        // `Sub` is a no-sumcheck op (it only propagates operand openings), so a
+        // Sub-only model emits no execution proof. The eval-reduction proof for
+        // the output node is the artifact that confirms `iop` ran in isolation.
+        assert!(proofs.is_empty());
         assert!(eval_reduction_proofs.contains_key(&output_idx));
     }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/malicious_sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/malicious_sub.rs
@@ -1,12 +1,14 @@
 //! Malicious variant of the Sub prover for soundness testing.
 //!
-//! This module contains a Sub prover that forges virtual operand claims
-//! while keeping the underlying sumcheck honest. It is used exclusively
-//! by [`MaliciousONNXProof`] to test that the verifier correctly handles
-//! (and rejects) such attacks.
+//! The honest `Sub` proof is a no-sumcheck op (see [`crate::onnx_proof::ops::sub`]):
+//! it opens both operands at the node's reduced output point `r` and the verifier
+//! checks `left(r) - right(r) == output(r)` directly. This module forges the left
+//! operand opening (off by one) so that `left(r) - right(r) != output(r)`, exercising
+//! that the verifier's direct difference check rejects the attack. Used exclusively by
+//! [`MaliciousONNXProof`](crate::onnx_proof::malicious_prover).
 
 use crate::{
-    onnx_proof::{malicious_prover::malicious_sumcheck_prove, ProofId, ProofType, Prover},
+    onnx_proof::{ProofId, Prover},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
 use atlas_onnx_tracer::{
@@ -14,149 +16,38 @@ use atlas_onnx_tracer::{
     node::ComputationNode,
 };
 use joltworks::{
-    field::{IntoOpening, JoltField},
-    poly::{
-        eq_poly::EqPolynomial,
-        multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
-        opening_proof::ProverOpeningAccumulator,
-        split_eq_poly::GruenSplitEqPolynomial,
-        unipoly::UniPoly,
-    },
-    subprotocols::{
-        sumcheck::SumcheckInstanceProof, sumcheck_prover::SumcheckInstanceProver,
-        sumcheck_verifier::SumcheckInstanceParams,
-    },
+    field::JoltField,
+    poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
+    subprotocols::sumcheck::SumcheckInstanceProof,
     transcripts::Transcript,
 };
 
-use crate::onnx_proof::ops::sub::SubParams;
-
 /// Run the malicious Sub prover for a single node.
 ///
-/// Returns the proof entry suitable for insertion into the proof map.
+/// Mirrors the honest no-sumcheck `Sub::prove` but forges the left operand
+/// opening as `left(r) + 1`, leaving the right operand honest. The verifier's
+/// `left - right == output` check then necessarily fails. Returns `vec![]` (no
+/// execution proof), exactly like the honest op.
 pub fn malicious_sub_prove<F: JoltField, T: Transcript>(
     node: &ComputationNode,
     prover: &mut Prover<F, T>,
 ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
-    let params = SubParams::new(node.clone(), &prover.accumulator);
-    let mut prover_sumcheck = MaliciousSubProver::initialize(&prover.trace, params);
+    let (opening_point, _claim) =
+        AccOpeningAccessor::new(&prover.accumulator, node).get_reduced_opening();
 
-    let (proof, r_sumcheck, final_claim) = malicious_sumcheck_prove(
-        &mut prover_sumcheck,
-        &mut prover.accumulator,
-        &mut prover.transcript,
-    );
-    prover_sumcheck.final_claim = Some(final_claim);
-    prover_sumcheck.cache_openings(&mut prover.accumulator, &mut prover.transcript, &r_sumcheck);
-    vec![(ProofId(node.idx, ProofType::Execution), proof)]
-}
+    let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
+    let [left, right] = operands[..] else {
+        panic!("Expected two operands for Sub operation")
+    };
+    let forged_left = MultilinearPolynomial::from(left.padded_next_power_of_two())
+        .evaluate(&opening_point.r)
+        + F::one();
+    let right_claim =
+        MultilinearPolynomial::from(right.padded_next_power_of_two()).evaluate(&opening_point.r);
 
-/// Malicious prover state for element-wise subtraction sumcheck protocol.
-///
-/// Identical to the honest SubProver in sumcheck computation, but forges
-/// operand claims in `cache_openings` to demonstrate the attack vector.
-struct MaliciousSubProver<F: JoltField> {
-    params: SubParams<F>,
-    eq_r_node_output: GruenSplitEqPolynomial<F>,
-    left_operand: MultilinearPolynomial<F>,
-    right_operand: MultilinearPolynomial<F>,
-    final_claim: Option<F>,
-}
-
-impl<F: JoltField> MaliciousSubProver<F> {
-    /// Initialize the prover with trace data and parameters.
-    fn initialize(trace: &Trace, params: SubParams<F>) -> Self {
-        let eq_r_node_output =
-            GruenSplitEqPolynomial::new(&params.r_node_output.r, BindingOrder::LowToHigh);
-        let LayerData {
-            operands,
-            output: _,
-        } = Trace::layer_data(trace, &params.computation_node);
-        let [left_operand, right_operand] = operands[..] else {
-            panic!("Expected two operands for Sub operation")
-        };
-        let left_operand = MultilinearPolynomial::from(left_operand.clone());
-        let right_operand = MultilinearPolynomial::from(right_operand.clone());
-        Self {
-            params,
-            eq_r_node_output,
-            left_operand,
-            right_operand,
-            final_claim: None,
-        }
-    }
-}
-
-impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for MaliciousSubProver<F> {
-    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        &self.params
-    }
-
-    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
-        let Self {
-            eq_r_node_output,
-            left_operand,
-            right_operand,
-            ..
-        } = self;
-        let [q_constant] = eq_r_node_output.par_fold_out_in_unreduced::<9, 1>(&|g| {
-            let lo0 = left_operand.get_bound_coeff(2 * g);
-            let ro0 = right_operand.get_bound_coeff(2 * g);
-            [lo0 - ro0]
-        });
-        eq_r_node_output.gruen_poly_deg_2(q_constant, previous_claim)
-    }
-
-    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
-        self.eq_r_node_output.bind(r_j);
-        self.left_operand
-            .bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.right_operand
-            .bind_parallel(r_j, BindingOrder::LowToHigh);
-    }
-
-    fn cache_openings(
-        &self,
-        accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut T,
-        sumcheck_challenges: &[F::Challenge],
-    ) {
-        let opening_point = self
-            .params
-            .normalize_opening_point(&sumcheck_challenges.into_opening());
-
-        // Malicious behavior: forge virtual operand claims while preserving the
-        // same subtraction difference, so expected_output_claim remains unchanged.
-        let left_claim = self.left_operand.final_claim();
-        let right_claim = self.right_operand.final_claim();
-        let final_claim = self
-            .final_claim
-            .expect("final_claim must be set before cache_openings");
-        let r_node_output_prime = self
-            .params
-            .normalize_opening_point(&sumcheck_challenges.into_opening())
-            .r;
-        let eq_eval = EqPolynomial::mle(&self.params.r_node_output.r, &r_node_output_prime);
-
-        // Choose forged claims so that:
-        // final_claim == eq_eval * (forged_left - forged_right)
-        let forged_left = left_claim + F::one();
-        let forged_right = if eq_eval.is_zero() {
-            // If eq_eval == 0, the only valid final claim is 0.
-            debug_assert!(final_claim.is_zero());
-            right_claim
-        } else {
-            let inv = eq_eval
-                .inverse()
-                .expect("non-zero eq_eval must be invertible");
-            forged_left - final_claim * inv
-        };
-        debug_assert_eq!(final_claim, eq_eval * (forged_left - forged_right));
-        let mut provider = AccOpeningAccessor::new(accumulator, &self.params.computation_node)
-            .into_provider(transcript, opening_point);
-
-        // Insert forged claims while keeping transcript/opener state consistent.
-        provider.append_nodeio(Target::Input(0), forged_left);
-        provider.append_nodeio(Target::Input(1), forged_right);
-    }
+    let mut provider = AccOpeningAccessor::new(&mut prover.accumulator, node)
+        .into_provider(&mut prover.transcript, opening_point);
+    provider.append_nodeio(Target::Input(0), forged_left);
+    provider.append_nodeio(Target::Input(1), right_claim);
+    vec![]
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mod.rs
@@ -109,7 +109,6 @@ use atlas_onnx_tracer::{node::ComputationNode, ops::Operator};
 // Re-export handler types for convenient access
 
 // Re-export operator param/prover/verifier types for the handler macro
-pub use add::{AddParams, AddProver, AddVerifier};
 use common::CommittedPoly;
 pub use cube::{CubeParams, CubeProver, CubeVerifier};
 pub use div::{DivParams, DivProver, DivVerifier};
@@ -122,11 +121,9 @@ use joltworks::{
     utils::errors::ProofVerifyError,
 };
 pub use mul::{MulParams, MulProver, MulVerifier};
-pub use neg::{NegParams, NegProver, NegVerifier};
 pub use rsqrt::{RsqrtParams, RsqrtProver, RsqrtVerifier};
 pub use square::{SquareParams, SquareProver, SquareVerifier};
 use std::collections::BTreeMap;
-pub use sub::{SubParams, SubProver, SubVerifier};
 
 use crate::onnx_proof::{ProofId, Prover, Verifier};
 

--- a/jolt-atlas-core/src/onnx_proof/ops/neg.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/neg.rs
@@ -1,6 +1,5 @@
 use crate::{
-    impl_standard_sumcheck_proof_api,
-    onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
+    onnx_proof::{ops::OperatorProofTrait, ProofId, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
 use atlas_onnx_tracer::{
@@ -16,7 +15,9 @@ use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
         eq_poly::EqPolynomial,
-        multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
         opening_proof::{
             OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, VerifierOpeningAccumulator,
             BIG_ENDIAN, LITTLE_ENDIAN,
@@ -33,7 +34,60 @@ use joltworks::{
     utils::errors::ProofVerifyError,
 };
 
-impl_standard_sumcheck_proof_api!(Neg, NegParams, NegProver, NegVerifier);
+/// No-sumcheck proof for element-wise negation.
+///
+/// `Neg` is linear: `output(x) = -operand(x)` on the shared boolean hypercube,
+/// so the identity holds at the random output opening point `r`. The prover
+/// opens the operand at the same `r`, and the verifier checks
+/// `-operand(r) == output(r)` directly — no sumcheck (cf. [`super::identity`]).
+///
+/// [`NegParams`]/[`NegProver`]/[`NegVerifier`] are retained for the ZK
+/// (BlindFold) path in `onnx_proof::zk`, which still proves `Neg` via a batched
+/// sumcheck; see the note on [`Add`](super::add) for details.
+impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Neg {
+    #[tracing::instrument(skip_all, name = "Neg::prove")]
+    fn prove(
+        &self,
+        node: &ComputationNode,
+        prover: &mut Prover<F, T>,
+    ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
+        let (opening_point, _claim) =
+            AccOpeningAccessor::new(&prover.accumulator, node).get_reduced_opening();
+
+        let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
+        let [operand] = operands[..] else {
+            panic!("Expected one operand for Neg operation")
+        };
+        let operand_claim = MultilinearPolynomial::from(operand.padded_next_power_of_two())
+            .evaluate(&opening_point.r);
+
+        let mut provider = AccOpeningAccessor::new(&mut prover.accumulator, node)
+            .into_provider(&mut prover.transcript, opening_point);
+        provider.append_nodeio(Target::Input(0), operand_claim);
+        vec![]
+    }
+
+    #[tracing::instrument(skip_all, name = "Neg::verify")]
+    fn verify(
+        &self,
+        node: &ComputationNode,
+        verifier: &mut Verifier<'_, F, T>,
+    ) -> Result<(), ProofVerifyError> {
+        let (opening_point, claim) =
+            AccOpeningAccessor::new(&verifier.accumulator, node).get_reduced_opening();
+        let mut provider = AccOpeningAccessor::new(&mut verifier.accumulator, node)
+            .into_provider(&mut verifier.transcript, opening_point);
+        provider.append_nodeio(Target::Input(0));
+        let operand_claim = provider.get_nodeio(Target::Input(0)).1;
+
+        if -operand_claim != claim {
+            return Err(ProofVerifyError::InvalidOpeningProof(
+                "Neg output claim should equal the negation of the operand claim".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
 
 /// Shared parameter block for the element-wise negation sumcheck proof.
 #[derive(Clone)]

--- a/jolt-atlas-core/src/onnx_proof/ops/sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sub.rs
@@ -1,6 +1,5 @@
 use crate::{
-    impl_standard_sumcheck_proof_api,
-    onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
+    onnx_proof::{ops::OperatorProofTrait, ProofId, Prover, Verifier},
     utils::opening_access::{AccOpeningAccessor, Target},
 };
 use atlas_onnx_tracer::{
@@ -16,7 +15,9 @@ use joltworks::{
     field::{IntoOpening, JoltField},
     poly::{
         eq_poly::EqPolynomial,
-        multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
         opening_proof::{
             OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, VerifierOpeningAccumulator,
             BIG_ENDIAN, LITTLE_ENDIAN,
@@ -33,7 +34,65 @@ use joltworks::{
     utils::errors::ProofVerifyError,
 };
 
-impl_standard_sumcheck_proof_api!(Sub, SubParams, SubProver, SubVerifier);
+/// No-sumcheck proof for element-wise subtraction.
+///
+/// `Sub` is linear: `output(x) = left(x) - right(x)` on the shared boolean
+/// hypercube, so the identity holds at the random output opening point `r`. The
+/// prover opens both operands at the same `r`, and the verifier checks
+/// `left(r) - right(r) == output(r)` directly — no sumcheck (cf. [`super::identity`]).
+///
+/// [`SubParams`]/[`SubProver`]/[`SubVerifier`] are retained for the ZK
+/// (BlindFold) path in `onnx_proof::zk`, which still proves `Sub` via a batched
+/// sumcheck; see the note on [`Add`](super::add) for details.
+impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sub {
+    #[tracing::instrument(skip_all, name = "Sub::prove")]
+    fn prove(
+        &self,
+        node: &ComputationNode,
+        prover: &mut Prover<F, T>,
+    ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
+        let (opening_point, _claim) =
+            AccOpeningAccessor::new(&prover.accumulator, node).get_reduced_opening();
+
+        let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
+        let [left, right] = operands[..] else {
+            panic!("Expected two operands for Sub operation")
+        };
+        let left_claim =
+            MultilinearPolynomial::from(left.padded_next_power_of_two()).evaluate(&opening_point.r);
+        let right_claim = MultilinearPolynomial::from(right.padded_next_power_of_two())
+            .evaluate(&opening_point.r);
+
+        let mut provider = AccOpeningAccessor::new(&mut prover.accumulator, node)
+            .into_provider(&mut prover.transcript, opening_point);
+        provider.append_nodeio(Target::Input(0), left_claim);
+        provider.append_nodeio(Target::Input(1), right_claim);
+        vec![]
+    }
+
+    #[tracing::instrument(skip_all, name = "Sub::verify")]
+    fn verify(
+        &self,
+        node: &ComputationNode,
+        verifier: &mut Verifier<'_, F, T>,
+    ) -> Result<(), ProofVerifyError> {
+        let (opening_point, claim) =
+            AccOpeningAccessor::new(&verifier.accumulator, node).get_reduced_opening();
+        let mut provider = AccOpeningAccessor::new(&mut verifier.accumulator, node)
+            .into_provider(&mut verifier.transcript, opening_point);
+        provider.append_nodeio(Target::Input(0));
+        provider.append_nodeio(Target::Input(1));
+        let left_claim = provider.get_nodeio(Target::Input(0)).1;
+        let right_claim = provider.get_nodeio(Target::Input(1)).1;
+
+        if left_claim - right_claim != claim {
+            return Err(ProofVerifyError::InvalidOpeningProof(
+                "Sub output claim should equal the difference of operand claims".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
 
 /// Shared parameter block for the element-wise subtraction sumcheck proof.
 #[derive(Clone)]

--- a/jolt-atlas-core/src/onnx_proof/soundness_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/soundness_tests.rs
@@ -130,14 +130,14 @@ fn duplicate_operand_sub_model(rng: &mut StdRng, t: usize) -> (Model, usize, usi
     (b.build(), x, y)
 }
 
-#[should_panic = "called `Result::unwrap()` on an `Err` value: InvalidOpeningProof(\"Const claim does not match expected claim\")"]
+#[should_panic = "InvalidOpeningProof(\"Sub output claim should equal the difference of operand claims\")"]
 #[test]
 fn soundness_sub_virtual_operand_attack_is_rejected() {
     // This test demonstrates the virtual-operand-claim attack shape:
-    // 1) malicious_sub forges operand claims (writes forged values into
-    //    openings[NodeOutput(input), NodeExecution(sub_node)] via append_virtual)
-    // 2) The forged claim propagates to the input/constant node verification,
-    //    which detects the mismatch against the known values.
+    // 1) malicious_sub forges the left operand opening (off by one) at the node's
+    //    reduced output point, leaving the right operand honest.
+    // 2) Sub is a no-sumcheck op, so the verifier checks `left - right == output`
+    //    directly at that point and rejects the forged opening at the Sub node.
     let t = 1 << 12;
     let mut rng = StdRng::seed_from_u64(0xA77ACCEE);
     let input = Tensor::<i32>::random_small(&mut rng, &[t]);
@@ -162,12 +162,12 @@ fn soundness_sub_virtual_operand_attack_is_rejected() {
         );
     }
 
-    // The forged NodeOutput claims propagate to input/constant verification,
-    // which panics on mismatch.
+    // The verifier's direct `left - right == output` check rejects the forged
+    // opening at the Sub node.
     proof.verify(&verifier_pp, &io, None).unwrap();
 }
 
-#[should_panic = "called `Result::unwrap()` on an `Err` value: InvalidOpeningProof(\"Const claim does not match expected claim\")"]
+#[should_panic = "InvalidOpeningProof(\"Sub output claim should equal the difference of operand claims\")"]
 #[test]
 fn soundness_sub_trace_tamper_3_minus_2_becomes_0_is_rejected() {
     let model = sub_model_const_2();


### PR DESCRIPTION
Closes #174.

`Add`, `Sub`, and `Neg` are linear element-wise ops. The output MLE is a fixed linear combination of the operand MLEs over the same boolean hypercube. Hence `output ≡ Σ±operand` as multilinear polynomials, which by Schwartz–Zippel holds at the already-random output opening point `r`. The per-op sumcheck is therefore redundant.

### Change
These ops now use the no-sumcheck opening-propagation form already used by `Identity`: the prover reads the node's reduced output opening, evaluates the operands at that point `r`, appends them as input openings, and emits **no** execution proof; the verifier checks the linear relation directly (`left+right` / `left-right` / `-operand == output`). Operand openings are discharged by the existing batched HyperKZG opening.

### Scope
The ZK (BlindFold) path still proves these ops via its batched sumcheck — there the algebraic relation is enforced by R1CS constraints derived from the sumcheck `Params`, and the no-sumcheck path has no equivalent constraint yet. So `*Params`/`*Prover`/`*Verifier` are **retained** for the ZK path and `zk.rs` is untouched. A follow-up can add a BlindFold algebraic-identity constraint (cf. the `AlgebraicIdentity` note in `zk.rs`) to drop the sumcheck there too.

### nanoGPT Measurements
Summed prove-span time across the model's 35 `Add`/`Sub` ops:

| | op-prove time |
| --- | --- |
| main (sumcheck) | 44.6 ms |
| this PR (no-sumcheck) | 7.75 ms |

~5.8× faster on those ops (~37 ms off prove). It's a small fraction of nanoGPT's ~2.9 s prove, but scales with residual/LayerNorm-heavy models.

### Soundness
Instead of forging operand claims after a sumcheck, sub soundness test forges the left operand opening directly, so the verifier's direct `left - right == output` check rejects it **at the Sub node** (a tighter rejection than the previous downstream Const-claim mismatch).

### Verification
- `cargo fmt --check`; clippy clean on both `--workspace --all-targets` and
  `-p jolt-atlas-core --features zk --all-targets`.
- `test_add`/`test_sub`/`test_neg` (incl. non-power-of-two) pass.
- Full `jolt-atlas-core` suite (incl. nanoGPT/minigpt/transformer e2e and proof
  serialization) passes.
- `soundness_tests` pass (both Sub `#[should_panic]` tests still reject).
- `--features zk` suite passes (ZK path unchanged).
