### PR TITLE
Add initial CLI release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release CLI binaries
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build ${{ matrix.asset }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: jolt-atlas-linux-x86_64
+          - os: macos-14
+            target: aarch64-apple-darwin
+            asset: jolt-atlas-macos-aarch64
+          - os: macos-13
+            target: x86_64-apple-darwin
+            asset: jolt-atlas-macos-x86_64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset: jolt-atlas-windows-x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+      - name: Build CLI
+        run: cargo build --release --locked --bin jolt-atlas --target ${{ matrix.target }}
+      - name: Package archive
+        shell: bash
+        run: |
+          mkdir -p dist/package
+          bin="target/${{ matrix.target }}/release/jolt-atlas"
+          exe="jolt-atlas"
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            bin="${bin}.exe"
+            exe="jolt-atlas.exe"
+          fi
+          cp "$bin" "dist/package/$exe"
+          tar -czf "dist/${{ matrix.asset }}.tar.gz" -C dist/package "$exe"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: dist/${{ matrix.asset }}.tar.gz
+
+  release:
+    name: Publish release assets
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,19 @@ jobs:
             exe="jolt-atlas.exe"
           fi
           cp "$bin" "dist/package/$exe"
-          tar -czf "dist/${{ matrix.asset }}.tar.gz" -C dist/package "$exe"
+          # Bundle the fixture models the CLI proves against so installed users
+          # can run `jolt-atlas prove <model>` without a repository checkout.
+          for model in nanoGPT microgpt minigpt transformer; do
+            src="atlas-onnx-tracer/models/${model}"
+            if [[ -f "${src}/network.onnx" ]]; then
+              mkdir -p "dist/package/models/${model}"
+              cp "${src}/network.onnx" "dist/package/models/${model}/network.onnx"
+            else
+              echo "missing fixture: ${src}/network.onnx" >&2
+              exit 1
+            fi
+          done
+          tar -czf "dist/${{ matrix.asset }}.tar.gz" -C dist/package .
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,8 +1176,11 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 name = "jolt-atlas"
 version = "0.1.0"
 dependencies = [
+ "atlas-onnx-tracer",
  "bincode 2.0.1",
+ "common",
  "jolt-atlas-core",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,10 @@ bincode = { version = "2.0.1", features = ["serde"] }
 
 
 [dependencies]
+atlas-onnx-tracer.workspace = true
+common.workspace = true
 jolt-atlas-core = { path = "./jolt-atlas-core" }
+rand = { workspace = true, features = ["std_rng"] }
 
 [profile.test]
 opt-level = 3

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="ICME-Lab/jolt-atlas"
+BIN="jolt-atlas"
+VERSION="${JOLT_ATLAS_VERSION:-latest}"
+INSTALL_DIR="${JOLT_ATLAS_INSTALL_DIR:-$HOME/.local/bin}"
+
+case "$(uname -s)" in
+  Linux) os="linux" ;;
+  Darwin) os="macos" ;;
+  MINGW*|MSYS*|CYGWIN*) os="windows" ;;
+  *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) arch="x86_64" ;;
+  arm64|aarch64) arch="aarch64" ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+if [ "$VERSION" = "latest" ]; then
+  url="https://github.com/$REPO/releases/latest/download/${BIN}-${os}-${arch}.tar.gz"
+else
+  url="https://github.com/$REPO/releases/download/$VERSION/${BIN}-${os}-${arch}.tar.gz"
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$INSTALL_DIR"
+
+echo "Downloading $url"
+curl -fsSL "$url" | tar -xz -C "$tmp"
+install -m 0755 "$tmp/$BIN" "$INSTALL_DIR/$BIN"
+echo "Installed $BIN to $INSTALL_DIR/$BIN"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,10 +6,13 @@ BIN="jolt-atlas"
 VERSION="${JOLT_ATLAS_VERSION:-latest}"
 INSTALL_DIR="${JOLT_ATLAS_INSTALL_DIR:-$HOME/.local/bin}"
 
+# Name of the executable inside the archive. Overridden to jolt-atlas.exe on Windows.
+BIN_FILE="$BIN"
+
 case "$(uname -s)" in
   Linux) os="linux" ;;
   Darwin) os="macos" ;;
-  MINGW*|MSYS*|CYGWIN*) os="windows" ;;
+  MINGW*|MSYS*|CYGWIN*) os="windows"; BIN_FILE="${BIN}.exe" ;;
   *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
 esac
 
