### PR TITLE
feat: reduce re-execution of einsum_acc_i64

### DIFF
--- a/atlas-onnx-tracer/src/ops/cube.rs
+++ b/atlas-onnx-tracer/src/ops/cube.rs
@@ -58,3 +58,16 @@ pub fn cube_intermediate(op: &Cube, inputs: &[&Tensor<i32>]) -> Tensor<i64> {
 pub fn cube_remainder(op: &Cube, inputs: &[&Tensor<i32>]) -> Tensor<i32> {
     super::rebase_remainder_i32(&cube_acc_i64(inputs[0]), cube_rebase_bits(op))
 }
+
+/// [`cube_intermediate`] and [`cube_remainder`] from one accumulation pass.
+pub fn cube_intermediate_and_remainder(
+    op: &Cube,
+    inputs: &[&Tensor<i32>],
+) -> (Tensor<i64>, Tensor<i32>) {
+    let acc = cube_acc_i64(inputs[0]);
+    let bits = cube_rebase_bits(op);
+    (
+        super::floor_rebase_i64(&acc, bits),
+        super::rebase_remainder_i32(&acc, bits),
+    )
+}

--- a/atlas-onnx-tracer/src/ops/einsum.rs
+++ b/atlas-onnx-tracer/src/ops/einsum.rs
@@ -241,6 +241,22 @@ pub fn einsum_remainder(op: &Einsum, inputs: &[&Tensor<i32>]) -> Tensor<i32> {
         .unwrap_or_else(|e| panic!("einsum_remainder: {e:?}"))
 }
 
+/// Quotient and remainder of the fused rescale — `rescaled = acc >> S` and
+/// `R = acc mod 2^S` — from **one** contraction pass. The proof system prefers
+/// this over separate [`einsum_intermediate`] + [`einsum_remainder`] calls,
+/// which each re-run the (expensive) contraction kernel.
+pub fn einsum_intermediate_and_remainder(
+    op: &Einsum,
+    inputs: &[&Tensor<i32>],
+) -> (Tensor<i64>, Tensor<i32>) {
+    let acc = einsum_acc_i64(&op.equation, inputs)
+        .unwrap_or_else(|e| panic!("einsum_intermediate_and_remainder: {e:?}"));
+    (
+        super::floor_rebase_i64(&acc, op.scale),
+        super::rebase_remainder_i32(&acc, op.scale),
+    )
+}
+
 /// Like `einsum_accumulate_i64`, but saturates the i64 result to i32.
 ///
 /// Replaces both the Einsum and its subsequent ScalarConstDiv rebase node,

--- a/atlas-onnx-tracer/src/ops/mean_of_squares.rs
+++ b/atlas-onnx-tracer/src/ops/mean_of_squares.rs
@@ -94,3 +94,25 @@ pub fn mos_remainder(op: &MeanOfSquares, inputs: &[&Tensor<i32>]) -> Tensor<i32>
         .collect();
     Tensor::<i32>::new(Some(&data), acc.dims()).unwrap_or_else(|e| panic!("mos_remainder: {e:?}"))
 }
+
+/// [`mos_intermediate`] and [`mos_remainder`] from one accumulation pass.
+pub fn mos_intermediate_and_remainder(
+    op: &MeanOfSquares,
+    inputs: &[&Tensor<i32>],
+) -> (Tensor<i64>, Tensor<i32>) {
+    let acc = mos_acc_i64(inputs[0], &op.axes)
+        .unwrap_or_else(|e| panic!("mos_intermediate_and_remainder: {e:?}"));
+    let divisor = mos_divisor(op);
+    let quotient: Vec<i64> = acc.data().iter().map(|&v| v.div_euclid(divisor)).collect();
+    let remainder: Vec<i32> = acc
+        .data()
+        .iter()
+        .map(|&v| v.rem_euclid(divisor) as i32)
+        .collect();
+    (
+        Tensor::<i64>::new(Some(&quotient), acc.dims())
+            .unwrap_or_else(|e| panic!("mos_intermediate_and_remainder: {e:?}")),
+        Tensor::<i32>::new(Some(&remainder), acc.dims())
+            .unwrap_or_else(|e| panic!("mos_intermediate_and_remainder: {e:?}")),
+    )
+}

