### PR TITLE
Add new tool for error analysis

### DIFF
--- a/atlas-onnx-tracer/examples/qwen_quant_error_analysis.rs
+++ b/atlas-onnx-tracer/examples/qwen_quant_error_analysis.rs
@@ -5,19 +5,19 @@ mod qea;
 
 use atlas_onnx_tracer::{model::Model, utils::quantize};
 use qea::{
-    Ctx, init_logging, make_f64_inputs, make_gpt2_i32_inputs, make_run_args, run_tract_f32,
+    Ctx, init_logging, make_f64_inputs, make_qwen_i32_inputs, make_run_args, run_tract_f32,
     step1_quant_vs_tract, step2a_per_node_drift_cumulative, step2b_per_node_drift_isolated,
     step3_shadow_vs_tract, step4_weight_quant_effect, step5_greedy_generation,
 };
 use tokenizers::Tokenizer;
 use tracing::{debug, info};
 
-const ONNX_PATH: &str = "atlas-onnx-tracer/models/gpt2/network.onnx";
-const TOKENIZER_PATH: &str = "atlas-onnx-tracer/models/gpt2/tokenizer.json";
-const VOCAB_SIZE: usize = 50257;
+const ONNX_PATH: &str = "atlas-onnx-tracer/models/qwen/network.onnx";
+const TOKENIZER_PATH: &str = "atlas-onnx-tracer/models/qwen/tokenizer.json";
+const VOCAB_SIZE: usize = 151936;
 const SCALE: i32 = 12;
 
-/// Quantization error analysis for GPT-2.
+/// Quantization error analysis for Qwen.
 ///
 /// Compares four views of the same forward pass (see GLOSSARY in the output):
 ///
@@ -39,29 +39,29 @@ const SCALE: i32 = 12;
 /// # Setup
 ///
 /// ```sh
-/// pip install 'optimum[exporters]' 'optimum[onnxruntime]'
-/// python -m optimum.exporters.onnx --model gpt2 atlas-onnx-tracer/models/gpt2
+/// python3 -m venv .venv && source .venv/bin/activate
+/// python scripts/download_qwen.py
 /// ```
 ///
 /// # Usage
 ///
 /// Default (info-level output, tract logs silenced):
 /// ```sh
-/// cargo run -r -p atlas-onnx-tracer --example quant_error_analysis
+/// cargo run -r -p atlas-onnx-tracer --example qwen_quant_error_analysis
 /// ```
 ///
 /// Show debug output (shapes, token details):
 /// ```sh
-/// RUST_LOG=debug cargo run -r -p atlas-onnx-tracer --example quant_error_analysis
+/// RUST_LOG=debug cargo run -r -p atlas-onnx-tracer --example qwen_quant_error_analysis
 /// ```
 ///
 /// Show everything *including* tract internals:
 /// ```sh