@@ -17,6 +20,19 @@ case "$(uname -m)" in
   x86_64|amd64) arch="x86_64" ;;
   arm64|aarch64) arch="aarch64" ;;
   *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Guard against (os, arch) combinations the release workflow does not build,
+# so users get a clear message instead of a confusing 404 from the download.
+supported="linux-x86_64 macos-x86_64 macos-aarch64 windows-x86_64"
+case " $supported " in
+  *" ${os}-${arch} "*) ;;
+  *)
+    echo "no prebuilt binary for ${os}-${arch}." >&2
+    echo "Prebuilt targets: ${supported}." >&2
+    echo "Build from source with: cargo install --git https://github.com/$REPO jolt-atlas" >&2
+    exit 1
+    ;;
 esac
 
 if [ "$VERSION" = "latest" ]; then
@@ -31,5 +47,14 @@ mkdir -p "$INSTALL_DIR"
 
 echo "Downloading $url"
 curl -fsSL "$url" | tar -xz -C "$tmp"
-install -m 0755 "$tmp/$BIN" "$INSTALL_DIR/$BIN"
-echo "Installed $BIN to $INSTALL_DIR/$BIN"
+install -m 0755 "$tmp/$BIN_FILE" "$INSTALL_DIR/$BIN_FILE"
+echo "Installed $BIN_FILE to $INSTALL_DIR/$BIN_FILE"
+
+# The CLI needs its fixture models. If the archive bundled a models/ directory,
+# install it next to the binary so 'jolt-atlas prove <model>' works out of the box.
+if [ -d "$tmp/models" ]; then
+  dest_models="$INSTALL_DIR/models"
+  rm -rf "$dest_models"
+  cp -R "$tmp/models" "$dest_models"
+  echo "Installed bundled models to $dest_models"
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,128 @@
+use atlas_onnx_tracer::{model::Model, tensor::Tensor};
+use common::utils::logging::setup_tracing;
+use jolt_atlas_core::onnx_proof::{
+    AtlasProverPreprocessing, AtlasSharedPreprocessing, AtlasVerifierPreprocessing,
+    Blake2bTranscript, Bn254, Fr, HyperKZG, ONNXProof,
+};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::{env, process};
+
+const USAGE: &str = "jolt-atlas - prove and verify bundled ONNX fixtures
+
+Usage:
+  jolt-atlas prove <model> [--trace | --trace-terminal]
+  jolt-atlas --help
+
+Bundled models:
+  nanoGPT       small GPT fixture
+  microgpt      tiny GPT fixture
+  minigpt       small GPT fixture
+  transformer   self-attention fixture
+
+Examples:
+  jolt-atlas prove nanoGPT
+  jolt-atlas prove transformer --trace-terminal
+";
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    match args.get(1).map(String::as_str) {
+        Some("prove") => {
+            let Some(model) = args.get(2).map(String::as_str) else {
+                eprintln!("missing model name\n\n{USAGE}");
+                process::exit(2);
+            };
+            if let Err(err) = prove_fixture(model) {
+                eprintln!("error: {err}");
+                eprintln!("\n{USAGE}");
+                process::exit(2);
+            }
+        }
+        Some("-h") | Some("--help") | None => print!("{USAGE}"),
+        Some(other) => {
+            eprintln!("unknown command: {other}\n\n{USAGE}");
+            process::exit(2);
+        }
+    }
+}
+
+fn prove_fixture(model: &str) -> Result<(), String> {
+    match model {
+        "nanoGPT" | "nanogpt" => prove_gpt_fixture(
+            "nanoGPT",
+            "atlas-onnx-tracer/models/nanoGPT/network.onnx",
+            64,
+            1 << 5,
+            -20..=20,
+            0x1096,
+        ),
+        "microgpt" => prove_gpt_fixture(
+            "microGPT",
+            "atlas-onnx-tracer/models/microgpt/network.onnx",
+            16,
+            0,
+            0..=31,
+            0x42,
+        ),
+        "minigpt" => prove_gpt_fixture(
+            "miniGPT",
+            "atlas-onnx-tracer/models/minigpt/network.onnx",
+            32,
+            0,
+            0..=1023,
+            0x44,
+        ),
+        "transformer" => prove_transformer(),
+        other => Err(format!("unsupported bundled model: {other}")),
+    }
+}
+
+fn prove_gpt_fixture(
+    title: &str,
+    model_path: &str,
+    block_size: usize,
+    offset: i32,
+    range: std::ops::RangeInclusive<i32>,
+    seed: u64,
+) -> Result<(), String> {
+    let (_guard, _tracing_enabled) = setup_tracing(&format!("{title} ONNX Proof"));
+    let mut rng = StdRng::seed_from_u64(seed);
+    let input_data: Vec<i32> = (0..block_size)
+        .map(|_| offset + rng.gen_range(range.clone()))
+        .collect();
+    let input = Tensor::new(Some(&input_data), &[1, block_size]).map_err(|err| err.to_string())?;
+    prove_and_verify(model_path, vec![input])
+}
+
+fn prove_transformer() -> Result<(), String> {
+    let (_guard, _tracing_enabled) = setup_tracing("Transformer ONNX Proof");
+    let mut rng = StdRng::seed_from_u64(0x1096);
+    let input_data: Vec<i32> = (0..64 * 64)
+        .map(|_| (1 << 7) + rng.gen_range(-50..=50))
+        .collect();
+    let input = Tensor::new(Some(&input_data), &[1, 64, 64]).map_err(|err| err.to_string())?;
+    prove_and_verify(
+        "atlas-onnx-tracer/models/transformer/network.onnx",
+        vec![input],
+    )
+}
+
+fn prove_and_verify(model_path: &str, inputs: Vec<Tensor<i32>>) -> Result<(), String> {
+    let model = Model::load(model_path, &Default::default());
+    let pp = AtlasSharedPreprocessing::preprocess(model);
+    let prover_preprocessing = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+
+    let timing = std::time::Instant::now();
+    let (proof, io, _debug_info) =
+        ONNXProof::<Fr, Blake2bTranscript, HyperKZG<Bn254>>::prove(&prover_preprocessing, &inputs);
+    println!("Proof generation took {:.2?}", timing.elapsed());
+
+    let verifier_preprocessing =
+        AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_preprocessing);
+    proof
+        .verify(&verifier_preprocessing, &io, None)
+        .map_err(|err| format!("proof verification failed: {err:?}"))?;
+    println!("Proof verified successfully!");
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,11 @@ use jolt_atlas_core::onnx_proof::{
     Blake2bTranscript, Bn254, Fr, HyperKZG, ONNXProof,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::{env, process};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process,
+};
 
 const USAGE: &str = "jolt-atlas - prove and verify bundled ONNX fixtures
 