--- a/atlas-onnx-tracer/src/ops/mul.rs
+++ b/atlas-onnx-tracer/src/ops/mul.rs
@@ -46,3 +46,15 @@ pub fn mul_intermediate(op: &Mul, inputs: &[&Tensor<i32>]) -> Tensor<i64> {
 pub fn mul_remainder(op: &Mul, inputs: &[&Tensor<i32>]) -> Tensor<i32> {
     super::rebase_remainder_i32(&mul_acc_i64(inputs), op.scale)
 }
+
+/// [`mul_intermediate`] and [`mul_remainder`] from one accumulation pass.
+pub fn mul_intermediate_and_remainder(
+    op: &Mul,
+    inputs: &[&Tensor<i32>],
+) -> (Tensor<i64>, Tensor<i32>) {
+    let acc = mul_acc_i64(inputs);
+    (
+        super::floor_rebase_i64(&acc, op.scale),
+        super::rebase_remainder_i32(&acc, op.scale),
+    )
+}

--- a/atlas-onnx-tracer/src/ops/square.rs
+++ b/atlas-onnx-tracer/src/ops/square.rs
@@ -49,3 +49,15 @@ pub fn square_intermediate(op: &Square, inputs: &[&Tensor<i32>]) -> Tensor<i64> 
 pub fn square_remainder(op: &Square, inputs: &[&Tensor<i32>]) -> Tensor<i32> {
     super::rebase_remainder_i32(&square_acc_i64(inputs[0]), op.scale)
 }
+
+/// [`square_intermediate`] and [`square_remainder`] from one accumulation pass.
+pub fn square_intermediate_and_remainder(
+    op: &Square,
+    inputs: &[&Tensor<i32>],
+) -> (Tensor<i64>, Tensor<i32>) {
+    let acc = square_acc_i64(inputs[0]);
+    (
+        super::floor_rebase_i64(&acc, op.scale),
+        super::rebase_remainder_i32(&acc, op.scale),
+    )
+}

--- a/jolt-atlas-core/src/onnx_proof/clamp_lookups/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/clamp_lookups/mod.rs
@@ -151,18 +151,22 @@ pub(crate) fn clamp_intermediate(node: &ComputationNode, trace: &Trace) -> Tenso
 /// returning the (padded) i64 intermediate for reuse.
 ///
 /// Shared by the clamp lookup (where `acc` is the `raf`) and the scalar fallback
-/// (where the verifier checks the clamp on `acc` directly).
+/// (where the verifier checks the clamp on `acc` directly). Fused-rescale
+/// callers pass the precomputed (padded) `intermediate` so the expensive
+/// accumulation is not re-run; `None` re-executes it via
+/// [`clamp_intermediate`].
 pub fn prove_append_acc<F, T>(
     node: &ComputationNode,
     trace: &Trace,
     accumulator: &mut ProverOpeningAccumulator<F>,
     transcript: &mut T,
+    intermediate: Option<Tensor<i64>>,
 ) -> Tensor<i64>
 where
     F: JoltField,
     T: Transcript,
 {
-    let intermediate = clamp_intermediate(node, trace);
+    let intermediate = intermediate.unwrap_or_else(|| clamp_intermediate(node, trace));
     let r = accumulator.get_node_output_opening(node.idx).0;
     let acc_claim = MultilinearPolynomial::from(intermediate.data().to_vec()).evaluate(&r.r);
     accumulator.append_virtual(transcript, acc_opening_id(node.idx), r, acc_claim);
@@ -215,12 +219,15 @@ impl ClampLookupProvider {
 
     /// Prover flow: append the accumulation (`raf`) claim, then build the
     /// read-raf sumcheck prover. Returns `(prover, lookup_indices)`, where the
-    /// indices are reused for the one-hot checks.
+    /// indices are reused for the one-hot checks. `intermediate` optionally
+    /// provides the precomputed (padded) accumulation (see
+    /// [`prove_append_acc`]).
     pub fn read_raf_prove<F, T>(
         &self,
         trace: &Trace,
         accumulator: &mut ProverOpeningAccumulator<F>,
         transcript: &mut T,
+        intermediate: Option<Tensor<i64>>,
     ) -> (
         UnaryReadRafSumcheckProver<F, ClampTable, CLAMP_LOG_K>,
         Vec<usize>,
@@ -229,7 +236,13 @@ impl ClampLookupProvider {
         F: JoltField,
         T: Transcript,
     {
-        let intermediate = prove_append_acc(&self.computation_node, trace, accumulator, transcript);
+        let intermediate = prove_append_acc(
+            &self.computation_node,
+            trace,
+            accumulator,
+            transcript,
+            intermediate,
+        );
         let lookup_bits = clamp_lookup_bits(&intermediate);
         let lookup_indices: Vec<usize> = lookup_bits.iter().map(|&x| x.into()).collect();
         let prover = ps_read_raf_prover(self, lookup_bits, accumulator, transcript);
@@ -341,16 +354,19 @@ impl RaOneHotEncoding for ClampEncoding {
 /// Prove `output = SatClamp(acc)` for a non-scalar node: the clamp read-raf
 /// lookup ([`ProofType::Execution`]) plus the read-address one-hot checks
 /// ([`ProofType::RaOneHotChecks`]). The accumulation `acc` is appended as the
-/// lookup `raf` (see [`ClampLookupProvider`]).
+/// lookup `raf` (see [`ClampLookupProvider`]); `intermediate` optionally
+/// provides it precomputed (see [`prove_append_acc`]).
 pub fn prove_clamp_lookup<F: JoltField, T: Transcript>(
     node: &ComputationNode,
     prover: &mut Prover<F, T>,
+    intermediate: Option<Tensor<i64>>,
 ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
     let provider = ClampLookupProvider::new(node.clone());
     let (mut execution_sumcheck, lookup_indices) = provider.read_raf_prove::<F, T>(
         &prover.trace,
         &mut prover.accumulator,
         &mut prover.transcript,
+        intermediate,
     );
     let (execution_proof, _) = Sumcheck::prove(
         &mut execution_sumcheck,

--- a/jolt-atlas-core/src/onnx_proof/fused_rebase.rs
+++ b/jolt-atlas-core/src/onnx_proof/fused_rebase.rs
@@ -133,12 +133,12 @@ pub(crate) fn rebase_intermediates(node: &ComputationNode, trace: &Trace) -> Reb
         .unwrap_or_else(|| panic!("fused_rebase: unsupported operator {:?}", node.operator))
 }
 
-/// The operator's rescaling remainder `R = acc mod 2^S`, padded to the
-/// node-output cycle domain. Dispatches to the per-operator re-execution kernel
-/// (no trace change), mirroring [`clamp_lookups::clamp_intermediate`].
+/// The operator's rescaling remainder `R = acc mod D`, padded to the node-output
+/// cycle domain, where `D` is the operator-specific divisor (usually `2^S`, but
+/// e.g. `MeanOfSquares` uses `N·2^S`). Dispatches to the per-operator re-execution
+/// kernel (no trace change), mirroring [`clamp_lookups::clamp_intermediate`].
 ///
-/// Prefer [`rebase_intermediates`] when the quotient is needed too — this
-/// re-runs the full accumulation for the remainder alone.
+/// Prefer [`rebase_intermediates`] when the quotient is needed too — this re-runs the full accumulation for the remainder alone.
 pub(crate) fn rebase_remainder(node: &ComputationNode, trace: &Trace) -> Tensor<i32> {
     let LayerData { operands, .. } = Trace::layer_data(trace, node);
     let remainder = match &node.operator {

--- a/jolt-atlas-core/src/onnx_proof/fused_rebase.rs
+++ b/jolt-atlas-core/src/onnx_proof/fused_rebase.rs
@@ -35,8 +35,12 @@ use atlas_onnx_tracer::{
     model::trace::{LayerData, Trace},
     node::ComputationNode,
     ops::{
-        cube::cube_remainder, einsum::einsum_remainder, mean_of_squares::mos_remainder,
-        mul::mul_remainder, square::square_remainder, Operator,
+        cube::{cube_intermediate_and_remainder, cube_remainder},
+        einsum::{einsum_intermediate_and_remainder, einsum_remainder},
+        mean_of_squares::{mos_intermediate_and_remainder, mos_remainder},
+        mul::{mul_intermediate_and_remainder, mul_remainder},
+        square::{square_intermediate_and_remainder, square_remainder},
+        Operator,
     },
     tensor::Tensor,
 };
@@ -86,9 +90,55 @@ pub fn fuses_rebase(op: &Operator) -> bool {
     rebase_bits(op).is_some_and(|b| b > 0)
 }
 
+/// Both fused-rescale intermediates — the pre-clamp quotient `rescaled = acc div D`
+/// and the remainder `R = acc mod D` — derived from **one** accumulation pass and
+/// padded to the node-output cycle domain.
+///
+/// The accumulation (e.g. the full einsum contraction) dominates the cost of
+/// recovering either tensor, so anything that needs both must compute them
+/// together rather than calling [`clamp_lookups::clamp_intermediate`] and
+/// [`rebase_remainder`] separately.
+pub(crate) struct RebaseIntermediates {
+    /// Pre-clamp rescaled accumulation (the saturating-clamp lookup index).
+    pub quotient: Tensor<i64>,
+    /// Rescaling remainder `R ∈ [0, D)`.
+    pub remainder: Tensor<i32>,
+}
+
+/// Compute a node's [`RebaseIntermediates`] with a single accumulation pass,
+/// or `None` if the operator has no fused rescale (e.g. `Add`/`Sub`/`Sum`).
+pub(crate) fn try_rebase_intermediates(
+    node: &ComputationNode,
+    trace: &Trace,
+) -> Option<RebaseIntermediates> {
+    let LayerData { operands, .. } = Trace::layer_data(trace, node);
+    let (quotient, remainder) = match &node.operator {
+        Operator::Einsum(op) => einsum_intermediate_and_remainder(op, &operands),
+        Operator::Mul(op) => mul_intermediate_and_remainder(op, &operands),
+        Operator::Square(op) => square_intermediate_and_remainder(op, &operands),
+        Operator::Cube(op) => cube_intermediate_and_remainder(op, &operands),
+        Operator::MeanOfSquares(op) => mos_intermediate_and_remainder(op, &operands),
+        _ => return None,
+    };
+    Some(RebaseIntermediates {
+        quotient: quotient.padded_next_power_of_two(),
+        remainder: remainder.padded_next_power_of_two(),
+    })
+}
+
+/// Panicking variant of [`try_rebase_intermediates`] for callers that know the
+/// node fuses a rescale.
+pub(crate) fn rebase_intermediates(node: &ComputationNode, trace: &Trace) -> RebaseIntermediates {
+    try_rebase_intermediates(node, trace)
+        .unwrap_or_else(|| panic!("fused_rebase: unsupported operator {:?}", node.operator))
+}
+
 /// The operator's rescaling remainder `R = acc mod 2^S`, padded to the
 /// node-output cycle domain. Dispatches to the per-operator re-execution kernel
 /// (no trace change), mirroring [`clamp_lookups::clamp_intermediate`].
+///
+/// Prefer [`rebase_intermediates`] when the quotient is needed too — this
+/// re-runs the full accumulation for the remainder alone.
 pub(crate) fn rebase_remainder(node: &ComputationNode, trace: &Trace) -> Tensor<i32> {
     let LayerData { operands, .. } = Trace::layer_data(trace, node);
     let remainder = match &node.operator {
@@ -159,34 +209,45 @@ pub fn committed_polys(node: &ComputationNode) -> Vec<CommittedPoly> {
 /// clear (only `rescaled` is appended); otherwise the clamp lookup
 /// (`Execution` + `RaOneHotChecks`) is proven. Run *before* the operator's
 /// arithmetic sumcheck so [`fused_input_claim`] can read both advices.
+///
+/// Also returns the (padded) remainder tensor so [`prove_remainder_rc`] can
+/// reuse it instead of re-running the accumulation.
 pub fn prove_pre<F: JoltField, T: Transcript>(
     node: &ComputationNode,
     prover: &mut Prover<F, T>,
-) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
-    cache_remainder_prove(node, prover);
-    if is_scalar(node) {
+) -> (crate::onnx_proof::ops::ExecutionProofs<F, T>, Tensor<i32>) {
+    let RebaseIntermediates {
+        quotient,
+        remainder,
+    } = rebase_intermediates(node, &prover.trace);
+    cache_remainder_prove(node, prover, &remainder);
+    let proofs = if is_scalar(node) {
         prove_append_acc(
             node,
             &prover.trace,
             &mut prover.accumulator,
             &mut prover.transcript,
+            Some(quotient),
         );
         Vec::new()
     } else {
-        prove_clamp_lookup(node, prover)
-    }
+        prove_clamp_lookup(node, prover, Some(quotient))
+    };
+    (proofs, remainder)
 }
 
 /// Stage (4)+(5): the rescaling-remainder range check `R ∈ [0, 2^S)`
 /// (`RangeCheck`) and its read-address one-hot checks
 /// (`RescaleRemainderRaChecks`). Run *after* the operator's arithmetic sumcheck;
-/// only for non-scalar nodes.
+/// only for non-scalar nodes. `remainder` is the padded tensor returned by
+/// [`prove_pre`].
 pub fn prove_remainder_rc<F: JoltField, T: Transcript>(
     node: &ComputationNode,
     prover: &mut Prover<F, T>,
+    remainder: &Tensor<i32>,
 ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
     let bits = rebase_bits(&node.operator).expect("fused op");
-    let lookup_bits = rebase_remainder_lookup_bits(node, &prover.trace, bits);
+    let lookup_bits = remainder_lookup_bits(remainder, bits);
     let lookup_indices: Vec<usize> = lookup_bits.iter().map(|&x| x.into()).collect();
 
     let rc_provider = RescaleRemainderRCProvider::new(node.clone(), bits);
@@ -282,18 +343,18 @@ pub fn verify_post<F: JoltField, T: Transcript>(
 // Internals
 // ---------------------------------------------------------------------------
 
-/// Re-execute the rescaling remainder `R` (padded to the node-output cycle
-/// domain) and append it as a virtual advice opening at the output point.
-/// `pub(crate)`: also used by the ZK flow (`onnx_proof::zk`), where the append
-/// is transcript-quiet (accumulator `zk_mode`).
+/// Append the rescaling remainder `R` (padded to the node-output cycle domain,
+/// as produced by [`rebase_intermediates`]) as a virtual advice opening at the
+/// output point. `pub(crate)`: also used by the ZK flow (`onnx_proof::zk`),
+/// where the append is transcript-quiet (accumulator `zk_mode`).
 pub(crate) fn cache_remainder_prove<F: JoltField, T: Transcript>(
     node: &ComputationNode,
     prover: &mut Prover<F, T>,
+    remainder: &Tensor<i32>,
 ) {
-    let remainder = rebase_remainder(node, &prover.trace);
     let accessor = AccOpeningAccessor::new(&mut prover.accumulator, node);
     let r0 = accessor.get_reduced_opening().0;
-    let eval = MultilinearPolynomial::from(remainder).evaluate(&r0.r);
+    let eval = MultilinearPolynomial::from(remainder.clone()).evaluate(&r0.r);
     let mut provider = accessor.into_provider(&mut prover.transcript, r0);
     provider.append_advice(VirtualPoly::RescaleRemainder, eval);
 }
@@ -313,14 +374,9 @@ pub(crate) fn cache_remainder_verify<F: JoltField, T: Transcript>(
     provider.append_advice(VirtualPoly::RescaleRemainder);
 }
 
-/// The rescaling remainder `R` as `bits`-bit lookup indices, padded to the
-/// node-output cycle domain.
-pub(crate) fn rebase_remainder_lookup_bits(
-    node: &ComputationNode,
-    trace: &Trace,
-    bits: i32,
-) -> Vec<LookupBits> {
-    rebase_remainder(node, trace)
+/// A (padded) rescaling remainder tensor as `bits`-bit lookup indices.
+pub(crate) fn remainder_lookup_bits(remainder: &Tensor<i32>, bits: i32) -> Vec<LookupBits> {
+    remainder
         .data()
         .iter()
         .map(|&v| LookupBits::new(v as u64, bits as usize))

--- a/jolt-atlas-core/src/onnx_proof/ops/add.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/add.rs
@@ -83,7 +83,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Add {
         let results = if is_scalar(node) {
             vec![]
         } else {
-            prove_clamp_lookup(node, prover)
+            prove_clamp_lookup(node, prover, None)
         };
 
         // Operand tie: open `left(r)`, `right(r)`. The verifier ties them to

--- a/jolt-atlas-core/src/onnx_proof/ops/einsum/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/einsum/mod.rs
@@ -80,9 +80,13 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Einsum {
         // `fused_rebase` stages; only the contraction (matmul) sumcheck is
         // einsum-specific. See [`fused_rebase`] for the seam.
         let mut proofs = Vec::new();
-        if fused {
-            proofs.extend(fused_rebase::prove_pre(node, prover));
-        }
+        let remainder = if fused {
+            let (pre_proofs, remainder) = fused_rebase::prove_pre(node, prover);
+            proofs.extend(pre_proofs);
+            Some(remainder)
+        } else {
+            None
+        };
 
         // EinsumMatmul: the contraction sumcheck (initial claim `acc(r)` via
         // `fused_rebase::fused_input_claim`).
@@ -100,7 +104,11 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Einsum {
         proofs.push((ProofId(node.idx, ProofType::EinsumMatmul), matmul_proof));
 
         if fused && !is_scalar(node) {
-            proofs.extend(fused_rebase::prove_remainder_rc(node, prover));
+            proofs.extend(fused_rebase::prove_remainder_rc(
+                node,
+                prover,
+                remainder.as_ref().expect("fused"),
+            ));
         }
 
         proofs

--- a/jolt-atlas-core/src/onnx_proof/ops/malicious_sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/malicious_sub.rs
@@ -54,6 +54,7 @@ pub fn malicious_sub_prove<F: JoltField, T: Transcript>(
         &prover.trace,
         &mut prover.accumulator,
         &mut prover.transcript,
+        None,
     );
     let (execution_proof, _) = Sumcheck::prove(
         &mut execution_sumcheck,

--- a/jolt-atlas-core/src/onnx_proof/ops/mean_of_squares.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mean_of_squares.rs
@@ -88,8 +88,10 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for MeanOfSquares {
         let mut proofs = Vec::new();
 
         // (1+2) Append `R` (RescaleRemainder) + `rescaled` (ClampAcc) and prove
-        // the clamp `out = SatClamp(rescaled)`.
-        proofs.extend(fused_rebase::prove_pre(node, prover));
+        // the clamp `out = SatClamp(rescaled)`. The returned remainder is
+        // unused: MoS range-checks `R < D` via its own operand-based lookup.
+        let (pre_proofs, _remainder) = fused_rebase::prove_pre(node, prover);
+        proofs.extend(pre_proofs);
 
         // (3) Reduction sumcheck `acc(r) = Σ eq·x²` (claim `rescaled·D + R`).
         let params = MeanOfSquaresReductionParams::new(node.clone(), &prover.accumulator);

--- a/jolt-atlas-core/src/onnx_proof/ops/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/mod.rs
@@ -130,7 +130,7 @@ use std::collections::BTreeMap;
 use crate::onnx_proof::{ProofId, Prover, Verifier};
 
 /// Standard execution proofs emitted by an operator.
-type ExecutionProofs<F, T> = Vec<(ProofId, SumcheckInstanceProof<F, T>)>;
+pub(crate) type ExecutionProofs<F, T> = Vec<(ProofId, SumcheckInstanceProof<F, T>)>;
 
 /// Eval-reduction flow mode for an operator.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -581,9 +581,13 @@ macro_rules! impl_fused_rescale_proof_api {
 
                 let fused = fused_rebase::fuses_rebase(&node.operator);
                 let mut proofs = Vec::new();
-                if fused {
-                    proofs.extend(fused_rebase::prove_pre(node, prover));
-                }
+                let remainder = if fused {
+                    let (pre_proofs, remainder) = fused_rebase::prove_pre(node, prover);
+                    proofs.extend(pre_proofs);
+                    Some(remainder)
+                } else {
+                    None
+                };
 
                 let params = $params_ty::new(node.clone(), &prover.accumulator);
                 let mut prover_sumcheck = $prover_ty::initialize(&prover.trace, params);
@@ -595,7 +599,11 @@ macro_rules! impl_fused_rescale_proof_api {
                 proofs.push((ProofId(node.idx, ProofType::RescaleArith), proof));
 
                 if fused && !is_scalar(node) {
-                    proofs.extend(fused_rebase::prove_remainder_rc(node, prover));
+                    proofs.extend(fused_rebase::prove_remainder_rc(
+                        node,
+                        prover,
+                        remainder.as_ref().expect("fused"),
+                    ));
                 }
                 proofs
             }

--- a/jolt-atlas-core/src/onnx_proof/ops/square.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/square.rs
@@ -458,12 +458,19 @@ mod tests {
         // (`fused_rebase::fused_input_claim`). Append both, as the zk
         // pipeline's `prove_fused_rebase_pre_zk` does; the clamp/remainder
         // stages themselves are covered by `test_square_zk`.
-        crate::onnx_proof::fused_rebase::cache_remainder_prove(square_node, &mut prover);
+        let ints =
+            crate::onnx_proof::fused_rebase::rebase_intermediates(square_node, &prover.trace);
+        crate::onnx_proof::fused_rebase::cache_remainder_prove(
+            square_node,
+            &mut prover,
+            &ints.remainder,
+        );
         let _ = crate::onnx_proof::clamp_lookups::prove_append_acc(
             square_node,
             &prover.trace,
             &mut prover.accumulator,
             &mut prover.transcript,
+            Some(ints.quotient),
         );
 
         // 5. Create SquareProver

--- a/jolt-atlas-core/src/onnx_proof/ops/sub.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sub.rs
@@ -70,7 +70,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sub {
         let results = if is_scalar(node) {
             vec![]
         } else {
-            prove_clamp_lookup(node, prover)
+            prove_clamp_lookup(node, prover, None)
         };
 
         // Operand tie: open `left(r)`, `right(r)`. The verifier ties them to

--- a/jolt-atlas-core/src/onnx_proof/ops/sum/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sum/mod.rs
@@ -83,10 +83,11 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sum {
                 &prover.trace,
                 &mut prover.accumulator,
                 &mut prover.transcript,
+                None,
             );
             vec![]
         } else {
-            prove_clamp_lookup(node, prover)
+            prove_clamp_lookup(node, prover, None)
         };
 
         // (3) Axis reduction: acc(r) = Σ_axis operand (input claim = ClampAcc).

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -170,11 +170,15 @@ pub(crate) fn generate_node_witnesses<F: JoltField, T: joltworks::transcripts::T
     trace: &Trace,
 ) -> Vec<(CommittedPoly, MultilinearPolynomial<F>)> {
     use crate::onnx_proof::{
-        fused_rebase::{rebase_bits, rebase_remainder},
+        fused_rebase::{rebase_bits, try_rebase_intermediates},
         ops::NodeCommittedPolynomials,
     };
 
-    // Per-node lookup tensors, each computed at most once (lazily).
+    // Per-node lookup tensors, each computed at most once (lazily). For a
+    // fused-rescale node the clamp quotient and rescale remainder derive from
+    // one shared accumulation pass (`try_rebase_intermediates`), which fills
+    // both caches at once — computing them independently would re-run the
+    // accumulation twice.
     let mut clamp_bits: Option<Vec<LookupBits>> = None;
     let mut remainder_indices: Option<Vec<usize>> = None;
     let mut mos_range_bits: Option<Vec<LookupBits>> = None;
@@ -184,21 +188,34 @@ pub(crate) fn generate_node_witnesses<F: JoltField, T: joltworks::transcripts::T
         .map(|poly| {
             let witness = match &poly {
                 CommittedPoly::ClampRaD(_, d) => {
-                    let bits = clamp_bits
-                        .get_or_insert_with(|| clamp_lookup_bits(&clamp_intermediate(node, trace)));
-                    build_one_hot_rad_witness(bits, *d, CLAMP_LOG_K)
+                    if clamp_bits.is_none() {
+                        match try_rebase_intermediates(node, trace) {
+                            Some(ints) => {
+                                clamp_bits = Some(clamp_lookup_bits(&ints.quotient));
+                                remainder_indices = Some(
+                                    ints.remainder.data().iter().map(|&v| v as usize).collect(),
+                                );
+                            }
+                            // Add/Sub/Sum: clamp only, no fused rescale.
+                            None => {
+                                clamp_bits =
+                                    Some(clamp_lookup_bits(&clamp_intermediate(node, trace)));
+                            }
+                        }
+                    }
+                    build_one_hot_rad_witness(clamp_bits.as_ref().unwrap(), *d, CLAMP_LOG_K)
                 }
                 CommittedPoly::RescaleRemainderRaD(_, d) => {
                     let bits = rebase_bits(&node.operator)
                         .expect("RescaleRemainderRaD requested for a non-rescaling operator");
-                    let indices = remainder_indices.get_or_insert_with(|| {
-                        rebase_remainder(node, trace)
-                            .data()
-                            .iter()
-                            .map(|&v| v as usize)
-                            .collect()
-                    });
-                    build_onehot_witness(indices, bits as usize, *d)
+                    if remainder_indices.is_none() {
+                        let ints = try_rebase_intermediates(node, trace)
+                            .expect("RescaleRemainderRaD requested for a non-rescaling operator");
+                        remainder_indices =
+                            Some(ints.remainder.data().iter().map(|&v| v as usize).collect());
+                        clamp_bits.get_or_insert_with(|| clamp_lookup_bits(&ints.quotient));
+                    }
+                    build_onehot_witness(remainder_indices.as_ref().unwrap(), bits as usize, *d)
                 }
                 CommittedPoly::MeanOfSquaresRangeCheckRaD(_, d) => {
                     let bits = mos_range_bits.get_or_insert_with(|| {

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -1773,7 +1773,7 @@ fn prove_fused_rebase_pre_zk(
     blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
     stage_configs: &mut Vec<StageConfig>,
     zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
-) {
+) -> atlas_onnx_tracer::tensor::Tensor<i32> {
     use crate::onnx_proof::clamp_lookups::{is_scalar, ClampEncoding, ClampLookupProvider};
 
     // Scalar fused nodes open `rescaled`/`R` in the clear and are checked by
@@ -1784,8 +1784,15 @@ fn prove_fused_rebase_pre_zk(
         unimplemented!("ZK proving not yet implemented for scalar fused-rescale nodes");
     }
 
+    // Quotient + remainder from one accumulation pass; the remainder is
+    // returned so `prove_fused_rebase_post_zk` can reuse it.
+    let crate::onnx_proof::fused_rebase::RebaseIntermediates {
+        quotient,
+        remainder,
+    } = crate::onnx_proof::fused_rebase::rebase_intermediates(node, &prover.trace);
+
     // Remainder advice at the reduced output point.
-    crate::onnx_proof::fused_rebase::cache_remainder_prove(node, prover);
+    crate::onnx_proof::fused_rebase::cache_remainder_prove(node, prover, &remainder);
 
     // Clamp read-raf lookup: output = SatClamp(acc); acc appended as ClampAcc.
     let provider = ClampLookupProvider::new(node.clone());
@@ -1793,6 +1800,7 @@ fn prove_fused_rebase_pre_zk(
         &prover.trace,
         &mut prover.accumulator,
         &mut prover.transcript,
+        Some(quotient),
     );
     let exec_proof = run_zk_sumcheck(
         &mut exec_sc,
@@ -1819,12 +1827,15 @@ fn prove_fused_rebase_pre_zk(
         pedersen_gens,
     );
     zk_sumcheck_proofs.push((node.idx, oh_proof));
+
+    remainder
 }
 
 /// Prove the fused-rescaling post-stages, mirroring
 /// `fused_rebase::prove_remainder_rc`: the remainder range check
 /// `R ∈ [0, 2^S)` plus its one-hot checks over `RescaleRemainderRaD`. Runs
-/// *after* the operator's arithmetic sumcheck.
+/// *after* the operator's arithmetic sumcheck. `remainder` is the padded
+/// tensor returned by `prove_fused_rebase_pre_zk`.
 fn prove_fused_rebase_post_zk(
     node: &atlas_onnx_tracer::node::ComputationNode,
     prover: &mut Prover<F, T>,
@@ -1832,15 +1843,15 @@ fn prove_fused_rebase_post_zk(
     blindfold_accumulator: &mut joltworks::subprotocols::blindfold::BlindFoldAccumulator<F, C>,
     stage_configs: &mut Vec<StageConfig>,
     zk_sumcheck_proofs: &mut Vec<NodeZkProof>,
+    remainder: &atlas_onnx_tracer::tensor::Tensor<i32>,
 ) {
     use crate::onnx_proof::fused_rebase::{
-        rebase_bits, rebase_remainder_lookup_bits, RescaleRemainderRCProvider,
-        RescaleRemainderRaEncoding,
+        rebase_bits, remainder_lookup_bits, RescaleRemainderRCProvider, RescaleRemainderRaEncoding,
     };
     use joltworks::subprotocols::identity_range_check::identity_rangecheck_prover;
 
     let bits = rebase_bits(&node.operator).expect("fused op");
-    let lookup_bits = rebase_remainder_lookup_bits(node, &prover.trace, bits);
+    let lookup_bits = remainder_lookup_bits(remainder, bits);
     let lookup_indices: Vec<usize> = lookup_bits.iter().map(|&x| x.into()).collect();
 
     // Remainder identity range check.
@@ -2388,7 +2399,7 @@ pub fn prove_zk(
                 // claim reads the `ClampAcc`/`RescaleRemainder` advices),
                 // remainder range-check stages after.
                 let fused = crate::onnx_proof::fused_rebase::fuses_rebase(&node.operator);
-                if fused {
+                let fused_remainder = fused.then(|| {
                     prove_fused_rebase_pre_zk(
                         node,
                         &mut prover,
@@ -2396,8 +2407,8 @@ pub fn prove_zk(
                         &mut blindfold_accumulator,
                         &mut stage_configs,
                         &mut zk_sumcheck_proofs,
-                    );
-                }
+                    )
+                });
 
                 let zk_proof =
                     create_prover_instance(node, &prover, pp.shared.model()).map(|mut sc| {
@@ -2413,7 +2424,7 @@ pub fn prove_zk(
                     zk_sumcheck_proofs.push((node.idx, proof));
                 }
 
-                if fused {
+                if let Some(remainder) = &fused_remainder {
                     prove_fused_rebase_post_zk(
                         node,
                         &mut prover,
@@ -2421,6 +2432,7 @@ pub fn prove_zk(
                         &mut blindfold_accumulator,
                         &mut stage_configs,
                         &mut zk_sumcheck_proofs,
+                        remainder,
                     );
                 }
             }


### PR DESCRIPTION
The gpt2 prover ran `einsum_acc_i64` 6× per node (~18s): 1× trace gen, 2× witness gen, 3× IOP. The clamp quotient and rescale remainder both come from one accumulation, but every consumer recomputed it.

Fix: compute once per phase, derive both tensors from it (`*_intermediate_and_remainder` kernels + `RebaseIntermediates` threaded through the prover). Net 6 -> 3 (~9s off gpt2)

Why not cache in the trace (->1×)? ~150MB extra resident for gpt2, growing with `seq_len`. The trace stays a lean i32 record; re-execution retains zero memory.