-/// RUST_LOG=trace cargo run -r -p atlas-onnx-tracer --example quant_error_analysis
+/// RUST_LOG=trace cargo run -r -p atlas-onnx-tracer --example qwen_quant_error_analysis
 /// ```
 fn main() {
     init_logging();
-    let ctx = setup("The white man worked as a");
+    let ctx = setup("The quick brown fox jumps over the lazy dog");
 
     print_glossary(&ctx);
     step1_quant_vs_tract(&ctx);
@@ -78,7 +78,7 @@ fn main() {
 
 fn setup(text: &str) -> Ctx {
     let tokenizer = Tokenizer::from_file(TOKENIZER_PATH)
-        .expect("failed to load tokenizer.json – see doc-comment for setup");
+        .expect("failed to load tokenizer.json – run scripts/download_qwen.py first");
 
     info!("Input text : \"{text}\"");
     let encoding = tokenizer.encode(text, false).expect("tokenization failed");
@@ -98,7 +98,7 @@ fn setup(text: &str) -> Ctx {
 
     info!("Running QUANT (i32 fixed-point, scale=2^{scale}) …");
     let model = Model::load(ONNX_PATH, &run_args);
-    let quant_inputs = make_gpt2_i32_inputs(&token_ids, seq_len, scale);
+    let quant_inputs = make_qwen_i32_inputs(&token_ids, seq_len, scale);
     let i32_outputs = model.forward(&quant_inputs);
     debug!(shape = ?i32_outputs[0].dims(), "QUANT output shape");
 
@@ -133,7 +133,7 @@ fn setup(text: &str) -> Ctx {
 
 fn print_glossary(ctx: &Ctx) {
     qea::print_section("GLOSSARY");
-    info!("  This analysis compares four views of the same GPT-2 forward pass:");
+    info!("  This analysis compares four views of the same Qwen forward pass:");
     info!("");
     info!("    TRACT     ONNX model evaluated by Tract at f32 precision.");
     info!("              This is the ground-truth reference.");

--- a/atlas-onnx-tracer/examples/utils/qea.rs
+++ b/atlas-onnx-tracer/examples/utils/qea.rs
@@ -491,8 +491,12 @@ pub fn step4_weight_quant_effect(ctx: &Ctx, sr: &ShadowResult) {
     let true_shadow =
         ctx.model
             .trace_with_true_f64_shadow(&ctx.shadow_inputs, &original_constants, ctx.scale);
-    let true_logits =
-        extract_shadow_logits(&true_shadow, "True shadow", ctx.last_pos_start, ctx.vocab_size);
+    let true_logits = extract_shadow_logits(
+        &true_shadow,
+        "True shadow",
+        ctx.last_pos_start,
+        ctx.vocab_size,
+    );
 
     info!("{THIN}");
     info!("  [4a] TRUE-F64 vs TRACT  (expected: near-zero error)");

--- a/atlas-onnx-tracer/examples/utils/qea.rs
+++ b/atlas-onnx-tracer/examples/utils/qea.rs
@@ -1,0 +1,529 @@
+/// Shared helpers used across quantization-analysis and generation examples.
+///
+/// Factored out here to avoid copying boilerplate between
+/// `quant_error_analysis`, `quant_error_analysis_qwen`, and `qwen_generate`.
+use atlas_onnx_tracer::{
+    model::{Model, RunArgs, shadow_trace::ShadowTrace},
+    tensor::Tensor,
+    utils::metrics,
+};
+use tokenizers::Tokenizer;
+use tracing::{debug, info};
+use tracing_subscriber::EnvFilter;
+
+/// Heavy section separator line.
+pub const SEP: &str = "═══════════════════════════════════════════════════════════";
+/// Thin sub-section separator line.
+pub const THIN: &str = "───────────────────────────────────────────────────────────";
+
+/// Per-node shadow trace together with extracted last-position logits.
+pub struct ShadowResult {
+    /// The full per-node shadow trace.
+    pub trace: ShadowTrace,
+    /// Last-position logits extracted from the final shadow node.
+    pub logits: Vec<f64>,
+}
+
+/// Shared context produced by `setup` and threaded through every analysis step.
+pub struct Ctx {
+    /// Tokenizer for the prompt text and for decoding predicted tokens.
+    pub tokenizer: Tokenizer,
+    /// The loaded, quantized model.
+    pub model: Model,
+    /// The `RunArgs` the model was loaded with.
+    pub run_args: RunArgs,
+    /// The quantization scale (also `run_args.scale`).
+    pub scale: i32,
+    /// Path to the model's `network.onnx`.
+    pub onnx_path: &'static str,
+    /// Output vocabulary size.
+    pub vocab_size: usize,
+    /// Encoded prompt token ids.
+    pub token_ids: Vec<u32>,
+    /// Number of prompt tokens.
+    pub seq_len: usize,
+    /// Flat-array offset of the last token position's logits.
+    pub last_pos_start: usize,
+    /// Quantized i32 model inputs.
+    pub quant_inputs: Vec<Tensor<i32>>,
+    /// f64 shadow input tensors (unquantized real values), shared by every step that runs an f64
+    /// trace, so it's built once instead of per-step.
+    pub shadow_inputs: Vec<Tensor<f64>>,
+    /// Last-position logits from the f32 Tract reference.
+    pub ref_logits: Vec<f64>,
+    /// Last-position logits from the dequantized i32 QUANT engine.
+    pub deq_logits: Vec<f64>,
+}
+
+// ── Logging ──────────────────────────────────────────────────────────────────
+
+/// Initialise `tracing-subscriber` silencing tract crate noise by default.
+/// Override with `RUST_LOG`.
+pub fn init_logging() {
+    let tract_suppressions = [
+        "tract_core=warn",
+        "tract_data=warn",
+        "tract_hir=warn",
+        "tract_linalg=warn",
+        "tract_nnef=warn",
+        "tract_onnx=warn",
+        "tract_onnx_opl=warn",
+        "tract_extra=warn",
+        "tract_pulse=warn",
+        "tract_pulse_opl=warn",
+    ];
+    let base = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+    let combined = format!("{},{}", base, tract_suppressions.join(","));
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new(combined))
+        .with_target(false)
+        .without_time()
+        .init();
+}
+
+// ── Section / step banners ────────────────────────────────────────────────────
+
+/// Print a titled section banner.
+pub fn print_section(title: &str) {
+    info!("\n");
+    info!("{SEP}");
+    info!("  {title}");
+    info!("{SEP}");
+}
+
+/// Print a step header (`[id/5] title`). `id` is usually a step number ("3"), but sub-steps of
+/// the same logical step use a letter suffix ("2a", "2b") rather than incrementing the count.
+pub fn print_step(id: &str, title: &str) {
+    info!("\n");
+    info!("{SEP}");
+    info!("  [{id}/5] {title}");
+    info!("{SEP}");
+}
+
+// ── Logit metrics ─────────────────────────────────────────────────────────────
+
+/// Print a standard suite of comparison metrics between two logit vectors.
+pub fn print_comparison_metrics(a: &[f64], b: &[f64], pad: &str) {
+    info!(
+        "{pad}Cosine similarity   : {:.6}",
+        metrics::cosine_similarity(a, b)
+    );
+    info!("{pad}MSE                 : {:.6}", metrics::mse(a, b));
+    info!("{pad}RMSE                : {:.6}", metrics::rmse(a, b));
+    info!(
+        "{pad}Max absolute error  : {:.6}",
+        metrics::max_abs_error(a, b)
+    );
+    info!(
+        "{pad}Mean absolute error : {:.6}",
+        metrics::mean_abs_error(a, b)
+    );
+    info!(
+        "{pad}Relative MSE        : {:.6}",
+        metrics::relative_mse(a, b)
+    );
+    info!(
+        "{pad}KL divergence       : {:.6}",
+        metrics::kl_divergence_from_logits(a, b)
+    );
+    info!(
+        "{pad}Top-1 agreement     : {:.2}%",
+        metrics::top_k_agreement(a, b, 1) * 100.0
+    );
+    info!(
+        "{pad}Top-5 agreement     : {:.2}%",
+        metrics::top_k_agreement(a, b, 5) * 100.0
+    );
+    info!(
+        "{pad}Top-10 agreement    : {:.2}%",
+        metrics::top_k_agreement(a, b, 10) * 100.0
+    );
+    info!(
+        "{pad}Spearman rank corr  : {:.6}",
+        metrics::spearman_rank_correlation(a, b)
+    );
+    info!(
+        "{pad}Pearson correlation : {:.6}",
+        metrics::pearson_correlation(a, b)
+    );
+}
+
+/// Return `(token_id, logit)` pairs sorted descending by logit.
+pub fn top_k_entries(logits: &[f64], k: usize) -> Vec<(usize, f64)> {
+    let mut indexed: Vec<(usize, f64)> = logits.iter().enumerate().map(|(i, &v)| (i, v)).collect();
+    indexed.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    indexed.truncate(k);
+    indexed
+}
+
+// ── Logit extraction ──────────────────────────────────────────────────────────
+
+/// Extract last-position logits from an f32 output tensor, cast to f64.
+pub fn last_position_logits_f32(data: &[f32], start: usize, vocab_size: usize) -> Vec<f64> {
+    data[start..start + vocab_size]
+        .iter()
+        .map(|&v| v as f64)
+        .collect()
+}
+
+/// Extract last-position logits from an i32 output tensor, dequantized to f64.
+pub fn last_position_logits_i32(
+    data: &[i32],
+    start: usize,
+    vocab_size: usize,
+    scale_mult: f64,
+) -> Vec<f64> {
+    data[start..start + vocab_size]
+        .iter()
+        .map(|&v| v as f64 / scale_mult)
+        .collect()
+}
+
+/// Extract the final-node f64 logits from a shadow trace.
+pub fn extract_shadow_logits(
+    shadow: &ShadowTrace,
+    label: &str,
+    last_pos_start: usize,
+    vocab_size: usize,
+) -> Vec<f64> {
+    let &node_idx = shadow.f64_outputs.keys().next_back().unwrap();
+    let tensor = &shadow.f64_outputs[&node_idx];
+    let data = tensor.data();
+    debug!(
+        label,
+        node_idx,
+        shape = ?tensor.dims(),
+        numel = data.len(),
+        "Shadow output"
+    );
+    data[last_pos_start..last_pos_start + vocab_size].to_vec()
+}
+
+// ── Input construction ────────────────────────────────────────────────────────
+
+/// Build the basic `RunArgs` (batch=1, no padding) with the given scale.
+pub fn make_run_args(seq_len: usize, scale: i32) -> RunArgs {
+    RunArgs::new([
+        ("batch_size", 1),
+        ("sequence_length", seq_len),
+        ("past_sequence_length", 0),
+    ])
+    .set_scale(scale)
+    .with_padding(false)
+}
+
+/// Prepare f64 shadow input tensors: `[input_ids, position_ids, attention_mask]`.
+pub fn make_f64_inputs(token_ids: &[u32], seq_len: usize) -> Vec<Tensor<f64>> {
+    let ids: Vec<f64> = token_ids.iter().map(|&id| id as f64).collect();
+    let pos: Vec<f64> = (0..seq_len).map(|i| i as f64).collect();
+    let mask: Vec<f64> = vec![1.0; seq_len];
+    vec![
+        Tensor::new(Some(&ids), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&pos), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&mask), &[1, seq_len]).unwrap(),
+    ]
+}
+
+/// Prepare GPT-2-style quantized i32 inputs: `[input_ids, position_ids, attention_mask]`.
+///
+/// Position IDs are raw (unscaled) integers — GPT-2 uses them only as a Gather index into a
+/// learned positional embedding table, not arithmetically (unlike Qwen's RoPE).
+pub fn make_gpt2_i32_inputs(token_ids: &[u32], seq_len: usize, scale: i32) -> Vec<Tensor<i32>> {
+    let ids: Vec<i32> = token_ids.iter().map(|&id| id as i32).collect();
+    let pos: Vec<i32> = (0..seq_len as i32).collect();
+    let mask: Vec<i32> = vec![1 << scale; seq_len];
+    vec![
+        Tensor::new(Some(&ids), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&pos), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&mask), &[1, seq_len]).unwrap(),
+    ]
+}
+
+/// Prepare Qwen-style quantized i32 inputs: `[input_ids, position_ids, attention_mask]`.
+///
+/// Position IDs are scaled (`i << scale`) to match RoPE Einsum expectations.
+pub fn make_qwen_i32_inputs(token_ids: &[u32], seq_len: usize, scale: i32) -> Vec<Tensor<i32>> {
+    let ids: Vec<i32> = token_ids.iter().map(|&id| id as i32).collect();
+    // position_ids in fixed-point: i × 2^scale so Einsum(freq_q, pos_q)/2^scale = freq × i
+    let max_pos = (i32::MAX >> scale) as usize;
+    assert!(
+        seq_len.saturating_sub(1) <= max_pos,
+        "make_qwen_i32_inputs: seq_len={seq_len} too large for scale={scale} (max position index {max_pos})"
+    );
+    let pos: Vec<i32> = (0..seq_len as i32).map(|i| i << scale).collect();
+    let mask: Vec<i32> = vec![1 << scale; seq_len];
+    vec![
+        Tensor::new(Some(&ids), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&pos), &[1, seq_len]).unwrap(),
+        Tensor::new(Some(&mask), &[1, seq_len]).unwrap(),
+    ]
+}
+
+// ── Tract helpers ─────────────────────────────────────────────────────────────
+
+/// Run the Tract f32 reference forward pass for `[input_ids, attention_mask, position_ids]`.
+pub fn run_tract_f32(
+    onnx_path: &str,
+    token_ids: &[u32],
+    seq_len: usize,
+    run_args: &RunArgs,
+) -> Vec<Tensor<f32>> {
+    let f32_ids: Vec<f32> = token_ids.iter().map(|&id| id as f32).collect();
+    let f32_mask: Vec<f32> = vec![1.0; seq_len];
+    let f32_pos: Vec<f32> = (0..seq_len as i64).map(|i| i as f32).collect();
+    Model::run_tract_forward(
+        onnx_path,
+        run_args,
+        &[
+            (
+                "input_ids",
+                Tensor::new(Some(&f32_ids), &[1, seq_len]).unwrap(),
+            ),
+            (
+                "attention_mask",
+                Tensor::new(Some(&f32_mask), &[1, seq_len]).unwrap(),
+            ),
+            (
+                "position_ids",
+                Tensor::new(Some(&f32_pos), &[1, seq_len]).unwrap(),
+            ),
+        ],
+    )
+}
+
+/// Greedy-decode `n_tokens` using the Tract f32 model.
+pub fn tract_greedy_generate(
+    onnx_path: &str,
+    prompt_ids: &[u32],
+    n_tokens: usize,
+    vocab_size: usize,
+) -> Vec<u32> {
+    let mut ids = prompt_ids.to_vec();
+    for _ in 0..n_tokens {
+        let len = ids.len();
+        let run_args = RunArgs::new([
+            ("batch_size", 1),
+            ("sequence_length", len),
+            ("past_sequence_length", 0),
+        ])
+        .with_padding(false);
+
+        let f32_ids: Vec<f32> = ids.iter().map(|&id| id as f32).collect();
+        let f32_mask: Vec<f32> = vec![1.0; len];
+        let f32_pos: Vec<f32> = (0..len as i64).map(|i| i as f32).collect();
+
+        let outs = Model::run_tract_forward(
+            onnx_path,
+            &run_args,
+            &[
+                ("input_ids", Tensor::new(Some(&f32_ids), &[1, len]).unwrap()),
+                (
+                    "attention_mask",
+                    Tensor::new(Some(&f32_mask), &[1, len]).unwrap(),
+                ),
+                (
+                    "position_ids",
+                    Tensor::new(Some(&f32_pos), &[1, len]).unwrap(),
+                ),
+            ],
+        );
+        let logits = outs[0].data();
+        let start = (len - 1) * vocab_size;
+        let next = logits[start..start + vocab_size]
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .unwrap()
+            .0 as u32;
+        ids.push(next);
+    }
+    ids
+}
+
+// ── Printing helpers ────────────────────────────────────────────────────────
+
+/// Print top-k predicted tokens from two logit vectors side by side.
+pub fn print_top_k_side_by_side(
+    label_a: &str,
+    logits_a: &[f64],
+    label_b: &str,
+    logits_b: &[f64],
+    tokenizer: &Tokenizer,
+    k: usize,
+) {
+    let top_a = top_k_entries(logits_a, k);
+    let top_b = top_k_entries(logits_b, k);
+
+    let decode = |id: usize| -> String {
+        tokenizer
+            .decode(&[id as u32], false)
+            .unwrap_or_else(|_| "<unk>".to_string())
+    };
+
+    info!(
+        "  {:<30}  |  {:<30}",
+        format!("Top-{k} {label_a}"),
+        format!("Top-{k} {label_b}"),
+    );
+    info!("  {:<30}  |  {:<30}", "-".repeat(30), "-".repeat(30));
+    for i in 0..k {
+        let (id_a, logit_a) = top_a[i];
+        let (id_b, logit_b) = top_b[i];
+        info!(
+            "  {:<2}. {:>8.4}  {:<16}  |  {:<2}. {:>8.4}  {:<16}",
+            i + 1,
+            logit_a,
+            format!("\"{}\"", decode(id_a)),
+            i + 1,
+            logit_b,
+            format!("\"{}\"", decode(id_b)),
+        );
+    }
+}
+
+// ── Analysis pipeline steps ───────────────────────────────────────────────────
+//
+// Shared by every quant-error-analysis example: identical regardless of model, since they only
+// touch `Ctx` fields (including `ctx.onnx_path`/`ctx.vocab_size`), never a model-specific
+// constant.
+
+/// [1/5] Compare QUANT vs TRACT end-to-end.
+pub fn step1_quant_vs_tract(ctx: &Ctx) {
+    print_step("1", "QUANT vs TRACT — overall quantization error");
+    info!("  Question: how much does our integer engine diverge from f32?");
+    info!("");
+    print_comparison_metrics(&ctx.ref_logits, &ctx.deq_logits, "  ");
+    info!("");
+    print_top_k_side_by_side(
+        "TRACT",
+        &ctx.ref_logits,
+        "QUANT",
+        &ctx.deq_logits,
+        &ctx.tokenizer,
+        5,
+    );
+}
+
+/// [2a/5] Run the f64 SHADOW alongside QUANT and report per-node drift, cumulative: each node's
+/// QUANT inputs are QUANT's own (possibly already-drifted) previous outputs, so an early node's
+/// error propagates and inflates every downstream node's apparent error too — see step 2b for the
+/// isolated alternative.
+pub fn step2a_per_node_drift_cumulative(ctx: &Ctx) -> ShadowResult {
+    print_step("2a", "SHADOW vs QUANT — per-node drift (cumulative)");
+    info!("  Each row compares the dequantized i32 output against the f64 shadow");
+    info!("  after every graph node. Shows where rounding error accumulates.");
+    info!("");
+
+    let trace = ctx
+        .model
+        .trace_with_shadow(&ctx.quant_inputs, &ctx.shadow_inputs, ctx.scale);
+    trace.print_report();
+
+    info!("");
+    info!("{THIN}");
+    info!("  Aggregated by operator type:");
+    info!("{THIN}");
+    trace.print_op_class_summary();
+
+    let logits = extract_shadow_logits(&trace, "Shadow", ctx.last_pos_start, ctx.vocab_size);
+    ShadowResult { trace, logits }
+}
+
+/// [2b/5] Like step 2a, but re-quantizes each node's inputs from the SHADOW's own (ideal)
+/// outputs instead of chaining QUANT's own history — isolates each node's own rounding error
+/// from upstream propagated drift.
+pub fn step2b_per_node_drift_isolated(ctx: &Ctx) {
+    print_step(
+        "2b",
+        "SHADOW vs QUANT — per-node drift (isolated, no error propagation)",
+    );
+    info!("  Each node's QUANT inputs are re-quantized from SHADOW's own outputs, not chained");
+    info!("  from QUANT's previous nodes — isolates each node's own rounding error.");
+    info!("");
+
+    let trace =
+        ctx.model
+            .trace_with_shadow_isolated(&ctx.quant_inputs, &ctx.shadow_inputs, ctx.scale);
+    trace.print_report();
+
+    info!("");
+    info!("{THIN}");
+    info!("  Aggregated by operator type:");
+    info!("{THIN}");
+    trace.print_op_class_summary();
+}
+
+/// [3/5] Compare SHADOW vs TRACT to verify the shadow is faithful.
+pub fn step3_shadow_vs_tract(ctx: &Ctx, sr: &ShadowResult) {
+    print_step("3", "SHADOW vs TRACT — shadow faithfulness");
+    info!("  Question: does the f64 shadow (with quantized weights) agree with");
+    info!("  the f32 Tract reference? High agreement means the shadow is valid.");
+    info!("");
+    print_comparison_metrics(&sr.logits, &ctx.ref_logits, "  ");
+    info!("");
+    print_top_k_side_by_side(
+        "SHADOW",
+        &sr.logits,
+        "TRACT",
+        &ctx.ref_logits,
+        &ctx.tokenizer,
+        5,
+    );
+}
+
+/// [4/5] Run TRUE-F64 (original weights) and compare to isolate
+/// weight-quantization error vs arithmetic rounding error.
+pub fn step4_weight_quant_effect(ctx: &Ctx, sr: &ShadowResult) {
+    print_step("4", "TRUE-F64 vs TRACT — weight quantization effect");
+    info!("  TRUE-F64 uses original f32 weights + f64 arithmetic.");
+    info!("  Comparing TRUE-F64 to TRACT should show near-zero error (just f64↔f32).");
+    info!("  Comparing SHADOW to TRUE-F64 isolates the error from quantizing weights.");
+    info!("");
+
+    let original_constants = ctx
+        .model
+        .load_original_f64_constants(ctx.onnx_path, &ctx.run_args);
+    debug!(
+        count = original_constants.len(),
+        "Loaded original f64 constants from Tract"
+    );
+
+    let true_shadow =
+        ctx.model
+            .trace_with_true_f64_shadow(&ctx.shadow_inputs, &original_constants, ctx.scale);
+    let true_logits =
+        extract_shadow_logits(&true_shadow, "True shadow", ctx.last_pos_start, ctx.vocab_size);
+
+    info!("{THIN}");
+    info!("  [4a] TRUE-F64 vs TRACT  (expected: near-zero error)");
+    info!("{THIN}");
+    print_comparison_metrics(&true_logits, &ctx.ref_logits, "  ");
+    info!("");
+    print_top_k_side_by_side(
+        "TRUE-F64",
+        &true_logits,
+        "TRACT",
+        &ctx.ref_logits,
+        &ctx.tokenizer,
+        5,
+    );
+
+    info!("");
+    info!("{THIN}");
+    info!("  [4b] SHADOW vs TRUE-F64  (difference = weight quantization error)");
+    info!("{THIN}");
+    print_comparison_metrics(&sr.logits, &true_logits, "  ");
+}
+
+/// [5/5] Greedy-decode 10 tokens with the Tract f32 model as a sanity check.
+pub fn step5_greedy_generation(ctx: &Ctx) {
+    print_step("5", "TRACT greedy generation (sanity check)");
+    info!("  Greedy-decoding 10 tokens with the f32 Tract model.");
+    info!("");
+    let generated = tract_greedy_generate(ctx.onnx_path, &ctx.token_ids, 10, ctx.vocab_size);
+    let text = ctx
+        .tokenizer
+        .decode(&generated, false)
+        .unwrap_or_else(|_| "<decode error>".to_string());
+    info!("  \"{text}\"");
+}

--- a/atlas-onnx-tracer/src/model/mod.rs
+++ b/atlas-onnx-tracer/src/model/mod.rs
@@ -2,7 +2,6 @@
 
 use crate::{node::ComputationNode, ops::Operator, tensor::Tensor, utils::quantize};
 use common::consts::LOG_K_CHUNK;
-use consts::DEFAULT_SCALE;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
@@ -400,7 +399,7 @@ impl Default for RunArgs {
         variables.insert("batch_size".to_string(), 1);
         RunArgs {
             variables,
-            scale: DEFAULT_SCALE,
+            scale: common::consts::MODEL_SCALE as i32,
             pad_to_power_of_2: true,
         }
     }
@@ -425,7 +424,7 @@ impl RunArgs {
         let variables = variables.into_iter().map(|(k, v)| (k.into(), v)).collect();
         RunArgs {
             variables,
-            scale: DEFAULT_SCALE,
+            scale: common::consts::MODEL_SCALE as i32,
             pad_to_power_of_2: true,
         }
     }
@@ -487,17 +486,6 @@ impl RunArgs {
         self.pad_to_power_of_2 = enable;
         self
     }
-}
-
-/// Const values used across the model and ops.
-pub mod consts {
-    /// Default quantization scale (denominator in fixed-point representation).
-    pub const DEFAULT_SCALE: i32 = common::consts::MODEL_SCALE as i32;
-
-    /// Const used in the zkVM to wrap around a multiple of 2π,
-    /// using the periodicity of the cosine function while keeping the lookup table size reasonable.
-    /// For a scale of 8, the best multiple was found to be 4: value = round(4 * π * 256) = 3217
-    pub const FOUR_PI_APPROX: i32 = 3217;
 }
 
 #[cfg(test)]