@@ -22,6 +26,14 @@ Bundled models:
 Examples:
   jolt-atlas prove nanoGPT
   jolt-atlas prove transformer --trace-terminal
+
+Model resolution:
+  Fixture ONNX files are looked up in the first existing location of:
+    1. $JOLT_ATLAS_MODELS_DIR
+    2. <dir-of-executable>/models  (bundled in release archives)
+    3. <dir-of-executable>/../models
+    4. atlas-onnx-tracer/models    (repository checkout)
+  Override the search explicitly with JOLT_ATLAS_MODELS_DIR.
 ";
 
 fn main() {
@@ -47,32 +59,68 @@ fn main() {
     }
 }
 
+/// Resolve the directory that contains the bundled fixture models.
+///
+/// Installed users receive the fixtures alongside the binary (see the release
+/// workflow), so we search next to the executable before falling back to the
+/// repository layout used during development.
+fn models_dir() -> Result<PathBuf, String> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    if let Some(dir) = env::var_os("JOLT_ATLAS_MODELS_DIR") {
+        candidates.push(PathBuf::from(dir));
+    }
+
+    if let Ok(exe) = env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            candidates.push(exe_dir.join("models"));
+            candidates.push(exe_dir.join("../models"));
+        }
+    }
+
+    candidates.push(PathBuf::from("atlas-onnx-tracer/models"));
+
+    for candidate in &candidates {
+        if candidate.is_dir() {
+            return Ok(candidate.clone());
+        }
+    }
+
+    Err(format!(
+        "could not locate bundled models directory (looked in: {}). \
+         Set JOLT_ATLAS_MODELS_DIR to the directory containing the fixture models.",
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+/// Resolve a fixture-relative ONNX path and verify it exists before use.
+fn fixture_model_path(relative: &str) -> Result<PathBuf, String> {
+    let path = models_dir()?.join(relative);
+    if !path.is_file() {
+        return Err(format!(
+            "model file not found: {} (set JOLT_ATLAS_MODELS_DIR if the fixtures live elsewhere)",
+            path.display()
+        ));
+    }
+    Ok(path)
+}
+
 fn prove_fixture(model: &str) -> Result<(), String> {
     match model {
         "nanoGPT" | "nanogpt" => prove_gpt_fixture(
             "nanoGPT",
-            "atlas-onnx-tracer/models/nanoGPT/network.onnx",
+            "nanoGPT/network.onnx",
             64,
             1 << 5,
             -20..=20,
             0x1096,
         ),
-        "microgpt" => prove_gpt_fixture(
-            "microGPT",
-            "atlas-onnx-tracer/models/microgpt/network.onnx",
-            16,
-            0,
-            0..=31,
-            0x42,
-        ),
-        "minigpt" => prove_gpt_fixture(
-            "miniGPT",
-            "atlas-onnx-tracer/models/minigpt/network.onnx",
-            32,
-            0,
-            0..=1023,
-            0x44,
-        ),
+        "microgpt" => prove_gpt_fixture("microGPT", "microgpt/network.onnx", 16, 0, 0..=31, 0x42),
+        "minigpt" => prove_gpt_fixture("miniGPT", "minigpt/network.onnx", 32, 0, 0..=1023, 0x44),
         "transformer" => prove_transformer(),
         other => Err(format!("unsupported bundled model: {other}")),
     }
@@ -80,36 +128,40 @@ fn prove_fixture(model: &str) -> Result<(), String> {
 
 fn prove_gpt_fixture(
     title: &str,
-    model_path: &str,
+    model_rel: &str,
     block_size: usize,
     offset: i32,
     range: std::ops::RangeInclusive<i32>,
     seed: u64,
 ) -> Result<(), String> {
+    let model_path = fixture_model_path(model_rel)?;
     let (_guard, _tracing_enabled) = setup_tracing(&format!("{title} ONNX Proof"));
     let mut rng = StdRng::seed_from_u64(seed);
     let input_data: Vec<i32> = (0..block_size)
         .map(|_| offset + rng.gen_range(range.clone()))
         .collect();
     let input = Tensor::new(Some(&input_data), &[1, block_size]).map_err(|err| err.to_string())?;
-    prove_and_verify(model_path, vec![input])
+    prove_and_verify(&model_path, vec![input])
 }
 
 fn prove_transformer() -> Result<(), String> {
+    let model_path = fixture_model_path("transformer/network.onnx")?;
     let (_guard, _tracing_enabled) = setup_tracing("Transformer ONNX Proof");
     let mut rng = StdRng::seed_from_u64(0x1096);
     let input_data: Vec<i32> = (0..64 * 64)
         .map(|_| (1 << 7) + rng.gen_range(-50..=50))
         .collect();
     let input = Tensor::new(Some(&input_data), &[1, 64, 64]).map_err(|err| err.to_string())?;
-    prove_and_verify(
-        "atlas-onnx-tracer/models/transformer/network.onnx",
-        vec![input],
-    )
+    prove_and_verify(&model_path, vec![input])
 }
 
-fn prove_and_verify(model_path: &str, inputs: Vec<Tensor<i32>>) -> Result<(), String> {
-    let model = Model::load(model_path, &Default::default());
+fn prove_and_verify(model_path: &Path, inputs: Vec<Tensor<i32>>) -> Result<(), String> {
+    let model = Model::load(
+        model_path
+            .to_str()
+            .ok_or_else(|| format!("model path is not valid UTF-8: {}", model_path.display()))?,
+        &Default::default(),
+    );
     let pp = AtlasSharedPreprocessing::preprocess(model);
     let prover_preprocessing = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
 


### PR DESCRIPTION
## Summary
- add an initial `jolt-atlas` binary with `prove <model>` for bundled fixture models
- add a release workflow that builds tagged CLI archives for Linux, macOS, and Windows
- add a small `scripts/install.sh` helper for downloading release assets

## Notes
This is a conservative first CLI slice for #172. The current repository exposes model-specific proof examples rather than a generic input format, so the binary wraps existing bundled fixture flows instead of inventing a broader ONNX/input CLI contract.

## Verification
- `cargo fmt --all`
- `cargo check --bin jolt-atlas`
- `sh -n scripts/install.sh`
- parsed `.github/workflows/release.yml` with PyYAML

Closes #172.