### PR TITLE
fix(zk): bring the zk path up to date with the non-zk prover (#28 regression from #256)

### DIFF
--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -806,7 +806,7 @@ fn test_square_zk() {
 
     let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
         joltworks::curve::Bn254Curve,
-    >::deterministic(16);
+    >::deterministic(32);
     let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
 
     crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
@@ -1008,7 +1008,7 @@ fn test_zk_rejects_rebound_input_for_square_model() {
 
     let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
         joltworks::curve::Bn254Curve,
-    >::deterministic(16);
+    >::deterministic(32);
 
     // Honest proof for input x.
     let (bundle, mut io) =
@@ -1185,7 +1185,7 @@ fn test_mul_zk() {
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
     let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
         joltworks::curve::Bn254Curve,
-    >::deterministic(16);
+    >::deterministic(32);
     let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
     crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
@@ -1208,7 +1208,7 @@ fn test_cube_zk() {
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
     let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
         joltworks::curve::Bn254Curve,
-    >::deterministic(16);
+    >::deterministic(32);
     let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
     crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("ZK verification should succeed");
@@ -1688,7 +1688,7 @@ fn test_multi_op_arithmetic_chain_zk() {
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
     let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
         joltworks::curve::Bn254Curve,
-    >::deterministic(16);
+    >::deterministic(32);
     let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
     crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("Multi-op arithmetic chain ZK verification should succeed");
@@ -1719,7 +1719,7 @@ fn test_multi_op_mul_div_sub_zk() {
     let verifier_pp = AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_pp);
     let gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
         joltworks::curve::Bn254Curve,
-    >::deterministic(16);
+    >::deterministic(32);
     let (bundle, io) = crate::onnx_proof::zk::prove_zk(&prover_pp, &[input], &gens);
     crate::onnx_proof::zk::verify_zk(&bundle, &verifier_pp, &io, &gens)
         .expect("Multi-op mul/div/sub ZK verification should succeed");
@@ -1736,7 +1736,10 @@ fn test_multi_op_cube_relu_zk() {
     let input = Tensor::<i32>::random_small(&mut rng, &[size]);
     let mut builder = ModelBuilder::new();
     let i = builder.input(vec![size]);
-    let c = builder.cube(i, 1 << 8);
+    // `scale` is the log2 rebase shift (bits = 2·scale, see `rebase_bits`);
+    // the pre-#256 `1 << 8` predates the fused kernel, which now interprets
+    // it as a 512-bit shift.
+    let c = builder.cube(i, 1);
     let out = builder.relu(c);
     builder.mark_output(out);
     let model = builder.build();
@@ -1816,7 +1819,7 @@ fn bench_square_zk_overhead() {
     // ZK prove (single pass: setup + ZK sumcheck + BlindFold)
     let bench_gens = joltworks::poly::commitment::pedersen::PedersenGenerators::<
         joltworks::curve::Bn254Curve,
-    >::deterministic(16);
+    >::deterministic(32);
     let t0 = Instant::now();
     let (bundle, io_zk) =
         crate::onnx_proof::zk::prove_zk(&prover_pp, &[input.clone()], &bench_gens);

--- a/jolt-atlas-core/src/onnx_proof/fused_rebase.rs
+++ b/jolt-atlas-core/src/onnx_proof/fused_rebase.rs
@@ -284,7 +284,9 @@ pub fn verify_post<F: JoltField, T: Transcript>(
 
 /// Re-execute the rescaling remainder `R` (padded to the node-output cycle
 /// domain) and append it as a virtual advice opening at the output point.
-fn cache_remainder_prove<F: JoltField, T: Transcript>(
+/// `pub(crate)`: also used by the ZK flow (`onnx_proof::zk`), where the append
+/// is transcript-quiet (accumulator `zk_mode`).
+pub(crate) fn cache_remainder_prove<F: JoltField, T: Transcript>(
     node: &ComputationNode,
     prover: &mut Prover<F, T>,
 ) {
@@ -297,8 +299,10 @@ fn cache_remainder_prove<F: JoltField, T: Transcript>(
 }
 
 /// Verifier counterpart of [`cache_remainder_prove`]: append the remainder
-/// opening point (its claim is loaded from the proof's opening claims).
-fn cache_remainder_verify<F: JoltField, T: Transcript>(
+/// opening point (its claim is loaded from the proof's opening claims; a
+/// placeholder in ZK mode, where the value reaches the proof only through
+/// the prover-supplied baked initial claims of the following stages).
+pub(crate) fn cache_remainder_verify<F: JoltField, T: Transcript>(
     node: &ComputationNode,
     accumulator: &mut VerifierOpeningAccumulator<F>,
     transcript: &mut T,
@@ -311,7 +315,7 @@ fn cache_remainder_verify<F: JoltField, T: Transcript>(
 
 /// The rescaling remainder `R` as `bits`-bit lookup indices, padded to the
 /// node-output cycle domain.
-fn rebase_remainder_lookup_bits(
+pub(crate) fn rebase_remainder_lookup_bits(
     node: &ComputationNode,
     trace: &Trace,
     bits: i32,

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -76,9 +76,12 @@ impl<F: JoltField> SumcheckInstanceParams<F> for SquareParams<F> {
             .log_2()
     }
 
-    // The input claim is the node's own output evaluation from eval reduction.
-    // This value is baked as a constant in BlindFold's R1CS (not a variable),
-    // so no constraint is needed.
+    // Non-fused: the input claim is the node's own output evaluation from
+    // eval reduction. Fused (`fuses_rebase`): it is `ClampAcc·2^S +
+    // RescaleRemainder` from two prover advices. Either way the value is
+    // baked as a constant in BlindFold's R1CS (not a variable) — like every
+    // chain-start initial claim in the zk pipeline today; a real constraint
+    // over the advice openings is future work.
     #[cfg(feature = "zk")]
     fn input_claim_constraint(&self) -> InputClaimConstraint {
         InputClaimConstraint::default()
@@ -449,6 +452,19 @@ mod tests {
         let nodes = pp.model().nodes();
         let (_, square_node) = nodes.iter().next_back().unwrap();
         NodeEvalReduction::prove(&mut prover, square_node);
+
+        // 4b. The Square node fuses the rescale, so its arithmetic sumcheck's
+        // input claim reads the `ClampAcc`/`RescaleRemainder` advices
+        // (`fused_rebase::fused_input_claim`). Append both, as the zk
+        // pipeline's `prove_fused_rebase_pre_zk` does; the clamp/remainder
+        // stages themselves are covered by `test_square_zk`.
+        crate::onnx_proof::fused_rebase::cache_remainder_prove(square_node, &mut prover);
+        let _ = crate::onnx_proof::clamp_lookups::prove_append_acc(
+            square_node,
+            &prover.trace,
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
 
         // 5. Create SquareProver
         let params = SquareParams::<F>::new(square_node.clone(), &prover.accumulator);

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -936,6 +936,109 @@ fn verify_cos_sin_zk(
     Ok(())
 }
 
+/// Verify the fused-rescaling pre-stages (mirror of `prove_fused_rebase_pre_zk`):
+/// remainder advice, clamp read-raf lookup, clamp one-hot batch.
+fn verify_fused_rebase_pre_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::clamp_lookups::{is_scalar, ClampEncoding, ClampLookupProvider};
+
+    // Mirror of the prover-side panic; see `prove_fused_rebase_pre_zk`.
+    if is_scalar(node) {
+        unimplemented!("ZK verification not yet implemented for scalar fused-rescale nodes");
+    }
+
+    crate::onnx_proof::fused_rebase::cache_remainder_verify(node, accumulator, transcript);
+
+    // Clamp read-raf lookup.
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(
+            *proof_node_idx, node.idx,
+            "ZK sumcheck proof order mismatch"
+        );
+        let provider = ClampLookupProvider::new(node.clone());
+        let execution_verifier = provider.read_raf_verify::<F, T>(accumulator, transcript);
+        verify_zk_sumcheck_instances(
+            zk_proof,
+            vec![Box::new(execution_verifier)],
+            accumulator,
+            transcript,
+        )?;
+        *zk_proof_idx += 1;
+    }
+
+    // Clamp one-hot batch.
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(
+            *proof_node_idx, node.idx,
+            "ZK sumcheck proof order mismatch"
+        );
+        let encoding = ClampEncoding::new(node);
+        let [ra, hw, b] = joltworks::subprotocols::shout::ra_onehot_verifiers(
+            &encoding,
+            &*accumulator,
+            transcript,
+        );
+        verify_zk_sumcheck_instances(zk_proof, vec![ra, hw, b], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+    Ok(())
+}
+
+/// Verify the fused-rescaling post-stages (mirror of `prove_fused_rebase_post_zk`):
+/// remainder identity range check, remainder one-hot batch.
+fn verify_fused_rebase_post_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    bundle: &ZkProofBundle,
+    accumulator: &mut joltworks::poly::opening_proof::VerifierOpeningAccumulator<F>,
+    transcript: &mut T,
+    zk_proof_idx: &mut usize,
+) -> Result<(), ProofVerifyError> {
+    use crate::onnx_proof::fused_rebase::{
+        rebase_bits, RescaleRemainderRCProvider, RescaleRemainderRaEncoding,
+    };
+    use joltworks::subprotocols::identity_range_check::identity_rangecheck_verifier;
+
+    let bits = rebase_bits(&node.operator).expect("fused op");
+
+    // Remainder identity range check.
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(
+            *proof_node_idx, node.idx,
+            "ZK sumcheck proof order mismatch"
+        );
+        let rc_provider = RescaleRemainderRCProvider::new(node.clone(), bits);
+        let rc = identity_rangecheck_verifier(&rc_provider, accumulator);
+        verify_zk_sumcheck_instances(zk_proof, vec![Box::new(rc)], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+
+    // Remainder one-hot batch.
+    {
+        let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[*zk_proof_idx];
+        assert_eq!(
+            *proof_node_idx, node.idx,
+            "ZK sumcheck proof order mismatch"
+        );
+        let encoding = RescaleRemainderRaEncoding::new(node.idx, bits);
+        let [ra, hw, boolean] = joltworks::subprotocols::shout::ra_onehot_verifiers(
+            &encoding,
+            &*accumulator,
+            transcript,
+        );
+        verify_zk_sumcheck_instances(zk_proof, vec![ra, hw, boolean], accumulator, transcript)?;
+        *zk_proof_idx += 1;
+    }
+    Ok(())
+}
+
 /// Prove a neural teleportation operator (Sigmoid, Tanh, Erf) with ZK.
 /// Default flow: eval reduction first, then division + lookup + range/onehot stages.
 #[expect(clippy::too_many_arguments)]
@@ -995,8 +1098,12 @@ fn prove_neural_teleport_zk(
     zk_sumcheck_proofs.push((node.idx, div_proof));
 
     // 3. Lookup sumcheck (operator-specific: needs mutable accumulator/transcript)
+    // Extra trailing args are forwarded to `initialize`: `TanhProver::initialize`
+    // additionally takes the opening accumulator + transcript to append the
+    // clamped-input advice (`VirtualPoly::DummyClampedTanhInput`, #256); the
+    // append is transcript-quiet in zk mode, mirroring `TanhVerifier::new`.
     macro_rules! prove_lookup_zk {
-        ($Params:ty, $Prover:ty, $op:expr) => {{
+        ($Params:ty, $Prover:ty, $op:expr $(, $init_extra:expr)*) => {{
             let params = <$Params>::new(
                 node.clone(),
                 &model.graph,
@@ -1004,7 +1111,7 @@ fn prove_neural_teleport_zk(
                 &mut prover.transcript,
                 $op.clone(),
             );
-            let mut sc = <$Prover>::initialize(&prover.trace, params);
+            let mut sc = <$Prover>::initialize(&prover.trace, params $(, $init_extra)*);
             let proof = run_zk_sumcheck(
                 &mut sc,
                 prover,
@@ -1022,7 +1129,13 @@ fn prove_neural_teleport_zk(
         }
         Operator::Tanh(op) => {
             use crate::onnx_proof::ops::tanh::{TanhParams, TanhProver};
-            prove_lookup_zk!(TanhParams::<F>, TanhProver::<F>, op);
+            prove_lookup_zk!(
+                TanhParams::<F>,
+                TanhProver::<F>,
+                op,
+                &mut prover.accumulator,
+                &mut prover.transcript
+            );
         }
         Operator::Erf(op) => {
             use crate::onnx_proof::ops::erf::{ErfParams, ErfProver};
@@ -1634,6 +1747,126 @@ fn prove_relu_zk(
     zk_sumcheck_proofs.push((node.idx, oh_proof));
 }
 
+/// Prove the fused-rescaling pre-stages for a fused arithmetic node (einsum /
+/// `Mul` / `Square` / `Cube` with `scale > 0`), mirroring
+/// `fused_rebase::prove_pre`: append the `RescaleRemainder` advice, then
+/// discharge `output = SatClamp(rescaled)` via the 64-bit clamp read-raf
+/// lookup and its one-hot checks. Must run *before* the operator's arithmetic
+/// sumcheck so `fused_rebase::fused_input_claim` can read the
+/// `ClampAcc`/`RescaleRemainder` advices. Both advice appends are
+/// transcript-quiet in ZK mode; their values enter the proof via the baked
+/// initial claims of the following stages (prover-supplied, like every
+/// chain-start initial claim in this pipeline — the same treatment the Tanh
+/// `DummyClampedTanhInput` advice gets), not as committed BlindFold output
+/// claims. Binding them with a real `InputClaimConstraint` is future work
+/// alongside the other baked-claim bindings.
+fn prove_fused_rebase_pre_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::clamp_lookups::{is_scalar, ClampEncoding, ClampLookupProvider};
+
+    // Scalar fused nodes open `rescaled`/`R` in the clear and are checked by
+    // the verifier directly (`fused_rebase::verify_post`); that cleartext
+    // check has no ZK counterpart yet. Fail loudly rather than prove an
+    // unbound clamp.
+    if is_scalar(node) {
+        unimplemented!("ZK proving not yet implemented for scalar fused-rescale nodes");
+    }
+
+    // Remainder advice at the reduced output point.
+    crate::onnx_proof::fused_rebase::cache_remainder_prove(node, prover);
+
+    // Clamp read-raf lookup: output = SatClamp(acc); acc appended as ClampAcc.
+    let provider = ClampLookupProvider::new(node.clone());
+    let (mut exec_sc, lookup_indices) = provider.read_raf_prove::<F, T>(
+        &prover.trace,
+        &mut prover.accumulator,
+        &mut prover.transcript,
+    );
+    let exec_proof = run_zk_sumcheck(
+        &mut exec_sc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, exec_proof));
+
+    // Clamp one-hot batch (Ra, HammingWeight, Booleanity) over `ClampRaD`.
+    let encoding = ClampEncoding::new(node);
+    let [mut ra, mut hw, mut b] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &encoding,
+        &lookup_indices,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let oh_proof = run_zk_batched_sumcheck(
+        vec![&mut *ra, &mut *hw, &mut *b],
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, oh_proof));
+}
+
+/// Prove the fused-rescaling post-stages, mirroring
+/// `fused_rebase::prove_remainder_rc`: the remainder range check
+/// `R ∈ [0, 2^S)` plus its one-hot checks over `RescaleRemainderRaD`. Runs
+/// *after* the operator's arithmetic sumcheck.
+fn prove_fused_rebase_post_zk(
+    node: &atlas_onnx_tracer::node::ComputationNode,
+    prover: &mut Prover<F, T>,
+    pedersen_gens: &PedersenGenerators<C>,
+    blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
+    stage_configs: &mut Vec<StageConfig>,
+    zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+) {
+    use crate::onnx_proof::fused_rebase::{
+        rebase_bits, rebase_remainder_lookup_bits, RescaleRemainderRCProvider,
+        RescaleRemainderRaEncoding,
+    };
+    use joltworks::subprotocols::identity_range_check::identity_rangecheck_prover;
+
+    let bits = rebase_bits(&node.operator).expect("fused op");
+    let lookup_bits = rebase_remainder_lookup_bits(node, &prover.trace, bits);
+    let lookup_indices: Vec<usize> = lookup_bits.iter().map(|&x| x.into()).collect();
+
+    // Remainder identity range check.
+    let rc_provider = RescaleRemainderRCProvider::new(node.clone(), bits);
+    let mut rc = identity_rangecheck_prover(&rc_provider, lookup_bits, &mut prover.accumulator);
+    let rc_proof = run_zk_sumcheck(
+        &mut rc,
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, rc_proof));
+
+    // Remainder one-hot batch over `RescaleRemainderRaD`.
+    let encoding = RescaleRemainderRaEncoding::new(node.idx, bits);
+    let [mut ra, mut hw, mut boolean] = joltworks::subprotocols::shout::ra_onehot_provers(
+        &encoding,
+        &lookup_indices,
+        &prover.accumulator,
+        &mut prover.transcript,
+    );
+    let ra_proof = run_zk_batched_sumcheck(
+        vec![&mut *ra, &mut *hw, &mut *boolean],
+        prover,
+        blindfold_accumulator,
+        stage_configs,
+        pedersen_gens,
+    );
+    zk_sumcheck_proofs.push((node.idx, ra_proof));
+}
+
 /// Prove Rsqrt with ZK: custom flow (execution from transcript, eval reduction, range checks).
 #[expect(clippy::too_many_arguments)]
 fn prove_rsqrt_zk(
@@ -1847,19 +2080,26 @@ pub fn prove_zk(
     // public auxiliary vectors) toggle this flag off and back on.
     prover.accumulator.zk_mode = true;
 
-    // The ZK pipeline proves `Add`/`Sub`/`Sum` un-clamped (the saturating clamp
-    // lookup is not yet wired into `prove_zk`; per-node provers are the
-    // un-clamped `AddProver`/`SubProver`/`SumAxisProver`). Those provers never
-    // open the clamp one-hot decomposition (`ClampRaD`), so committing it would
-    // leave it without an opening-reduction sumcheck. Filter it out here so the
-    // committed set matches what the zk sumchecks actually open. (The non-ZK
-    // path commits and opens `ClampRaD` as usual.)
+    // The ZK pipeline still proves `Add`/`Sub`/`Sum` un-clamped (the saturating
+    // clamp lookup is not yet wired into `prove_zk` for them; per-node provers
+    // are the un-clamped `AddProver`/`SubProver`/`SumAxisProver`). Those provers
+    // never open the clamp one-hot decomposition (`ClampRaD`), so committing it
+    // would leave it without an opening-reduction sumcheck. Filter those out so
+    // the committed set matches what the zk sumchecks actually open. Fused
+    // rescale ops (einsum/Mul/Square/Cube, `fuses_rebase`) DO open `ClampRaD`
+    // in ZK via `prove_fused_rebase_pre_zk`, so theirs stay committed. (The
+    // non-ZK path commits and opens `ClampRaD` for all clamped ops as usual.)
     let poly_map: std::collections::BTreeMap<
         common::CommittedPoly,
         joltworks::poly::multilinear_polynomial::MultilinearPolynomial<F>,
     > = ONNXProof::<F, T, PCS>::polynomial_map(pp.model(), &prover.trace)
         .into_iter()
-        .filter(|(poly, _)| !matches!(poly, common::CommittedPoly::ClampRaD(..)))
+        .filter(|(poly, _)| match poly {
+            common::CommittedPoly::ClampRaD(node_idx, _) => {
+                crate::onnx_proof::fused_rebase::fuses_rebase(&pp.model()[*node_idx].operator)
+            }
+            _ => true,
+        })
         .collect();
     let commitments = ONNXProof::<F, T, PCS>::commit_to_polynomials(&poly_map, &pp.generators);
     for commitment in &commitments {
@@ -2136,6 +2376,23 @@ pub fn prove_zk(
                     &mut eval_reduction_h_commitments,
                 );
 
+                // Fused-rescale ops (einsum/Mul/Square/Cube with scale > 0)
+                // mirror the non-zk `fused_rebase` flow: remainder advice +
+                // clamp stages before the arithmetic sumcheck (its input
+                // claim reads the `ClampAcc`/`RescaleRemainder` advices),
+                // remainder range-check stages after.
+                let fused = crate::onnx_proof::fused_rebase::fuses_rebase(&node.operator);
+                if fused {
+                    prove_fused_rebase_pre_zk(
+                        node,
+                        &mut prover,
+                        pedersen_gens,
+                        &mut blindfold_accumulator,
+                        &mut stage_configs,
+                        &mut zk_sumcheck_proofs,
+                    );
+                }
+
                 let zk_proof =
                     create_prover_instance(node, &prover, pp.shared.model()).map(|mut sc| {
                         run_zk_sumcheck(
@@ -2148,6 +2405,17 @@ pub fn prove_zk(
                     });
                 if let Some(proof) = zk_proof {
                     zk_sumcheck_proofs.push((node.idx, proof));
+                }
+
+                if fused {
+                    prove_fused_rebase_post_zk(
+                        node,
+                        &mut prover,
+                        pedersen_gens,
+                        &mut blindfold_accumulator,
+                        &mut stage_configs,
+                        &mut zk_sumcheck_proofs,
+                    );
                 }
             }
         }
@@ -2983,6 +3251,18 @@ fn verify_zk_with_pcs_capture_and_extract(
             | Operator::Sum(_) => {
                 verify_zk_eval_reduction(node, bundle, &mut accumulator, &mut transcript)?;
 
+                // Mirror of the prover-side fused-rescale staging.
+                let fused = crate::onnx_proof::fused_rebase::fuses_rebase(&node.operator);
+                if fused {
+                    verify_fused_rebase_pre_zk(
+                        node,
+                        bundle,
+                        &mut accumulator,
+                        &mut transcript,
+                        &mut zk_proof_idx,
+                    )?;
+                }
+
                 let (proof_node_idx, zk_proof) = &bundle.zk_sumcheck_proofs[zk_proof_idx];
                 assert_eq!(
                     *proof_node_idx, node.idx,
@@ -2999,6 +3279,16 @@ fn verify_zk_with_pcs_capture_and_extract(
                 )?;
 
                 zk_proof_idx += 1;
+
+                if fused {
+                    verify_fused_rebase_post_zk(
+                        node,
+                        bundle,
+                        &mut accumulator,
+                        &mut transcript,
+                        &mut zk_proof_idx,
+                    )?;
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

#256 restructured the non-zk prover (i64 accumulate + saturating clamp for `Add`/`Sub`/`Sum`, fused
rescale+clamp for einsum/`Mul`/`Square`/`Cube`, a clamped-input advice for `Tanh`) and deferred the
mirroring zk updates to #28. Since the merge, the `Clippy & Test (zk)` job is red. Concretely, on
`main` the zk path has two breaks:

1. **Compile** — `TanhProver::initialize` gained `(acc, transcript)` parameters (it now appends the
   `VirtualPoly::DummyClampedTanhInput` advice), but the shared `prove_lookup_zk!` macro in
   `onnx_proof/zk.rs` still calls the 2-arg form → `E0061`. This is the only compile break
   (audited statically and re-confirmed empirically by stubbing the Tanh arm and rebuilding all
   targets under `-D warnings`).
2. **Prove-time panic for fused-rescale ops** — #256 folded the rescaling division and saturating
   clamp *into* einsum/`Mul`/`Square`/`Cube` (the tracer no longer emits the separate
   `ScalarConstDiv` rebase node). Their arithmetic sumcheck's input claim is now
   `ClampAcc·2^S + RescaleRemainder` — two advices appended by `fused_rebase::prove_pre` /
   `clamp_lookups`, which the zk pipeline never runs. Any fused node panics at prove time with
   `opening for ... ClampAcc(i) not found`. With the Tanh arm unblocked, 10 of 150 zk tests fail —
   nine at exactly this panic: `test_{square,mul,cube,einsum}_zk`,
   `test_multi_op_{arithmetic_chain,mul_div_sub}_zk`, `test_srs_derived_pedersen_generators`,
   `test_zk_rejects_rebound_input_for_square_model`, and
   `ops::square::tests::test_square_blindfold_e2e`. The tenth, `test_multi_op_cube_relu_zk`,
   trips a stale fixture that the same #256 fusion change exposed one step earlier, at trace
   time (measured: `attempt to shift left with overflow` in the tracer's `floor_rebase`,
   `ops/mod.rs:229` — see Tests).

## Change

- **Tanh (compile + advice threading).** `prove_lookup_zk!` accepts optional trailing args
  forwarded to `initialize`; the Tanh arm passes `&mut prover.accumulator, &mut prover.transcript`
  (Sigmoid/Erf stay 2-arg). The advice append is transcript-quiet in zk mode on both sides
  (`TanhVerifier::new` already appends the verifier-side placeholder), so prover/verifier
  transcripts stay in sync, and the claim is queued for BlindFold exactly like other zk-mode
  advice claims.
- **Fused-rescale ops (einsum/`Mul`/`Square`/`Cube`).** New `prove_fused_rebase_{pre,post}_zk` /
  `verify_fused_rebase_{pre,post}_zk` in `onnx_proof/zk.rs` mirror the non-zk flow around the
  (unchanged) arithmetic sumcheck:
  - *pre*: append the `RescaleRemainder` advice, then the 64-bit saturating-clamp read-raf lookup
    (`output = SatClamp(rescaled)`, appends `ClampAcc`) and its one-hot batch over `ClampRaD` —
    the same `ps_shout` read-raf + `shout::ra_onehot` building blocks the zk path already uses for
    ReLU and the neural-teleport range checks, run through the same
    `run_zk_sumcheck`/`run_zk_batched_sumcheck` machinery;
  - *post*: the rescaling-remainder identity range check `R ∈ [0, 2^S)` and its one-hot batch over
    `RescaleRemainderRaD` (the identity-RC params already carry BlindFold constraint impls).
  The verifier consumes the same four extra stages per fused node, in order.
- **Commit set.** The #256 `ClampRaD` commit filter becomes conditional: fused-rescale nodes now
  commit *and open* `ClampRaD` (and their `RescaleRemainderRaD`); `Add`/`Sub`/`Sum` keep the
  filter because their zk provers still prove the un-clamped relation (see "Not in this PR").
- **Scalar fused nodes** (`log_T = 0`): explicit `unimplemented!` on both sides. The non-zk scalar
  fallback checks the clamp on cleartext claims, which has no zk counterpart yet; failing loudly
  beats silently proving an unbound clamp. (Previously these panicked with the opaque `ClampAcc`
  lookup error.)
- **Tests.**
  - Six zk tests bump `PedersenGenerators::deterministic(16)` → `32`: the clamp read-raf stage
    raises the Hyrax column count to 32 — the size every lookup-op zk test (sigmoid/tanh/erf/relu/
    einsum/sum) already uses. The existing generator-size assert caught this cleanly.
  - `test_multi_op_cube_relu_zk`: `cube(i, 1 << 8)` → `cube(i, 1)`. Pre-#256 the fused Cube kernel
    sat behind the default-off `fused-ops` feature, so `scale` was ignored (raw `x³`); #256 made
    the kernel unconditional, turning `scale = 256` into a 2·256 = 512-bit shift that overflows at
    trace time. Stale fixture (the non-zk path panics identically on this model; #256's own cube
    test uses `cube(i, 12)`).
  - `ops::square::tests::test_square_blindfold_e2e` drives `SquareProver` directly (bypassing the
    zk.rs orchestration), so it now appends the two advices itself, exactly as
    `prove_fused_rebase_pre_zk` does.

## Not in this PR (documented, deliberate)

- **`Add`/`Sub`/`Sum` still prove the un-clamped relation in zk** — #256's explicit deferral (the
  in-code comments in `zk.rs` and `ops/add.rs` say the clamp fold into the zk path is tracked
  separately). Their zk tests pass on non-saturating traces; wiring the clamp lookup for them is
  the remaining #28 body of work and follows the exact stage pattern this PR establishes for the
  fused ops (happy to do that as a follow-up).
- **`MeanOfSquares` zk prove/verify `unimplemented!`** — pre-existing gap, predates #256. (This is
  also what `test_gpt2_zk` — `#[ignore]`, not a CI job — stops on; on `main` that test cannot run
  at all since the zk build doesn't compile.)
- **Scalar fused-rescale nodes in zk** — loud `unimplemented!` (above), not silently weakened;
  mirrors the `MeanOfSquares` arm's convention.
- Two pre-existing observations surfaced while auditing (no code change here): `fused_input_claim`'s
  `1u64 << bits` wraps silently in release for `bits ≥ 64` (absurd-but-expressible scales; the stale
  `cube(i, 1 << 8)` fixture sat in exactly that regime — its debug build panics first in the
  tracer's `floor_rebase`), and the verifier-side `unimplemented!` arms panic
  rather than returning `Err` on hostile bundles.

## Soundness

Parity with the shipped zk design — no new trust assumptions, and none removed:

- The fused-op stages reuse, unmodified, the constraint-carrying sumcheck types that already run
  under BlindFold elsewhere in the zk path (ReLU's `ps_shout` read-raf, the teleport one-hot
  batches, the identity range check). Each new stage's *output* claim is therefore bound by the
  same BlindFold constraint set as its non-zk counterpart's verifier checks: the read-raf output
  relation, one-hot/booleanity/hamming over the committed `ClampRaD`/`RescaleRemainderRaD`, and
  the identity-RC output relation.
- Stage *initial* claims — including the fused arithmetic stage's
  `ClampAcc·2^S + RescaleRemainder` and the Tanh lookup stage's `rv + γ·DummyClampedTanhInput` —
  are prover-supplied baked constants in the BlindFold R1CS, like **every** chain-start initial
  claim in the zk pipeline today (no non-default `InputClaimConstraint` exists in the codebase;
  Sigmoid/Erf's lookup stages work the same way). The new code's comments state this explicitly
  rather than overclaiming. Wiring real input-claim constraints over the advice openings is a
  natural follow-up and would slot into the existing `StageConfig::with_input_constraint`
  machinery — happy to take that on, but it is new protocol work beyond restoring #256 parity,
  and it belongs with the other baked-claim bindings tracked as future work.
- An adversarial review pass over the change (independent reviewers on Tanh advice flow, stage
  mechanics/transcript sync, zk-vs-non-zk parity, and the test fixtures) found no completeness or
  transcript-sync defects; its substantive findings were the comment-accuracy point above and one
  missed generator bump in an ignored benchmark (both addressed).

## Verification

All on this branch, macOS (Apple Silicon), `RUSTFLAGS='-D warnings'` for the clippy rows:

| Check (CI mirror) | Result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets` | clean |
| `cargo clippy -p jolt-atlas-core --all-targets --features zk` | clean |
| `cargo nextest run --workspace` (default) | **318/318 passed** |
| `cargo nextest run -p jolt-atlas-core --features zk` | **150/150 passed** (base `80a718e`: compile error; Tanh-fix-only: 140 pass / 10 fail) |
| GPT-2 job (`--run-ignored ignored-only -E 'test(test_gpt2)'`, default) | **PASS** (122.7s locally) |
| BGE job | **PASS** (44.3s) |
| wasm build (`atlas-onnx-tracer`, `wasm32-unknown-unknown`) | clean |
| `test_gpt2_zk` (zk, `#[ignore]`; not a CI job) | runs to the **pre-existing** `MeanOfSquares` zk `unimplemented!` (same arm exists verbatim pre-#256; on `main` the zk build doesn't compile, so this test can't run at all) |

## Context

Saw the zk updates were deferred to #28 due to time — took a full pass over the regression surface
(compile + every failing zk test root-caused). Happy to adjust, split, or defer any part if you're
already mid-way on #28.