--- a/atlas-onnx-tracer/src/model/shadow_trace.rs
+++ b/atlas-onnx-tracer/src/model/shadow_trace.rs
@@ -261,6 +261,109 @@ impl Model {
         }
     }
 
+    /// Like [`trace_with_shadow`](Self::trace_with_shadow), but re-quantizes each node's inputs
+    /// from the shadow's f64 outputs instead of chaining QUANT's own i32 history — isolates each
+    /// node's own rounding error, rather than the cumulative drift `trace_with_shadow` measures.
+    ///
+    /// # Arguments
+    ///
+    /// * `i32_inputs` — Quantized i32 input tensors (same as `forward()`).
+    /// * `f64_inputs` — Unquantized f64 input tensors (original real values).
+    /// * `scale`      — The quantization scale used.
+    pub fn trace_with_shadow_isolated(
+        &self,
+        i32_inputs: &[Tensor<i32>],
+        f64_inputs: &[Tensor<f64>],
+        scale: Scale,
+    ) -> ShadowTrace {
+        let mut i32_outputs: BTreeMap<usize, Tensor<i32>> = BTreeMap::new();
+        let mut f64_outputs: BTreeMap<usize, Tensor<f64>> = BTreeMap::new();
+
+        // Store inputs
+        self.store_i32_inputs(i32_inputs, &mut i32_outputs);
+        self.store_f64_inputs(f64_inputs, &mut f64_outputs);
+
+        let mut node_metrics = Vec::new();
+
+        for (node_idx, node) in &self.graph.nodes {
+            if matches!(node.operator, Operator::Input(_)) {
+                if let Some(f64_t) = f64_outputs.get(node_idx) {
+                    node_metrics.push(NodeMetrics::input(*node_idx, f64_t));
+                }
+                continue;
+            }
+
+            // ── f64 shadow path (ground truth; drives both branches) ─────
+            let f64_input_tensors: Vec<&Tensor<f64>> = node
+                .inputs
+                .iter()
+                .map(|&idx| f64_outputs.get(&idx).unwrap())
+                .collect();
+            let f64_out = shadow_f64(&node.operator, f64_input_tensors, scale);
+
+            // ── i32 path: re-quantize the shadow's inputs, not QUANT's own history ──
+            //
+            // Raw/discrete-valued nodes (see `is_raw_valued`) are passed through unchanged
+            // instead: re-quantizing a Gather index or an exact-0/1 boolean would corrupt it.
+            let i32_input_tensors_owned: Vec<Tensor<i32>> = node
+                .inputs
+                .iter()
+                .map(|&idx| {
+                    if self.is_raw_valued(idx) {
+                        i32_outputs.get(&idx).unwrap().clone()
+                    } else {
+                        requantize_tensor(f64_outputs.get(&idx).unwrap(), scale)
+                    }
+                })
+                .collect();
+            let i32_input_tensors: Vec<&Tensor<i32>> = i32_input_tensors_owned.iter().collect();
+            let i32_out = node.operator.f(i32_input_tensors);
+
+            // ── Compute metrics ─────────────────────────────────────────
+            let op_name = op_variant_name(&node.operator);
+            let deq = dequantize_tensor(&i32_out, scale);
+            node_metrics.push(compute_metrics(*node_idx, &op_name, &deq, &f64_out));
+            i32_outputs.insert(*node_idx, i32_out);
+            f64_outputs.insert(*node_idx, f64_out);
+        }
+
+        ShadowTrace {
+            node_metrics,
+            f64_outputs,
+            i32_outputs,
+        }
+    }
+
+    /// Whether node `idx`'s output carries raw/discrete (not fixed-point-scaled) values, and so
+    /// must not be re-quantized. Traces back through value-preserving ops (shape ops, Gather's
+    /// dict operand, and `ScalarConstDiv` by a rebase divisor — same check `shadow_f64` uses) to
+    /// find the actual value-defining ancestor before checking its operator type.
+    fn is_raw_valued(&self, mut idx: usize) -> bool {
+        loop {
+            match &self.graph.nodes[&idx].operator {
+                Operator::Input(_) | Operator::And(_) | Operator::IsNan(_) => return true,
+                // A constant baked into the graph as an unscaled boolean mask (all values
+                // exactly 0 or 1) — as opposed to a legitimately scaled real constant.
+                Operator::Constant(c) => {
+                    return c.0.data().iter().all(|&v| v == 0 || v == 1);
+                }
+                Operator::Identity(_)
+                | Operator::Reshape(_)
+                | Operator::Broadcast(_)
+                | Operator::MoveAxis(_)
+                | Operator::Slice(_)
+                | Operator::GatherSmall(_)
+                | Operator::GatherLarge(_) => {
+                    idx = self.graph.nodes[&idx].inputs[0];
+                }
+                Operator::ScalarConstDiv(scd) if is_rebase_divisor(scd.divisor, self.scale) => {
+                    idx = self.graph.nodes[&idx].inputs[0];
+                }
+                _ => return false,
+            }
+        }
+    }
+
     /// Store i32 inputs into the node output map (mirrors execute.rs logic).
     fn store_i32_inputs(&self, inputs: &[Tensor<i32>], outputs: &mut BTreeMap<usize, Tensor<i32>>) {
         self.store_shadow_inputs(inputs, outputs);
@@ -668,6 +771,16 @@ fn dequantize_tensor(t: &Tensor<i32>, scale: Scale) -> Tensor<f64> {
         .data()
         .iter()
         .map(|&v| quantize::dequantize(v, scale))
+        .collect();
+    Tensor::construct(data, t.dims().to_vec())
+}
+
+/// Quantize an f64 tensor to i32 using the given scale.
+fn requantize_tensor(t: &Tensor<f64>, scale: Scale) -> Tensor<i32> {
+    let data: Vec<i32> = t
+        .data()
+        .iter()
+        .map(|&v| quantize::quantize_float(v, scale))
         .collect();
     Tensor::construct(data, t.dims().to_vec())
 }

--- a/atlas-onnx-tracer/src/node/handlers/activation.rs
+++ b/atlas-onnx-tracer/src/node/handlers/activation.rs
@@ -13,9 +13,6 @@ use crate::{
 
 use super::{HandlerContext, OpHandlerFn};
 
-/// Model scale (log2) at which the trig (cos/sin) teleport constants are tuned.
-pub const NEURAL_TELEPORT_REFERENCE_SCALE: i32 = 8;
-
 /// Returns a map of activation operator names to their handler functions.
 pub fn handlers() -> HashMap<&'static str, OpHandlerFn> {
     HashMap::from([
@@ -72,7 +69,6 @@ fn handle_tanh(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
 /// Cos: Cosine activation.
 fn handle_cos(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
     let scale = hctx.run_args.scale;
-    assert_trig_reference_scale(scale, "Cos");
 
     HandlerBuilder::new(hctx)
         .with_broadcast()
@@ -83,25 +79,11 @@ fn handle_cos(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
 /// Sin: Sine activation.
 fn handle_sin(hctx: &mut HandlerContext) -> Vec<ComputationNode> {
     let scale = hctx.run_args.scale;
-    assert_trig_reference_scale(scale, "Sin");
 
     HandlerBuilder::new(hctx)
         .with_broadcast()
         .simple_op(Operator::Sin(Sin { scale }))
         .build()
-}
-
-/// The trig (cos/sin) periodic teleportation still hardcodes its `2π·2^s` period
-/// modulus (`FOUR_PI_APPROX`) and lookup-table quantization for the reference
-/// scale. Unlike the signed activations (tanh/erf/sigmoid), it is not yet
-/// scale-aware, so reject other scales loudly rather than emit a wrong proof.
-// TODO: make cos/sin scale-aware (brute-force the per-scale `k·2π·2^s` modulus).
-fn assert_trig_reference_scale(scale: i32, op: &str) {
-    assert_eq!(
-        scale, NEURAL_TELEPORT_REFERENCE_SCALE,
-        "{op} teleportation is only calibrated for scale {NEURAL_TELEPORT_REFERENCE_SCALE} \
-         (got {scale}); cos/sin are not yet scale-aware."
-    );
 }
 
 /// Erf: Error function activation.

--- a/atlas-onnx-tracer/src/ops/erf.rs
+++ b/atlas-onnx-tracer/src/ops/erf.rs
@@ -3,17 +3,13 @@ use crate::{
     tensor::{self, Tensor},
     utils::quantize::scale_to_multiplier,
 };
-use common::consts::{ACTIVATION_BOUND, MODEL_SCALE};
 
 impl Op for Erf {
     #[tracing::instrument(name = "Erf::f", skip_all)]
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        debug_assert_eq!(
-            self.scale, MODEL_SCALE as i32,
-            "Erf only supports scale={MODEL_SCALE}"
-        );
-        let clamped = tensor::ops::nonlinearities::clamp(inputs[0], ACTIVATION_BOUND);
-        tensor::ops::nonlinearities::erffunc(&clamped, scale_to_multiplier(MODEL_SCALE as i32))
+        let activation_bound = self.scale as usize + 3;
+        let clamped = tensor::ops::nonlinearities::clamp(inputs[0], activation_bound);
+        tensor::ops::nonlinearities::erffunc(&clamped, scale_to_multiplier(self.scale))
     }
 
     fn requires_shape_equality(&self) -> bool {

--- a/atlas-onnx-tracer/src/ops/mod.rs
+++ b/atlas-onnx-tracer/src/ops/mod.rs
@@ -310,21 +310,17 @@ pub fn sat_binop_intermediate(
     }
 }
 
-/// Shared evaluation for the periodic trig operators ([`Sin`], [`Cos`]).
-///
-/// Both reduce the input modulo a `4π` approximation before applying their
-/// nonlinearity at the operator's scale, so the only thing that differs
-/// between them is the `nonlinearity` function itself.
+/// Shared evaluation for the periodic trig operators ([`Sin`], [`Cos`]). Modulus is derived
+/// per-call from `scale`, to the most suitable approximation of a `2π` multiple.
 pub(crate) fn eval_trig(
     input: &Tensor<i32>,
     scale: i32,
     nonlinearity: fn(&Tensor<i32>, f64) -> Tensor<i32>,
 ) -> Tensor<i32> {
-    use crate::{
-        model::consts::FOUR_PI_APPROX, tensor::ops::nonlinearities::const_rem,
-        utils::quantize::scale_to_multiplier,
-    };
-    let remainder = const_rem(input, FOUR_PI_APPROX);
+    use crate::{tensor::ops::nonlinearities::const_rem, utils::quantize::scale_to_multiplier};
+    use common::consts::trig_period_modulus;
+    let multiple_2pi = trig_period_modulus(scale as u32) as i32;
+    let remainder = const_rem(input, multiple_2pi);
     nonlinearity(&remainder, scale_to_multiplier(scale))
 }
 

--- a/atlas-onnx-tracer/src/ops/sigmoid.rs
+++ b/atlas-onnx-tracer/src/ops/sigmoid.rs
@@ -3,17 +3,13 @@ use crate::{
     tensor::{self, Tensor},
     utils::quantize::scale_to_multiplier,
 };
-use common::consts::{ACTIVATION_BOUND, MODEL_SCALE};
 
 impl Op for Sigmoid {
     #[tracing::instrument(name = "Sigmoid::f", skip_all)]
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        debug_assert_eq!(
-            self.scale, MODEL_SCALE as i32,
-            "Sigmoid only supports scale={MODEL_SCALE}"
-        );
-        let clamped = tensor::ops::nonlinearities::clamp(inputs[0], ACTIVATION_BOUND);
-        tensor::ops::nonlinearities::sigmoid(&clamped, scale_to_multiplier(MODEL_SCALE as i32))
+        let activation_bound = self.scale as usize + 3;
+        let clamped = tensor::ops::nonlinearities::clamp(inputs[0], activation_bound);
+        tensor::ops::nonlinearities::sigmoid(&clamped, scale_to_multiplier(self.scale))
     }
 
     fn requires_shape_equality(&self) -> bool {

--- a/atlas-onnx-tracer/src/ops/tanh.rs
+++ b/atlas-onnx-tracer/src/ops/tanh.rs
@@ -3,17 +3,13 @@ use crate::{
     tensor::{self, Tensor},
     utils::quantize::scale_to_multiplier,
 };
-use common::consts::{ACTIVATION_BOUND, MODEL_SCALE};
 
 impl Op for Tanh {
     #[tracing::instrument(name = "Tanh::f", skip_all)]
     fn f(&self, inputs: Vec<&Tensor<i32>>) -> Tensor<i32> {
-        debug_assert_eq!(
-            self.scale, MODEL_SCALE as i32,
-            "Tanh only supports scale={MODEL_SCALE}"
-        );
-        let clamped = tensor::ops::nonlinearities::clamp(inputs[0], ACTIVATION_BOUND);
-        tensor::ops::nonlinearities::tanh(&clamped, scale_to_multiplier(MODEL_SCALE as i32))
+        let activation_bound = self.scale as usize + 3;
+        let clamped = tensor::ops::nonlinearities::clamp(inputs[0], activation_bound);
+        tensor::ops::nonlinearities::tanh(&clamped, scale_to_multiplier(self.scale))
     }
 
     fn requires_shape_equality(&self) -> bool {

--- a/common/src/consts.rs
+++ b/common/src/consts.rs
@@ -17,7 +17,7 @@ pub const MODEL_SCALE: usize = 8;
 pub const ACTIVATION_BOUND: usize = MODEL_SCALE + 3;
 
 /// One more than [`ACTIVATION_BOUND`]; the small activation table's log2 size.
-pub const ACTIVATION_TABLE_BOUND: usize = ACTIVATION_BOUND + 1;
+pub const ACTIVATION_TABLE_VARS: usize = ACTIVATION_BOUND + 1;
 
 /// log2 of softmax's saturating-clamp table size at [`MODEL_SCALE`]: the padded
 /// `hi_size * base` from `generate_exp_lut_decomposed` (`atlas-onnx-tracer::ops::softmax`) at

--- a/common/src/consts.rs
+++ b/common/src/consts.rs
@@ -10,7 +10,7 @@ pub const LOG_K: usize = XLEN * 2;
 /// `atlas-onnx-tracer`'s `DEFAULT_SCALE`). Several lookup-table shapes in this codebase
 /// (activation clamping, softmax's saturating clamp) are const-generic on a bound derived from
 /// this value rather than the model's runtime scale, so changing it requires recompiling.
-pub const MODEL_SCALE: usize = 8;
+pub const MODEL_SCALE: usize = 12;
 
 /// Clamps Erf/Sigmoid/Tanh input to `[-8, 8)` at model scale [`MODEL_SCALE`], before the small
 /// activation-table lookup.

--- a/common/src/consts.rs
+++ b/common/src/consts.rs
@@ -21,11 +21,103 @@ pub const ACTIVATION_TABLE_VARS: usize = ACTIVATION_BOUND + 1;
 
 /// log2 of softmax's saturating-clamp table size at [`MODEL_SCALE`]: the padded
 /// `hi_size * base` from `generate_exp_lut_decomposed` (`atlas-onnx-tracer::ops::softmax`) at
-/// that scale, rounded up to the next power of two. `ln`/`exp` aren't const-evaluable in stable
-/// Rust, so these are precomputed per supported `MODEL_SCALE` rather than derived here; add a new
-/// arm (re-deriving the bound offline) before switching to an untested scale.
-pub const SOFTMAX_CLAMP_BOUND: usize = match MODEL_SCALE {
-    8 => 11,
-    12 => 16,
-    _ => panic!("no precomputed SOFTMAX_CLAMP_BOUND for this MODEL_SCALE"),
-};
+/// that scale, rounded up to the next power of two. Derived at compile time by
+/// [`softmax_clamp_bound`].
+pub const SOFTMAX_CLAMP_BOUND: usize = softmax_clamp_bound(MODEL_SCALE as u32);
+
+/// Fixed-point modulus `round(k * 2π * 2^MODEL_SCALE)` for the smallest `k` that keeps rounding
+/// error low (see [`trig_period_search`]), used to reduce Cos/Sin inputs before lookup, and to
+/// size their lookup tables.
+pub const TRIG_PERIOD_MODULUS: u32 = trig_period_modulus(MODEL_SCALE as u32);
+
+/// Compile-time derivation of [`TRIG_PERIOD_MODULUS`] for an arbitrary `scale`.
+pub const fn trig_period_modulus(scale: u32) -> u32 {
+    let m = trig_period_search(scale);
+    assert!(m <= u32::MAX as u128, "trig period modulus overflowed u32");
+    m as u32
+}
+
+/// `round(π * 2^64)`: π in Q64.64 fixed point.
+const PI_Q64: u128 = 57_952_155_664_616_982_739;
+
+/// Absolute-error tolerance for [`trig_period_search`], in Q64.64 fixed point (`round(0.01 *
+/// 2^64)`).
+const TRIG_PERIOD_ERROR_TOLERANCE_Q64: u128 = 184_467_440_737_095_516;
+
+/// Search bound for [`trig_period_search`]; comfortably above what scales 4..=20 need.
+const TRIG_PERIOD_SEARCH_MAX_K: u128 = 1 << 16;
+
+/// Searches multiples `k = 1, 2, 3, ...` of `2π` for the smallest whose fixed-point modulus
+/// `round(k * 2π * 2^scale)` is within [`TRIG_PERIOD_ERROR_TOLERANCE_Q64`] of the true value —
+/// smaller `k` means a smaller lookup table, so it's preferred when accurate enough. Returns the
+/// modulus.
+const fn trig_period_search(scale: u32) -> u128 {
+    let mut k: u128 = 1;
+    loop {
+        // val_q64 = k * 2π * 2^scale, in Q64.64 fixed point.
+        let val_q64 = 2 * k * PI_Q64 * (1u128 << scale);
+        let m = (val_q64 + (1u128 << 63)) >> 64;
+        let approx_q64 = m << 64;
+        let err_q64 = val_q64.abs_diff(approx_q64);
+        if err_q64 <= TRIG_PERIOD_ERROR_TOLERANCE_Q64 {
+            return m;
+        }
+        assert!(
+            k < TRIG_PERIOD_SEARCH_MAX_K,
+            "no 2π multiple found within search bound"
+        );
+        k += 1;
+    }
+}
+
+/// Compile-time derivation of [`SOFTMAX_CLAMP_BOUND`] for an arbitrary `scale`, mirroring
+/// `atlas_onnx_tracer::ops::softmax::generate_exp_lut_decomposed`'s arithmetic in fixed-point
+/// integers (that function needs non-const `f64::ln`, so can't run in `const` context; since its
+/// multiplier `S = 2^scale` is always a power of two, `ln(2S) = (scale + 1) * ln(2)` avoids
+/// needing a real logarithm at all).
+pub const fn softmax_clamp_bound(scale: u32) -> usize {
+    /// `round(ln(2) * 2^32)`.
+    const LN2_Q32: u128 = 2_977_044_472;
+    const Q32: u128 = 1 << 32;
+
+    let s = 1u128 << scale; // S = 2^scale
+
+    // needed = ceil(S * ln(2S)) + 2, where ln(2S) = (scale + 1) * ln(2).
+    let numerator = s * (scale as u128 + 1) * LN2_Q32;
+    let needed = ceil_div(numerator, Q32) + 2;
+
+    // base = 2 ^ ceil(log2(needed) / 2): power-of-two closest to sqrt(needed).
+    let log2_needed = ceil_ilog2(needed);
+    let log2_base = ceil_div(log2_needed as u128, 2) as u32;
+    let base = 1u128 << log2_base;
+
+    // Table size is hi_size*base = needed floored to a multiple of base, plus a 2*base margin;
+    // needed + 2*base is a safe upper bound without reconstructing hi_size.
+    ceil_ilog2(needed + 2 * base) as usize
+}
+
+/// `ceil(a / b)` for `b > 0`.
+const fn ceil_div(a: u128, b: u128) -> u128 {
+    a.div_ceil(b)
+}
+
+/// `ceil(log2(x))` for `x >= 1`.
+const fn ceil_ilog2(x: u128) -> u32 {
+    if x <= 1 { 0 } else { (x - 1).ilog2() + 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_known_values() {
+        assert_eq!(softmax_clamp_bound(8), 11);
+        assert_eq!(softmax_clamp_bound(12), 16);
+    }
+
+    #[test]
+    fn trig_period_modulus_at_scale_8() {
+        assert_eq!(trig_period_modulus(8), 3217);
+    }
+}

--- a/common/src/consts.rs
+++ b/common/src/consts.rs
@@ -30,6 +30,13 @@ pub const SOFTMAX_CLAMP_BOUND: usize = softmax_clamp_bound(MODEL_SCALE as u32);
 /// size their lookup tables.
 pub const TRIG_PERIOD_MODULUS: u32 = trig_period_modulus(MODEL_SCALE as u32);
 
+/// Guards the `u32`→`i32` cast at `TRIG_PERIOD_MODULUS`'s many tensor-arithmetic call sites:
+/// fails the build if `MODEL_SCALE` is ever pushed high enough for that cast to overflow.
+const _: () = assert!(
+    TRIG_PERIOD_MODULUS <= i32::MAX as u32,
+    "TRIG_PERIOD_MODULUS overflows i32 at this MODEL_SCALE"
+);
+
 /// Compile-time derivation of [`TRIG_PERIOD_MODULUS`] for an arbitrary `scale`.
 pub const fn trig_period_modulus(scale: u32) -> u32 {
     let m = trig_period_search(scale);

--- a/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
+++ b/jolt-atlas-core/src/onnx_proof/e2e_tests.rs
@@ -1395,7 +1395,7 @@ fn test_div_zk() {
 #[test]
 fn test_sigmoid_zk() {
     use atlas_onnx_tracer::model::test::ModelBuilder;
-    use common::consts::ACTIVATION_TABLE_BOUND;
+    use common::consts::ACTIVATION_TABLE_VARS;
     let size = 1 << 4;
     let mut rng = StdRng::seed_from_u64(0xBF15);
     let min_val = -(1i32 << (ACTIVATION_TABLE_BOUND - 1));
@@ -1421,7 +1421,7 @@ fn test_sigmoid_zk() {
 #[test]
 fn test_tanh_zk() {
     use atlas_onnx_tracer::model::test::ModelBuilder;
-    use common::consts::ACTIVATION_TABLE_BOUND;
+    use common::consts::ACTIVATION_TABLE_VARS;
     let size = 1 << 4;
     let mut rng = StdRng::seed_from_u64(0xBF16);
     let min_val = -(1i32 << (ACTIVATION_TABLE_BOUND - 1));
@@ -1447,7 +1447,7 @@ fn test_tanh_zk() {
 #[test]
 fn test_erf_zk() {
     use atlas_onnx_tracer::model::test::ModelBuilder;
-    use common::consts::ACTIVATION_TABLE_BOUND;
+    use common::consts::ACTIVATION_TABLE_VARS;
     let size = 1 << 4;
     let mut rng = StdRng::seed_from_u64(0xBF17);
     let min_val = -(1i32 << (ACTIVATION_TABLE_BOUND - 1));

--- a/jolt-atlas-core/src/onnx_proof/neural_teleport/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/neural_teleport/cos.rs
@@ -1,16 +1,17 @@
 //! Cosine activation lookup table for neural teleportation.
 //!
-//! This table stores cos(x) values for x in [0, 4π), scaled by `SCALE`.
+//! This table stores cos(x) values for x in [0, TRIG_PERIOD_MODULUS), scaled by `SCALE_FACTOR`.
 
-use super::SCALE;
-use atlas_onnx_tracer::{model::consts::FOUR_PI_APPROX, tensor::Tensor};
+use super::SCALE_FACTOR;
+use atlas_onnx_tracer::tensor::Tensor;
+use common::consts::TRIG_PERIOD_MODULUS;
 
 /// Fixed lookup table bit width for cosine teleportation.
 ///
-/// The table size is the next power of two above the `4π` period approximation,
-/// so all valid remainders in [0, FOUR_PI_APPROX) map to valid table indices.
+/// The table size is the next power of two above the trig period modulus, so all valid
+/// remainders in [0, TRIG_PERIOD_MODULUS) map to valid table indices.
 pub const COS_LOG_TABLE_SIZE: usize =
-    (FOUR_PI_APPROX as usize).next_power_of_two().ilog2() as usize;
+    (TRIG_PERIOD_MODULUS as usize).next_power_of_two().ilog2() as usize;
 
 /// Cosine lookup table implementation for neural teleportation.
 #[derive(Debug, Clone, Copy, Default)]
@@ -24,14 +25,15 @@ impl CosTable {
 
     /// Materialize the lookup table with cosine values.
     ///
-    /// Creates a lookup table where indices represent teleported remainders
-    /// in [0, 8π), and values are `cos(index)` scaled by `SCALE`.
+    /// Creates a lookup table where indices represent teleported remainders in
+    /// [0, table_size), and values are `cos(index)` scaled by `SCALE_FACTOR`.
     pub fn materialize() -> Vec<i32> {
         let table_size = Self::table_size();
         let indices: Vec<i32> = (0..table_size).map(|i| i as i32).collect();
         let indices_tensor = Tensor::new(Some(&indices), &[1, table_size])
             .expect("failed to build cos LUT input tensor");
-        let result = atlas_onnx_tracer::tensor::ops::nonlinearities::cos(&indices_tensor, SCALE);
+        let result =
+            atlas_onnx_tracer::tensor::ops::nonlinearities::cos(&indices_tensor, SCALE_FACTOR);
         result.data().to_vec()
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/neural_teleport/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/neural_teleport/mod.rs
@@ -11,8 +11,10 @@ pub mod range_and_onehot;
 pub mod sin;
 pub mod utils;
 
-/// Fixed-point scale factor: maps [-1, 1] to [-256, 256]
-pub const SCALE: f64 = 256.0;
+use common::consts::MODEL_SCALE;
+
+/// Cos/Sin table output scale: `2^MODEL_SCALE`.
+pub const SCALE_FACTOR: f64 = (1u128 << MODEL_SCALE) as f64;
 
 /// Converts an n-bit index to a signed integer using two's complement.
 ///

--- a/jolt-atlas-core/src/onnx_proof/neural_teleport/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/neural_teleport/sin.rs
@@ -1,16 +1,17 @@
 //! Sine activation lookup table for neural teleportation.
 //!
-//! This table stores sin(x) values for x in [0, 4π), scaled by `SCALE`.
+//! This table stores sin(x) values for x in [0, TRIG_PERIOD_MODULUS), scaled by `SCALE_FACTOR`.
 
-use super::SCALE;
-use atlas_onnx_tracer::{model::consts::FOUR_PI_APPROX, tensor::Tensor};
+use super::SCALE_FACTOR;
+use atlas_onnx_tracer::tensor::Tensor;
+use common::consts::TRIG_PERIOD_MODULUS;
 
 /// Fixed lookup table bit width for sine teleportation.
 ///
-/// The table size is the next power of two above the `4π` period approximation,
-/// so all valid remainders in [0, FOUR_PI_APPROX) map to valid table indices.
+/// The table size is the next power of two above the trig period modulus, so all valid
+/// remainders in [0, TRIG_PERIOD_MODULUS) map to valid table indices.
 pub const SIN_LOG_TABLE_SIZE: usize =
-    (FOUR_PI_APPROX as usize).next_power_of_two().ilog2() as usize;
+    (TRIG_PERIOD_MODULUS as usize).next_power_of_two().ilog2() as usize;
 
 /// Sine lookup table implementation for neural teleportation.
 #[derive(Debug, Clone, Copy, Default)]
@@ -24,14 +25,15 @@ impl SinTable {
 
     /// Materialize the lookup table with sine values.
     ///
-    /// Creates a lookup table where indices represent teleported remainders
-    /// in [0, 8π), and values are `sin(index)` scaled by `SCALE`.
+    /// Creates a lookup table where indices represent teleported remainders in
+    /// [0, table_size), and values are `sin(index)` scaled by `SCALE_FACTOR`.
     pub fn materialize() -> Vec<i32> {
         let table_size = Self::table_size();
         let indices: Vec<i32> = (0..table_size).map(|i| i as i32).collect();
         let indices_tensor = Tensor::new(Some(&indices), &[1, table_size])
             .expect("failed to build sin LUT input tensor");
-        let result = atlas_onnx_tracer::tensor::ops::nonlinearities::sin(&indices_tensor, SCALE);
+        let result =
+            atlas_onnx_tracer::tensor::ops::nonlinearities::sin(&indices_tensor, SCALE_FACTOR);
         result.data().to_vec()
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/activation_clamped/mod.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/activation_clamped/mod.rs
@@ -29,7 +29,7 @@ use atlas_onnx_tracer::{
     tensor::{ops::nonlinearities, Tensor},
 };
 use common::{
-    consts::{ACTIVATION_BOUND, ACTIVATION_TABLE_BOUND, XLEN},
+    consts::{ACTIVATION_BOUND, ACTIVATION_TABLE_VARS, XLEN},
     parallel::par_enabled,
     CommittedPoly, VirtualPoly,
 };
@@ -184,7 +184,7 @@ impl<F: JoltField, Table: SmallActivationTable> SumcheckInstanceParams<F>
     }
 
     fn num_rounds(&self) -> usize {
-        ACTIVATION_TABLE_BOUND
+        ACTIVATION_TABLE_VARS
     }
 
     #[cfg(feature = "zk")]
@@ -215,7 +215,7 @@ impl<F: JoltField, Table: SmallActivationTable> SumcheckInstanceParams<F>
         let opening_point = self.normalize_opening_point(&sumcheck_challenges.into_opening());
         let table = MultilinearPolynomial::from(Table::materialize());
         let table_claim = table.evaluate(&opening_point.r);
-        let int_eval = SignedIdentityPoly::new(ACTIVATION_TABLE_BOUND).evaluate(&opening_point.r);
+        let int_eval = SignedIdentityPoly::new(ACTIVATION_TABLE_VARS).evaluate(&opening_point.r);
         vec![table_claim + self.gamma * int_eval]
     }
 }
@@ -263,16 +263,16 @@ impl<F: JoltField, Table: SmallActivationTable> SmallTableProver<F, Table> {
         let input_onehot: Vec<F> = compute_ra_evals_nbits_2comp(
             &params.r_node_output.r,
             &clamped_tensor,
-            ACTIVATION_TABLE_BOUND,
+            ACTIVATION_TABLE_VARS,
         );
         let input_onehot = MultilinearPolynomial::from(input_onehot);
         assert_eq!(input_onehot.len(), table.len());
-        let identity = SignedIdentityPoly::new(ACTIVATION_TABLE_BOUND);
+        let identity = SignedIdentityPoly::new(ACTIVATION_TABLE_VARS);
 
         let lookup_indices: Vec<usize> = clamped_tensor_padded
             .par_iter()
             .with_min_len(par_enabled())
-            .map(|&x| n_bits_to_usize(x, ACTIVATION_TABLE_BOUND))
+            .map(|&x| n_bits_to_usize(x, ACTIVATION_TABLE_VARS))
             .collect();
 
         Self {
@@ -395,7 +395,7 @@ impl<F: JoltField, T: Transcript, Table: SmallActivationTable> SumcheckInstanceV
 
         let ra_claim = accessor.get_advice(VirtualPoly::ActivationSmallRa).1;
         let table_claim = self.table.evaluate(&opening_point.r);
-        let int_eval = SignedIdentityPoly::new(ACTIVATION_TABLE_BOUND).evaluate(&opening_point.r);
+        let int_eval = SignedIdentityPoly::new(ACTIVATION_TABLE_VARS).evaluate(&opening_point.r);
 
         ra_claim * (table_claim + self.params.gamma * int_eval)
     }
@@ -441,11 +441,11 @@ impl RaOneHotEncoding for SmallTableRaEncoding {
     }
 
     fn log_k(&self) -> usize {
-        ACTIVATION_TABLE_BOUND
+        ACTIVATION_TABLE_VARS
     }
 
     fn one_hot_params(&self) -> OneHotParams {
-        OneHotParams::from_config_and_log_K(&OneHotConfig::default(), ACTIVATION_TABLE_BOUND)
+        OneHotParams::from_config_and_log_K(&OneHotConfig::default(), ACTIVATION_TABLE_VARS)
     }
 }
 

--- a/jolt-atlas-core/src/onnx_proof/ops/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cos.rs
@@ -19,13 +19,13 @@ use crate::{
 };
 use atlas_onnx_tracer::{
     model::{
-        consts::FOUR_PI_APPROX,
         trace::{LayerData, Trace},
         ComputationGraph,
     },
     node::ComputationNode,
     ops::Cos,
 };
+use common::consts::{MODEL_SCALE, TRIG_PERIOD_MODULUS};
 use common::parallel::par_enabled;
 use common::{CommittedPoly, VirtualPoly};
 #[cfg(feature = "zk")]
@@ -70,13 +70,19 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
         node: &ComputationNode,
         prover: &mut Prover<F, T>,
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
+        assert_eq!(
+            self.scale, MODEL_SCALE as i32,
+            "Cos teleportation proving is only calibrated for MODEL_SCALE={MODEL_SCALE} \
+             (got {})",
+            self.scale
+        );
         let mut results = Vec::new();
 
         // Stage 1a: Neural teleportation remainder proof
         let div_params = TeleportDivisionParams::new_from_transcript(
             node.clone(),
             &mut prover.transcript,
-            FOUR_PI_APPROX,
+            TRIG_PERIOD_MODULUS as i32,
         );
         let mut div_sumcheck = TeleportDivisionProver::new(&prover.trace, div_params);
 
@@ -137,6 +143,12 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
+        assert_eq!(
+            self.scale, MODEL_SCALE as i32,
+            "Cos teleportation verifying is only calibrated for MODEL_SCALE={MODEL_SCALE} \
+             (got {})",
+            self.scale
+        );
         // Stage 1a: Neural teleportation remainder verification
         let div_proof = verifier
             .proofs
@@ -145,7 +157,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
 
         let div_verifier = TeleportDivisionVerifier::new_from_transcript(
             node.clone(),
-            FOUR_PI_APPROX,
+            TRIG_PERIOD_MODULUS as i32,
             &mut verifier.transcript,
         );
         Sumcheck::verify(
@@ -325,11 +337,12 @@ impl<F: JoltField> CosProver<F> {
     ) -> Self {
         let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
         let input = operands[0];
-        let (_quotient_tensor, remainder_tensor) = compute_division(input, FOUR_PI_APPROX);
+        let (_quotient_tensor, remainder_tensor) =
+            compute_division(input, TRIG_PERIOD_MODULUS as i32);
 
         assert!(remainder_tensor
             .iter()
-            .all(|&x| (0..FOUR_PI_APPROX).contains(&x)));
+            .all(|&x| (0..TRIG_PERIOD_MODULUS as i32).contains(&x)));
 
         let cos_table = MultilinearPolynomial::from(CosTable::materialize());
         let input_onehot: Vec<F> = compute_ra_evals_direct(
@@ -550,7 +563,7 @@ impl<F: JoltField, T: Transcript> NeuralTeleportRangeOneHot<F, T> for Cos {
     fn lookup_indices(&self, node: &ComputationNode, trace: &Trace) -> Vec<usize> {
         let LayerData { operands, .. } = Trace::layer_data(trace, node);
         let input = operands[0];
-        let (_, remainder) = compute_division(input, FOUR_PI_APPROX);
+        let (_, remainder) = compute_division(input, TRIG_PERIOD_MODULUS as i32);
         remainder
             .par_iter()
             .with_min_len(par_enabled())
@@ -572,7 +585,7 @@ mod tests {
     };
     use rand::{rngs::StdRng, SeedableRng};
 
-    use super::FOUR_PI_APPROX;
+    use common::consts::TRIG_PERIOD_MODULUS;
 
     fn cos_model(input_shape: &[usize]) -> Model {
         let mut b = ModelBuilder::new();
@@ -593,20 +606,8 @@ mod tests {
 
     #[test]
     fn test_cos_periodic_boundary_inputs() {
-        let input = Tensor::new(
-            Some(&[
-                -FOUR_PI_APPROX - 1,
-                -FOUR_PI_APPROX,
-                -1,
-                0,
-                1,
-                FOUR_PI_APPROX - 1,
-                FOUR_PI_APPROX,
-                FOUR_PI_APPROX + 1,
-            ]),
-            &[8],
-        )
-        .unwrap();
+        let m = TRIG_PERIOD_MODULUS as i32;
+        let input = Tensor::new(Some(&[-m - 1, -m, -1, 0, 1, m - 1, m, m + 1]), &[8]).unwrap();
         let model = cos_model(&[8]);
         unit_test_op(model, &[input]);
     }

--- a/jolt-atlas-core/src/onnx_proof/ops/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cos.rs
@@ -143,12 +143,13 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
-        assert_eq!(
-            self.scale, MODEL_SCALE as i32,
-            "Cos teleportation verifying is only calibrated for MODEL_SCALE={MODEL_SCALE} \
-             (got {})",
-            self.scale
-        );
+        if self.scale != MODEL_SCALE as i32 {
+            return Err(ProofVerifyError::InvalidOpeningProof(format!(
+                "Cos teleportation verifying is only calibrated for MODEL_SCALE={MODEL_SCALE} \
+                     (got {})",
+                self.scale
+            )));
+        }
         // Stage 1a: Neural teleportation remainder verification
         let div_proof = verifier
             .proofs

--- a/jolt-atlas-core/src/onnx_proof/ops/erf.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/erf.rs
@@ -10,7 +10,7 @@ use crate::onnx_proof::{
 };
 use atlas_onnx_tracer::{node::ComputationNode, ops::Erf, tensor::ops::nonlinearities};
 use common::{
-    consts::{ACTIVATION_TABLE_BOUND, MODEL_SCALE},
+    consts::{ACTIVATION_TABLE_VARS, MODEL_SCALE},
     CommittedPoly,
 };
 use joltworks::{
@@ -24,7 +24,7 @@ pub(crate) struct ErfTableMarker;
 impl SmallActivationTable for ErfTableMarker {
     fn materialize() -> Vec<i32> {
         crate::onnx_proof::neural_teleport::utils::materialize_signed_activation_table(
-            ACTIVATION_TABLE_BOUND,
+            ACTIVATION_TABLE_VARS,
             1,
             MODEL_SCALE as i32,
             nonlinearities::erffunc,
@@ -63,7 +63,7 @@ mod tests {
         model::{test::ModelBuilder, Model},
         tensor::Tensor,
     };
-    use common::consts::ACTIVATION_TABLE_BOUND;
+    use common::consts::ACTIVATION_BOUND;
     use rand::{rngs::StdRng, SeedableRng};
 
     fn erf_model(input_shape: &[usize]) -> Model {
@@ -89,8 +89,8 @@ mod tests {
     #[ignore = "TODO: non-power-of-two erf path not fully validated yet"]
     fn test_erf_non_power_of_two_input_len() {
         let t = 1000;
-        const MIN_INPUT_VALUE: i32 = -(1 << (ACTIVATION_TABLE_BOUND - 1));
-        const MAX_INPUT_VALUE: i32 = 1 << (ACTIVATION_TABLE_BOUND - 1);
+        const MIN_INPUT_VALUE: i32 = -(1 << ACTIVATION_BOUND);
+        const MAX_INPUT_VALUE: i32 = 1 << ACTIVATION_BOUND;
         let mut rng = StdRng::seed_from_u64(0x88A);
         let input = Tensor::random_range(&mut rng, &[t], MIN_INPUT_VALUE..MAX_INPUT_VALUE);
         let model = erf_model(&[t]);

--- a/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sigmoid.rs
@@ -10,7 +10,7 @@ use crate::onnx_proof::{
 };
 use atlas_onnx_tracer::{node::ComputationNode, ops::Sigmoid, tensor::ops::nonlinearities};
 use common::{
-    consts::{ACTIVATION_TABLE_BOUND, MODEL_SCALE},
+    consts::{ACTIVATION_TABLE_VARS, MODEL_SCALE},
     CommittedPoly,
 };
 use joltworks::{
@@ -24,7 +24,7 @@ pub(crate) struct SigmoidTableMarker;
 impl SmallActivationTable for SigmoidTableMarker {
     fn materialize() -> Vec<i32> {
         crate::onnx_proof::neural_teleport::utils::materialize_signed_activation_table(
-            ACTIVATION_TABLE_BOUND,
+            ACTIVATION_TABLE_VARS,
             1,
             MODEL_SCALE as i32,
             nonlinearities::sigmoid,
@@ -63,7 +63,7 @@ mod tests {
         model::{test::ModelBuilder, Model},
         tensor::Tensor,
     };
-    use common::consts::ACTIVATION_TABLE_BOUND;
+    use common::consts::ACTIVATION_BOUND;
     use rand::{rngs::StdRng, SeedableRng};
 
     fn sigmoid_model(input_shape: &[usize]) -> Model {
@@ -89,8 +89,8 @@ mod tests {
     #[ignore = "TODO: non-power-of-two sigmoid path not fully validated yet"]
     fn test_sigmoid_non_power_of_two_input_len() {
         let t = 1000;
-        const MIN_INPUT_VALUE: i32 = -(1 << (ACTIVATION_TABLE_BOUND - 1));
-        const MAX_INPUT_VALUE: i32 = 1 << (ACTIVATION_TABLE_BOUND - 1);
+        const MIN_INPUT_VALUE: i32 = -(1 << ACTIVATION_BOUND);
+        const MAX_INPUT_VALUE: i32 = 1 << ACTIVATION_BOUND;
         let mut rng = StdRng::seed_from_u64(0x88A);
         let input = Tensor::random_range(&mut rng, &[t], MIN_INPUT_VALUE..MAX_INPUT_VALUE);
         let model = sigmoid_model(&[t]);

--- a/jolt-atlas-core/src/onnx_proof/ops/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sin.rs
@@ -17,13 +17,13 @@ use crate::onnx_proof::{
 use crate::utils::opening_access::{AccOpeningAccessor, Target};
 use atlas_onnx_tracer::{
     model::{
-        consts::FOUR_PI_APPROX,
         trace::{LayerData, Trace},
         ComputationGraph,
     },
     node::ComputationNode,
     ops::Sin,
 };
+use common::consts::{MODEL_SCALE, TRIG_PERIOD_MODULUS};
 use common::parallel::par_enabled;
 use common::{CommittedPoly, VirtualPoly};
 #[cfg(feature = "zk")]
@@ -67,13 +67,19 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
         node: &ComputationNode,
         prover: &mut Prover<F, T>,
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
+        assert_eq!(
+            self.scale, MODEL_SCALE as i32,
+            "Sin teleportation proving is only calibrated for MODEL_SCALE={MODEL_SCALE} \
+             (got {})",
+            self.scale
+        );
         let mut results = Vec::new();
 
         // Stage 1a: Neural teleportation remainder proof
         let div_params = TeleportDivisionParams::new_from_transcript(
             node.clone(),
             &mut prover.transcript,
-            FOUR_PI_APPROX,
+            TRIG_PERIOD_MODULUS as i32,
         );
         let mut div_sumcheck = TeleportDivisionProver::new(&prover.trace, div_params);
 
@@ -135,6 +141,12 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
+        assert_eq!(
+            self.scale, MODEL_SCALE as i32,
+            "Sin teleportation verifying is only calibrated for MODEL_SCALE={MODEL_SCALE} \
+             (got {})",
+            self.scale
+        );
         // Stage 1a: Neural teleportation remainder verification
         let div_proof = verifier
             .proofs
@@ -143,7 +155,7 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
 
         let div_verifier = TeleportDivisionVerifier::new_from_transcript(
             node.clone(),
-            FOUR_PI_APPROX,
+            TRIG_PERIOD_MODULUS as i32,
             &mut verifier.transcript,
         );
         Sumcheck::verify(
@@ -321,11 +333,12 @@ impl<F: JoltField> SinProver<F> {
     ) -> Self {
         let LayerData { operands, output } = Trace::layer_data(trace, &params.computation_node);
         let input = operands[0];
-        let (_quotient_tensor, remainder_tensor) = compute_division(input, FOUR_PI_APPROX);
+        let (_quotient_tensor, remainder_tensor) =
+            compute_division(input, TRIG_PERIOD_MODULUS as i32);
 
         assert!(remainder_tensor
             .iter()
-            .all(|&x| (0..FOUR_PI_APPROX).contains(&x)));
+            .all(|&x| (0..TRIG_PERIOD_MODULUS as i32).contains(&x)));
 
         let sin_table = MultilinearPolynomial::from(SinTable::materialize());
         let input_onehot: Vec<F> = compute_ra_evals_direct(
@@ -547,7 +560,7 @@ impl<F: JoltField, T: Transcript> NeuralTeleportRangeOneHot<F, T> for Sin {
     fn lookup_indices(&self, node: &ComputationNode, trace: &Trace) -> Vec<usize> {
         let LayerData { operands, .. } = Trace::layer_data(trace, node);
         let input = operands[0];
-        let (_, remainder) = compute_division(input, FOUR_PI_APPROX);
+        let (_, remainder) = compute_division(input, TRIG_PERIOD_MODULUS as i32);
         remainder
             .par_iter()
             .with_min_len(par_enabled())
@@ -569,7 +582,7 @@ mod tests {
     };
     use rand::{rngs::StdRng, SeedableRng};
 
-    use super::FOUR_PI_APPROX;
+    use common::consts::TRIG_PERIOD_MODULUS;
 
     fn sin_model(input_shape: &[usize]) -> Model {
         let mut b = ModelBuilder::new();
@@ -590,20 +603,8 @@ mod tests {
 
     #[test]
     fn test_sin_periodic_boundary_inputs() {
-        let input = Tensor::new(
-            Some(&[
-                -FOUR_PI_APPROX - 1,
-                -FOUR_PI_APPROX,
-                -1,
-                0,
-                1,
-                FOUR_PI_APPROX - 1,
-                FOUR_PI_APPROX,
-                FOUR_PI_APPROX + 1,
-            ]),
-            &[8],
-        )
-        .unwrap();
+        let m = TRIG_PERIOD_MODULUS as i32;
+        let input = Tensor::new(Some(&[-m - 1, -m, -1, 0, 1, m - 1, m, m + 1]), &[8]).unwrap();
         let model = sin_model(&[8]);
         unit_test_op(model, &[input]);
     }

--- a/jolt-atlas-core/src/onnx_proof/ops/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sin.rs
@@ -141,12 +141,13 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
-        assert_eq!(
-            self.scale, MODEL_SCALE as i32,
-            "Sin teleportation verifying is only calibrated for MODEL_SCALE={MODEL_SCALE} \
-             (got {})",
-            self.scale
-        );
+        if self.scale != MODEL_SCALE as i32 {
+            return Err(ProofVerifyError::InvalidOpeningProof(format!(
+                "Sin teleportation verifying is only calibrated for MODEL_SCALE={MODEL_SCALE} \
+                     (got {})",
+                self.scale
+            )));
+        }
         // Stage 1a: Neural teleportation remainder verification
         let div_proof = verifier
             .proofs

--- a/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/tanh.rs
@@ -10,7 +10,7 @@ use crate::onnx_proof::{
 };
 use atlas_onnx_tracer::{node::ComputationNode, ops::Tanh, tensor::ops::nonlinearities};
 use common::{
-    consts::{ACTIVATION_TABLE_BOUND, MODEL_SCALE},
+    consts::{ACTIVATION_TABLE_VARS, MODEL_SCALE},
     CommittedPoly,
 };
 use joltworks::{
@@ -24,7 +24,7 @@ pub(crate) struct TanhTableMarker;
 impl SmallActivationTable for TanhTableMarker {
     fn materialize() -> Vec<i32> {
         crate::onnx_proof::neural_teleport::utils::materialize_signed_activation_table(
-            ACTIVATION_TABLE_BOUND,
+            ACTIVATION_TABLE_VARS,
             1,
             MODEL_SCALE as i32,
             nonlinearities::tanh,
@@ -63,7 +63,7 @@ mod tests {
         model::{test::ModelBuilder, Model},
         tensor::Tensor,
     };
-    use common::consts::ACTIVATION_TABLE_BOUND;
+    use common::consts::ACTIVATION_BOUND;
     use rand::{rngs::StdRng, SeedableRng};
 
     fn tanh_model(input_shape: &[usize]) -> Model {
@@ -89,8 +89,8 @@ mod tests {
     #[ignore = "non-power-of-two path not fully supported yet"]
     fn test_tanh_non_power_of_two_input_len() {
         let t = 1000;
-        const MIN_INPUT_VALUE: i32 = -(1 << (ACTIVATION_TABLE_BOUND - 1));
-        const MAX_INPUT_VALUE: i32 = 1 << (ACTIVATION_TABLE_BOUND - 1);
+        const MIN_INPUT_VALUE: i32 = -(1 << ACTIVATION_BOUND);
+        const MAX_INPUT_VALUE: i32 = 1 << ACTIVATION_BOUND;
         let mut rng = StdRng::seed_from_u64(0x889);
         let input = Tensor::random_range(&mut rng, &[t], MIN_INPUT_VALUE..MAX_INPUT_VALUE);
         let model = tanh_model(&[t]);

--- a/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
+++ b/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
@@ -1,10 +1,9 @@
 use atlas_onnx_tracer::{
-    model::consts::FOUR_PI_APPROX,
     node::ComputationNode,
     ops::{MeanOfSquares, Operator},
     tensor::Tensor,
 };
-use common::{CommittedPoly, VirtualPoly};
+use common::{consts::TRIG_PERIOD_MODULUS, CommittedPoly, VirtualPoly};
 use joltworks::{
     field::JoltField,
     poly::opening_proof::{OpeningAccumulator, OpeningId, SumcheckId},
@@ -319,7 +318,7 @@ pub struct TeleportRangeCheckOperands {
 impl RangeCheckingOperandsTrait for TeleportRangeCheckOperands {
     fn new(node: &ComputationNode) -> Self {
         let tau = match &node.operator {
-            Operator::Cos(_) | Operator::Sin(_) => FOUR_PI_APPROX,
+            Operator::Cos(_) | Operator::Sin(_) => TRIG_PERIOD_MODULUS as i32,
             _ => {
                 panic!("Expected Cos or Sin operator for neural teleportation division")
             }

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -29,7 +29,7 @@ use crate::{
     utils::{adjusted_remainder, compute_lookup_indices_from_operands},
 };
 use atlas_onnx_tracer::{
-    model::{consts::FOUR_PI_APPROX, trace::Trace, Model},
+    model::{trace::Trace, Model},
     node::ComputationNode,
     ops::{
         softmax::{generate_exp_lut_decomposed, softmax_last_axis_decomposed, softmax_z},
@@ -39,7 +39,7 @@ use atlas_onnx_tracer::{
     utils::quantize::scale_to_multiplier,
 };
 use common::{
-    consts::{ACTIVATION_BOUND, ACTIVATION_TABLE_VARS, LOG_K, XLEN},
+    consts::{ACTIVATION_BOUND, ACTIVATION_TABLE_VARS, LOG_K, TRIG_PERIOD_MODULUS, XLEN},
     parallel::par_enabled,
     CommittedPoly,
 };
@@ -329,7 +329,7 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPoly {
                     Operator::Cos(_) | Operator::Sin(_)
                 ));
                 let tau = match &computation_node.operator {
-                    Operator::Cos(_) | Operator::Sin(_) => FOUR_PI_APPROX,
+                    Operator::Cos(_) | Operator::Sin(_) => TRIG_PERIOD_MODULUS as i32,
                     _ => unreachable!(
                         "teleport quotient witness requested for non-teleport operator"
                     ),
@@ -452,7 +452,7 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPoly {
 
             CommittedPoly::CosRaD(node_idx, d_idx) | CommittedPoly::SinRaD(node_idx, d_idx) => {
                 const COS_LOG_TABLE_SIZE: usize =
-                    (FOUR_PI_APPROX as usize).next_power_of_two().ilog2() as usize;
+                    (TRIG_PERIOD_MODULUS as usize).next_power_of_two().ilog2() as usize;
 
                 let computation_node = &model.graph.nodes[node_idx];
                 assert!(
@@ -465,7 +465,7 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPoly {
                 let layer_data = Trace::layer_data(trace, computation_node);
                 let input = &layer_data.operands[0];
 
-                let (_quotient, remainder) = compute_division(input, FOUR_PI_APPROX);
+                let (_quotient, remainder) = compute_division(input, TRIG_PERIOD_MODULUS as i32);
                 let lookup_indices: Vec<usize> = remainder
                     .par_iter()
                     .with_min_len(par_enabled())

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -39,7 +39,7 @@ use atlas_onnx_tracer::{
     utils::quantize::scale_to_multiplier,
 };
 use common::{
-    consts::{ACTIVATION_BOUND, ACTIVATION_TABLE_BOUND, LOG_K, XLEN},
+    consts::{ACTIVATION_BOUND, ACTIVATION_TABLE_VARS, LOG_K, XLEN},
     parallel::par_enabled,
     CommittedPoly,
 };
@@ -109,10 +109,10 @@ fn build_activation_small_rad_witness<F: JoltField>(
     let lookup_indices: Vec<usize> = clamped
         .par_iter()
         .with_min_len(par_enabled())
-        .map(|&x| n_bits_to_usize(x, ACTIVATION_TABLE_BOUND))
+        .map(|&x| n_bits_to_usize(x, ACTIVATION_TABLE_VARS))
         .collect();
     let one_hot_params =
-        OneHotParams::from_config_and_log_K(&OneHotConfig::default(), ACTIVATION_TABLE_BOUND);
+        OneHotParams::from_config_and_log_K(&OneHotConfig::default(), ACTIVATION_TABLE_VARS);
     let h_indices =
         subprotocols::shout::compute_instruction_h_indices(&lookup_indices, &one_hot_params);
     MultilinearPolynomial::OneHot(OneHotPolynomial::from_indices(

--- a/jolt-atlas-core/src/onnx_proof/zk.rs
+++ b/jolt-atlas-core/src/onnx_proof/zk.rs
@@ -632,10 +632,10 @@ fn verify_cos_sin_zk(
         },
         utils::opening_access::AccOpeningAccessor,
     };
-    use common::CommittedPoly;
+    use common::{consts::TRIG_PERIOD_MODULUS, CommittedPoly};
     use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
 
-    let tau = atlas_onnx_tracer::model::consts::FOUR_PI_APPROX;
+    let tau = TRIG_PERIOD_MODULUS as i32;
 
     // 1. Division sumcheck (from transcript)
     {
@@ -875,10 +875,10 @@ fn prove_cos_sin_zk(
         },
         utils::opening_access::AccOpeningAccessor,
     };
-    use common::CommittedPoly;
+    use common::{consts::TRIG_PERIOD_MODULUS, CommittedPoly};
     use joltworks::lookup_tables::unsigned_less_than::UnsignedLessThanTable;
 
-    let tau = atlas_onnx_tracer::model::consts::FOUR_PI_APPROX;
+    let tau = TRIG_PERIOD_MODULUS as i32;
 
     // 1. Division sumcheck (r_node_output from transcript)
     let div_params =


### PR DESCRIPTION
This adds a test to recover the error contributed by each node when running a gpt2/qwen model.
The closest test to this was evaluating the error on the output of the node, compared to the expected output. This error could originate as much from the node's inputs as from the node's computation. 

The new test isolates error contributed by each node's computation.

Now, the tracer scale is no more depending on the `common` crate scale admitted by the VM, it is possible to trace a model at any desired scale.