### PR TITLE
Feat: Unary Rangecheck for constant bound

### DIFF
--- a/atlas-onnx-tracer/src/model/mod.rs
+++ b/atlas-onnx-tracer/src/model/mod.rs
@@ -288,6 +288,7 @@ impl Model {
                 | Operator::Add(_)
                 | Operator::Sub(_)
                 | Operator::Sum(_)
+                | Operator::ScalarConstDiv(_)
                 // Einsum commits a one-hot decomposition for its fused rescaling
                 // remainder range check (`k_chunk`-wide chunks, like Add/Sum).
                 | Operator::Einsum(_)
@@ -310,7 +311,6 @@ impl Model {
                 Operator::Cube(op) if op.scale > 0 => {
                     LOG_K_CHUNK + log_2(node.pow2_padded_num_output_elements())
                 }
-                Operator::ScalarConstDiv(_) => log_2(node.pow2_padded_num_output_elements()),
                 Operator::GatherSmall(_) => {
                     let input_nodes = self.get_input_nodes(node);
                     let num_words = input_nodes[0].output_dims[0];

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -27,7 +27,7 @@ canonical_serde_enum! {
     /// |-------|---------|
     /// | `NodeOutputRaD` / `{Cos,Sin}RaD` | One-hot read-address decompositions for activation-function lookup tables |
     /// | `Softmax*` | Polynomials specific to softmax sub-protocol |
-    /// | `Div* / Sqrt* / MeanOfSquares*` | Range-check one-hot polynomials for integer-arithmetic advice values |
+    /// | `Div* / Sqrt* / MeanOfSquares* / ScalarConstDiv*` | Range-check one-hot polynomials for integer-arithmetic advice values |
     /// | `*NodeQuotient / *NodeRemainder / *NodeInv / *NodeRsqrt` | Scalar advice polynomials for division / reciprocal-square-root |
     /// | `GatherRa` | Read-address polynomial for the Gather operator |
     /// | `SoftmaxRecipMultRemainder` | Remainder used in the reciprocal-multiplication check of softmax |
@@ -88,16 +88,18 @@ canonical_serde_enum! {
         /// * `1` – decomposition index `d`
         SqrtRangeCheckRaD(usize, usize),
 
+        /// Interleaved remainder `R` and (constant) divisor one-hot polynomial for the
+        /// **ScalarConstDiv** range check `R < b`.
+        ///
+        /// * `0` – node index
+        /// * `1` – decomposition index `d`
+        ScalarConstDivRangeCheckRaD(usize, usize),
+
         // ----- Scalar advice polynomials (node_index) -----
         /// Advice polynomial for the **quotient** in integer division.
         ///
         /// * `0` – node index
         DivNodeQuotient(usize),
-
-        /// Advice polynomial for the **remainder** in scalar-constant division.
-        ///
-        /// * `0` – node index
-        ScalarConstDivNodeRemainder(usize),
 
         /// Advice polynomial for the fused Rsqrt **quotient** `⌊S³ / x̂⌋`,
         /// i.e. the value fed into the integer square root.
@@ -291,11 +293,22 @@ canonical_serde_enum! {
         /// * `0` – node index
         MeanOfSquaresRangeCheckRa(usize),
 
+        /// Read-address polynomial derived from
+        /// [`CommittedPoly::ScalarConstDivRangeCheckRaD`].
+        ///
+        /// * `0` – node index
+        ScalarConstDivRangeCheckRa(usize),
+
         // ----- Division / square-root remainder & quotient polynomials -----
         /// Remainder polynomial for integer division advice.
         ///
         /// * `0` – node index
         DivRemainder(usize),
+
+        /// Remainder polynomial for scalar-constant division advice (`a = b·q + R`).
+        ///
+        /// * `0` – node index
+        ScalarConstDivRemainder(usize),
 
         /// Remainder polynomial for square-root advice.
         ///

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -27,7 +27,7 @@ canonical_serde_enum! {
     /// |-------|---------|
     /// | `NodeOutputRaD` / `{Cos,Sin}RaD` | One-hot read-address decompositions for activation-function lookup tables |
     /// | `Softmax*` | Polynomials specific to softmax sub-protocol |
-    /// | `Div* / Sqrt* / Teleport*` | Range-check one-hot polynomials for integer-arithmetic advice values |
+    /// | `Div* / Sqrt* / MeanOfSquares*` | Range-check one-hot polynomials for integer-arithmetic advice values |
     /// | `*NodeQuotient / *NodeRemainder / *NodeInv / *NodeRsqrt` | Scalar advice polynomials for division / reciprocal-square-root |
     /// | `GatherRa` | Read-address polynomial for the Gather operator |
     /// | `SoftmaxRecipMultRemainder` | Remainder used in the reciprocal-multiplication check of softmax |
@@ -87,13 +87,6 @@ canonical_serde_enum! {
         /// * `0` – node index
         /// * `1` – decomposition index `d`
         SqrtRangeCheckRaD(usize, usize),
-
-        /// Remainder and input one-hot polynomial for the **neural teleportation**
-        /// division range check.
-        ///
-        /// * `0` – node index
-        /// * `1` – decomposition index `d`
-        TeleportRangeCheckRaD(usize, usize),
 
         // ----- Scalar advice polynomials (node_index) -----
         /// Advice polynomial for the **quotient** in integer division.
@@ -225,7 +218,7 @@ canonical_serde_enum! {
     /// | `{Cos,Sin}Ra` | Read-address polynomials for activation-function lookups |
     /// | `Softmax*` | Intermediate polynomials arising in the softmax sub-protocol |
     /// | `HammingWeight` | Polynomial used in the Hamming-weight sumcheck |
-    /// | `Div* / Sqrt* / Teleport*` | Advice-derived polynomials proven via `ReadRafSumcheckProver` from committed one-hot polynomials |
+    /// | `Div* / Sqrt* / MeanOfSquares*` | Advice-derived polynomials proven via `ReadRafSumcheckProver` from committed one-hot polynomials |
     #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Allocative)]
     pub enum VirtualPoly {
         // ----- Node output -----
@@ -291,12 +284,6 @@ canonical_serde_enum! {
         ///
         /// * `0` – node index
         SqrtRangeCheckRa(usize),
-
-        /// Read-address polynomial derived from
-        /// [`CommittedPoly::TeleportRangeCheckRaD`].
-        ///
-        /// * `0` – node index
-        TeleportRangeCheckRa(usize),
 
         /// Read-address polynomial derived from
         /// [`CommittedPoly::MeanOfSquaresRangeCheckRaD`].

--- a/jolt-atlas-core/examples/cos_bench.rs
+++ b/jolt-atlas-core/examples/cos_bench.rs
@@ -5,6 +5,9 @@
 //!
 //! ```bash
 //! cargo run --release --package jolt-atlas-core --example cos_bench
+//! # Also prints mean-of-NUM_RUNS timings for ONNXProof::{commit_witness_polynomials,
+//! # iop,prove_reduced_openings} (accumulated in-process from their tracing spans):
+//! cargo run --release --package jolt-atlas-core --example cos_bench -- --trace-terminal
 //! ```
 use atlas_onnx_tracer::{model::test::ModelBuilder, tensor::Tensor};
 use common::consts::MODEL_SCALE;
@@ -13,10 +16,22 @@ use jolt_atlas_core::onnx_proof::{
     Blake2bTranscript, Bn254, Fr, HyperKZG, ONNXProof,
 };
 use rand::{rngs::StdRng, SeedableRng};
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan, util::SubscriberInitExt};
 
 const INPUT_LENS: &[usize] = &[1 << 8, 1 << 16];
 const NUM_RUNS: usize = 5;
+
+/// Top-level `ONNXProof::prove` stages to accumulate mean timings for.
+const STAGE_SPANS: &[&str] = &[
+    "ONNXProof::commit_witness_polynomials",
+    "ONNXProof::iop",
+    "ONNXProof::prove_reduced_openings",
+];
 
 fn cos_model(input_len: usize) -> atlas_onnx_tracer::model::Model {
     let mut b = ModelBuilder::new();
@@ -51,8 +66,85 @@ fn mean(durations: &[Duration]) -> Duration {
     durations.iter().sum::<Duration>() / durations.len() as u32
 }
 
+/// Timestamp stashed in a span's extensions on entry, read back on close.
+struct SpanStart(Instant);
+
+/// Per-stage-name accumulated durations, shared between the tracing layer (writer)
+/// and `main` (reader, once per input length).
+#[derive(Default, Clone)]
+struct StageTimings(Arc<Mutex<HashMap<&'static str, Vec<Duration>>>>);
+
+impl StageTimings {
+    /// Drains and returns each stage's mean duration, in `STAGE_SPANS` order.
+    fn take_means(&self) -> Vec<(&'static str, Duration)> {
+        let mut recorded = self.0.lock().unwrap();
+        STAGE_SPANS
+            .iter()
+            .filter_map(|&name| {
+                let durations = recorded.remove(name)?;
+                (!durations.is_empty()).then(|| (name, mean(&durations)))
+            })
+            .collect()
+    }
+}
+
+/// Records each `STAGE_SPANS` span's wall-clock duration into `StageTimings`.
+struct StageTimingLayer {
+    timings: StageTimings,
+}
+
+impl<S> tracing_subscriber::Layer<S> for StageTimingLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_enter(&self, id: &tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if STAGE_SPANS.contains(&span.name()) {
+            span.extensions_mut().insert(SpanStart(Instant::now()));
+        }
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        let name = span.name();
+        if !STAGE_SPANS.contains(&name) {
+            return;
+        }
+        let Some(elapsed) = span
+            .extensions()
+            .get::<SpanStart>()
+            .map(|start| start.0.elapsed())
+        else {
+            return;
+        };
+        self.timings
+            .0
+            .lock()
+            .unwrap()
+            .entry(name)
+            .or_default()
+            .push(elapsed);
+    }
+}
+
+/// Registers only [`StageTimingLayer`] — no `fmt` layer, so nothing prints to the
+/// terminal except this bench's own `println!`s. `--trace-terminal` on other examples
+/// (via `common::utils::logging::setup_tracing`) dumps every span's raw timing to the
+/// terminal; here the means are read back in-process instead, so that dump is unused
+/// noise and is skipped entirely.
+fn setup_stage_timing_tracing(timings: StageTimings) {
+    tracing_subscriber::registry()
+        .with(StageTimingLayer { timings })
+        .init();
+}
+
 fn main() {
     let mut rng = StdRng::seed_from_u64(0xC05);
+    let trace_terminal = std::env::args().any(|a| a == "--trace-terminal");
+    let stage_timings = StageTimings::default();
+    if trace_terminal {
+        setup_stage_timing_tracing(stage_timings.clone());
+    }
 
     println!("MODEL_SCALE = {MODEL_SCALE}");
     println!("runs per input length = {NUM_RUNS} (+1 warmup, discarded)");
@@ -66,8 +158,10 @@ fn main() {
         let verifier_preprocessing =
             AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_preprocessing);
 
-        // Warmup run, discarded (page faults, allocator warmup, etc.).
+        // Warmup run, discarded (page faults, allocator warmup, etc.); also discards
+        // its span timings so they don't skew the per-stage means below.
         run_once(&prover_preprocessing, &verifier_preprocessing, &input);
+        stage_timings.take_means();
 
         let mut prove_times = Vec::with_capacity(NUM_RUNS);
         let mut verify_times = Vec::with_capacity(NUM_RUNS);
@@ -83,5 +177,10 @@ fn main() {
         println!("verify times = {verify_times:?}");
         println!("mean prove time  = {:?}", mean(&prove_times));
         println!("mean verify time = {:?}", mean(&verify_times));
+        if trace_terminal {
+            for (name, stage_mean) in stage_timings.take_means() {
+                println!("mean {name} = {stage_mean:?}");
+            }
+        }
     }
 }

--- a/jolt-atlas-core/examples/scalar_const_div_bench.rs
+++ b/jolt-atlas-core/examples/scalar_const_div_bench.rs
@@ -1,0 +1,181 @@
+//! Prove/verify timing benchmark for a standalone ScalarConstDiv node.
+//!
+//! ```bash
+//! cargo run --release --package jolt-atlas-core --example scalar_const_div_bench
+//! # Also prints mean-of-NUM_RUNS timings for ONNXProof::{commit_witness_polynomials,
+//! # iop,prove_reduced_openings} (accumulated in-process from their tracing spans):
+//! cargo run --release --package jolt-atlas-core --example scalar_const_div_bench -- --trace-terminal
+//! ```
+use atlas_onnx_tracer::{model::test::ModelBuilder, tensor::Tensor};
+use common::consts::MODEL_SCALE;
+use jolt_atlas_core::onnx_proof::{
+    AtlasProverPreprocessing, AtlasSharedPreprocessing, AtlasVerifierPreprocessing,
+    Blake2bTranscript, Bn254, Fr, HyperKZG, ONNXProof,
+};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan, util::SubscriberInitExt};
+
+const INPUT_LENS: &[usize] = &[1 << 8, 1 << 16];
+const DIVISOR: i32 = 128;
+const NUM_RUNS: usize = 5;
+
+/// Top-level `ONNXProof::prove` stages to accumulate mean timings for.
+const STAGE_SPANS: &[&str] = &[
+    "ONNXProof::commit_witness_polynomials",
+    "ONNXProof::iop",
+    "ONNXProof::prove_reduced_openings",
+];
+
+fn scalar_const_div_model(input_len: usize) -> atlas_onnx_tracer::model::Model {
+    let mut b = ModelBuilder::new();
+    let i = b.input(vec![input_len]);
+    let res = b.scalar_const_div(i, DIVISOR);
+    b.mark_output(res);
+    b.build()
+}
+
+fn run_once(
+    prover_preprocessing: &AtlasProverPreprocessing<Fr, HyperKZG<Bn254>>,
+    verifier_preprocessing: &AtlasVerifierPreprocessing<Fr, HyperKZG<Bn254>>,
+    input: &Tensor<i32>,
+) -> (Duration, Duration) {
+    let prove_start = Instant::now();
+    let (proof, io, debug_info) = ONNXProof::<Fr, Blake2bTranscript, HyperKZG<Bn254>>::prove(
+        prover_preprocessing,
+        &[input.clone()],
+    );
+    let prove_time = prove_start.elapsed();
+
+    let verify_start = Instant::now();
+    proof
+        .verify(verifier_preprocessing, &io, debug_info)
+        .unwrap();
+    let verify_time = verify_start.elapsed();
+
+    (prove_time, verify_time)
+}
+
+fn mean(durations: &[Duration]) -> Duration {
+    durations.iter().sum::<Duration>() / durations.len() as u32
+}
+
+/// Timestamp stashed in a span's extensions on entry, read back on close.
+struct SpanStart(Instant);
+
+/// Per-stage-name accumulated durations, shared between the tracing layer (writer)
+/// and `main` (reader, once per input length).
+#[derive(Default, Clone)]
+struct StageTimings(Arc<Mutex<HashMap<&'static str, Vec<Duration>>>>);
+
+impl StageTimings {
+    /// Drains and returns each stage's mean duration, in `STAGE_SPANS` order.
+    fn take_means(&self) -> Vec<(&'static str, Duration)> {
+        let mut recorded = self.0.lock().unwrap();
+        STAGE_SPANS
+            .iter()
+            .filter_map(|&name| {
+                let durations = recorded.remove(name)?;
+                (!durations.is_empty()).then(|| (name, mean(&durations)))
+            })
+            .collect()
+    }
+}
+
+/// Records each `STAGE_SPANS` span's wall-clock duration into `StageTimings`.
+struct StageTimingLayer {
+    timings: StageTimings,
+}
+
+impl<S> tracing_subscriber::Layer<S> for StageTimingLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_enter(&self, id: &tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if STAGE_SPANS.contains(&span.name()) {
+            span.extensions_mut().insert(SpanStart(Instant::now()));
+        }
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        let name = span.name();
+        if !STAGE_SPANS.contains(&name) {
+            return;
+        }
+        let Some(elapsed) = span
+            .extensions()
+            .get::<SpanStart>()
+            .map(|start| start.0.elapsed())
+        else {
+            return;
+        };
+        self.timings
+            .0
+            .lock()
+            .unwrap()
+            .entry(name)
+            .or_default()
+            .push(elapsed);
+    }
+}
+
+/// Registers only [`StageTimingLayer`] — no `fmt` layer, so nothing prints to the
+/// terminal except this bench's own `println!`s.
+fn setup_stage_timing_tracing(timings: StageTimings) {
+    tracing_subscriber::registry()
+        .with(StageTimingLayer { timings })
+        .init();
+}
+
+fn main() {
+    let mut rng = StdRng::seed_from_u64(0x5CD);
+    let trace_terminal = std::env::args().any(|a| a == "--trace-terminal");
+    let stage_timings = StageTimings::default();
+    if trace_terminal {
+        setup_stage_timing_tracing(stage_timings.clone());
+    }
+
+    println!("MODEL_SCALE = {MODEL_SCALE}, divisor = {DIVISOR}");
+    println!("runs per input length = {NUM_RUNS} (+1 warmup, discarded)");
+
+    for &input_len in INPUT_LENS {
+        let input = Tensor::<i32>::random_small(&mut rng, &[input_len]);
+
+        let model = scalar_const_div_model(input_len);
+        let pp = AtlasSharedPreprocessing::preprocess(model);
+        let prover_preprocessing = AtlasProverPreprocessing::<Fr, HyperKZG<Bn254>>::new(pp);
+        let verifier_preprocessing =
+            AtlasVerifierPreprocessing::<Fr, HyperKZG<Bn254>>::from(&prover_preprocessing);
+
+        // Warmup run, discarded (page faults, allocator warmup, etc.); also discards
+        // its span timings so they don't skew the per-stage means below.
+        run_once(&prover_preprocessing, &verifier_preprocessing, &input);
+        stage_timings.take_means();
+
+        let mut prove_times = Vec::with_capacity(NUM_RUNS);
+        let mut verify_times = Vec::with_capacity(NUM_RUNS);
+        for _ in 0..NUM_RUNS {
+            let (prove_time, verify_time) =
+                run_once(&prover_preprocessing, &verifier_preprocessing, &input);
+            prove_times.push(prove_time);
+            verify_times.push(verify_time);
+        }
+
+        println!("--- input length = {input_len} ---");
+        println!("prove times  = {prove_times:?}");
+        println!("verify times = {verify_times:?}");
+        println!("mean prove time  = {:?}", mean(&prove_times));
+        println!("mean verify time = {:?}", mean(&verify_times));
+        if trace_terminal {
+            for (name, stage_mean) in stage_timings.take_means() {
+                println!("mean {name} = {stage_mean:?}");
+            }
+        }
+    }
+}

--- a/jolt-atlas-core/src/onnx_proof/neural_teleport/trig_downscale.rs
+++ b/jolt-atlas-core/src/onnx_proof/neural_teleport/trig_downscale.rs
@@ -93,6 +93,57 @@ impl LookupOperandsTrait for TrigDownscaleOperands {
     }
 }
 
+/// `LookupOperandsTrait` helper for the remainder range-check (`remainder < TRIG_PERIOD_MODULUS`).
+/// Reuses [`TrigDownscaleOperands`]'s `ra`/witness/`r_cycle` identifiers: both lookups key off
+/// the same `remainder`, batched with matching round counts, so their `ra` claims are
+/// mathematically identical — letting the range-check share `TrigDownscaleRa`/`RaD` instead of
+/// committing and one-hot-checking a second read-address polynomial.
+#[derive(Default, Clone)]
+pub struct TeleportRangeCheckOperands;
+
+impl LookupOperandsTrait for TeleportRangeCheckOperands {
+    const LOG_K: usize = XLEN;
+
+    /// Every remainder must satisfy the range check, i.e. `Σ eq(r_cycle,·)·[remainder<τ] = 1`.
+    fn rv_claim<F: JoltField>(
+        _node: &ComputationNode,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> F {
+        F::one()
+    }
+
+    fn ra_virtual_poly(node_idx: usize) -> VirtualPoly {
+        TrigDownscaleOperands::ra_virtual_poly(node_idx)
+    }
+
+    fn ra_committed_poly(node_idx: usize, d: usize) -> CommittedPoly {
+        TrigDownscaleOperands::ra_committed_poly(node_idx, d)
+    }
+
+    fn witness_opening_id(node: &ComputationNode) -> OpeningId {
+        TrigDownscaleOperands::witness_opening_id(node)
+    }
+
+    fn r_cycle<F: JoltField>(
+        node: &ComputationNode,
+        accumulator: &dyn OpeningAccumulator<F>,
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        TrigDownscaleOperands::r_cycle(node, accumulator)
+    }
+
+    fn r_cycle_source(node_idx: usize) -> OpeningId {
+        TrigDownscaleOperands::r_cycle_source(node_idx)
+    }
+
+    fn witness(&self, node: &ComputationNode, trace: &Trace) -> Tensor<i64> {
+        TrigDownscaleOperands.witness(node, trace)
+    }
+
+    fn lookup_bits(witness: &Tensor<i64>) -> Vec<LookupBits> {
+        TrigDownscaleOperands::lookup_bits(witness)
+    }
+}
+
 /// Appends the downscaled value (`remainder >> TRIG_DOWNSCALE_BITS`) as a
 /// `VirtualPoly::TrigDownscaled` advice, evaluated at the node's standard reduced
 /// output-opening point (mirrors `fused_rebase::cache_remainder_prove`). Returns the

--- a/jolt-atlas-core/src/onnx_proof/ops/cos.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/cos.rs
@@ -7,13 +7,13 @@ use crate::{
                 cache_teleport_quotient_verify, compute_division, verify_teleport_input_claim,
             },
             trig_downscale::{
-                cache_downscaled_prove, cache_downscaled_verify, TrigDownscaleOperands,
+                cache_downscaled_prove, cache_downscaled_verify, TeleportRangeCheckOperands,
+                TrigDownscaleOperands,
             },
             utils::compute_ra_evals_from_usize_indices,
         },
         op_lookups::{OpLookupEncoding, OpLookupProvider},
         ops::OperatorProofTrait,
-        range_checking::{range_check_operands::TeleportRangeCheckOperands, RangeCheckProvider},
         ProofId, ProofType, Prover, Verifier,
     },
     utils::opening_access::AccOpeningAccessor,
@@ -37,7 +37,7 @@ use joltworks::subprotocols::blindfold::{
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
     field::{IntoOpening, JoltField},
-    lookup_tables::{right_shift::RightShiftTable, unsigned_less_than::UnsignedLessThanTable},
+    lookup_tables::{less_than_const::TrigLessThanConstTable, right_shift::RightShiftTable},
     poly::{
         identity_poly::IdentityPolynomial,
         multilinear_polynomial::{
@@ -105,9 +105,10 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
         let (cos_exec, cos_lookup_indices) =
             CosProver::initialize(&downscaled, params, &mut prover.accumulator);
 
-        let rc_provider = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
-        let (rangecheck_exec, rc_lookup_indices) = rc_provider
-            .read_raf_prove::<F, T, UnsignedLessThanTable<XLEN>>(
+        let rc_provider: OpLookupProvider<TeleportRangeCheckOperands> =
+            OpLookupProvider::new(node.clone());
+        let (rangecheck_exec, _) = rc_provider
+            .read_raf_prove::<F, T, TrigLessThanConstTable<XLEN>, XLEN>(
                 &prover.trace,
                 &mut prover.accumulator,
                 &mut prover.transcript,
@@ -125,11 +126,11 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
         );
         results.push((ProofId(node.idx, ProofType::Execution), exec_proof));
 
-        // Stage 2: batch every one-hot correctness triple together — downscale, Cos,
-        // and the range-check.
+        // Stage 2: batch every one-hot correctness triple together — downscale and Cos. The
+        // range-check shares downscale's `TrigDownscaleRa`/`RaD` (same remainder, same batched
+        // rounds above), so it has no one-hot triple of its own.
         let dsc_encoding = dsc_provider.encoding();
         let cos_encoding = CosRaEncoding::new(node);
-        let rc_encoding = rc_provider.encoding();
 
         let mut onehot_instances: Vec<Box<dyn SumcheckInstanceProver<F, T>>> = Vec::new();
         onehot_instances.extend(shout::ra_onehot_provers(
@@ -141,12 +142,6 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
         onehot_instances.extend(shout::ra_onehot_provers(
             &cos_encoding,
             &cos_lookup_indices,
-            &prover.accumulator,
-            &mut prover.transcript,
-        ));
-        onehot_instances.extend(shout::ra_onehot_provers(
-            &rc_encoding,
-            &rc_lookup_indices,
             &prover.accumulator,
             &mut prover.transcript,
         ));
@@ -198,11 +193,13 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
             &mut verifier.transcript,
         );
 
-        let rc_provider = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
-        let rangecheck_verifier = rc_provider.read_raf_verify::<F, T, UnsignedLessThanTable<XLEN>>(
-            &mut verifier.accumulator,
-            &mut verifier.transcript,
-        );
+        let rc_provider: OpLookupProvider<TeleportRangeCheckOperands> =
+            OpLookupProvider::new(node.clone());
+        let rangecheck_verifier = rc_provider
+            .read_raf_verify::<F, T, TrigLessThanConstTable<XLEN>, XLEN>(
+                &mut verifier.accumulator,
+                &mut verifier.transcript,
+            );
 
         let exec_proof = verifier
             .proofs
@@ -215,11 +212,10 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
             &mut verifier.transcript,
         )?;
 
-        // Stage 2: batch every one-hot correctness triple together — downscale, Cos,
-        // and the range-check.
+        // Stage 2: batch every one-hot correctness triple together — downscale and Cos. The
+        // range-check shares downscale's `TrigDownscaleRa`/`RaD`, so it has no triple of its own.
         let dsc_encoding = dsc_provider.encoding();
         let cos_encoding = CosRaEncoding::new(node);
-        let rc_encoding = rc_provider.encoding();
 
         let onehot_proof = verifier
             .proofs
@@ -233,11 +229,6 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
         ));
         onehot_verifiers.extend(shout::ra_onehot_verifiers(
             &cos_encoding,
-            &verifier.accumulator,
-            &mut verifier.transcript,
-        ));
-        onehot_verifiers.extend(shout::ra_onehot_verifiers(
-            &rc_encoding,
             &verifier.accumulator,
             &mut verifier.transcript,
         ));
@@ -257,16 +248,14 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Cos {
 
     fn get_committed_polynomials(&self, node: &ComputationNode) -> Vec<CommittedPoly> {
         let cos_encoding = CosRaEncoding::new(node);
-        let rc_encoding = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node).encoding();
         let dsc_encoding: OpLookupEncoding<TrigDownscaleOperands> =
             OpLookupProvider::<TrigDownscaleOperands>::new(node.clone()).encoding();
         let cos_d = cos_encoding.one_hot_params().instruction_d;
-        let rc_d = rc_encoding.one_hot_params().instruction_d;
         let dsc_d = dsc_encoding.one_hot_params().instruction_d;
         let mut polys = vec![CommittedPoly::TeleportNodeQuotient(node.idx)];
+        // The range-check shares downscale's `TrigDownscaleRaD` — no separate committed poly.
         polys.extend((0..dsc_d).map(|i| CommittedPoly::TrigDownscaleRaD(node.idx, i)));
         polys.extend((0..cos_d).map(|i| CommittedPoly::CosRaD(node.idx, i)));
-        polys.extend((0..rc_d).map(|i| CommittedPoly::TeleportRangeCheckRaD(node.idx, i)));
         polys
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/scalar_const_div.rs
@@ -1,37 +1,34 @@
 use crate::{
-    onnx_proof::{ops::OperatorProofTrait, ProofId, ProofType, Prover, Verifier},
-    utils::opening_access::{AccOpeningAccessor, Target},
+    onnx_proof::{
+        ops::OperatorProofTrait,
+        range_checking::{
+            range_check_operands::{RangeCheckOperands, ScalarConstDivRangeCheckOperands},
+            RangeCheckProvider,
+        },
+        ProofId, ProofType, Prover, Verifier,
+    },
+    utils::{
+        adjusted_remainder,
+        opening_access::{AccOpeningAccessor, Target},
+    },
 };
 use atlas_onnx_tracer::{
     model::trace::{LayerData, Trace},
     node::ComputationNode,
     ops::{Operator, ScalarConstDiv},
-    tensor::Tensor,
 };
-use common::CommittedPoly;
-#[cfg(feature = "zk")]
-use joltworks::subprotocols::blindfold::{
-    InputClaimConstraint, OutputClaimConstraint, ProductTerm, ValueSource,
-};
+use common::{consts::XLEN, CommittedPoly, VirtualPoly};
 use joltworks::{
-    field::{IntoOpening, JoltField},
-    poly::{
-        eq_poly::EqPolynomial,
-        multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding},
-        opening_proof::{
-            OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, VerifierOpeningAccumulator,
-            BIG_ENDIAN, LITTLE_ENDIAN,
-        },
-        split_eq_poly::GruenSplitEqPolynomial,
-        unipoly::UniPoly,
-    },
+    field::JoltField,
+    lookup_tables::unsigned_less_than::UnsignedLessThanTable,
+    poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
     subprotocols::{
-        sumcheck::{Sumcheck, SumcheckInstanceProof},
+        shout::{self, RaOneHotEncoding},
+        sumcheck::{BatchedSumcheck, Sumcheck, SumcheckInstanceProof},
         sumcheck_prover::SumcheckInstanceProver,
-        sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::{errors::ProofVerifyError, math::Math},
+    utils::errors::ProofVerifyError,
 };
 
 impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDiv {
@@ -41,18 +38,50 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDiv {
         node: &ComputationNode,
         prover: &mut Prover<F, T>,
     ) -> Vec<(ProofId, SumcheckInstanceProof<F, T>)> {
-        let mut results = Vec::new();
+        // Plumbing: cache the remainder's claim.
+        cache_remainder_prover(node, prover);
 
-        // Execution proof
-        let params = ScalarConstDivParams::new(node.clone(), &prover.accumulator);
-        let mut exec_sumcheck = ScalarConstDivProver::initialize(&prover.trace, params);
-        let (proof, _) = Sumcheck::prove(
-            &mut exec_sumcheck,
+        // Range check `0 <= R < b`.
+        let rangecheck_provider = RangeCheckProvider::<ScalarConstDivRangeCheckOperands>::new(node);
+        let (mut rangecheck_sumcheck, lookup_indices) = rangecheck_provider
+            .read_raf_prove::<F, T, UnsignedLessThanTable<XLEN>>(
+                &prover.trace,
+                &mut prover.accumulator,
+                &mut prover.transcript,
+            );
+        let (rangecheck_proof, _) = Sumcheck::prove(
+            &mut rangecheck_sumcheck,
             &mut prover.accumulator,
             &mut prover.transcript,
         );
-        results.push((ProofId(node.idx, ProofType::Execution), proof));
-        results
+
+        // The range check's read-address one-hot correctness checks.
+        let rc_operands = RangeCheckOperands::<ScalarConstDivRangeCheckOperands>::new(node);
+        let encoding = rc_operands.get_encoding(node);
+        let [ra_sumcheck, hw_sumcheck, bool_sumcheck] = shout::ra_onehot_provers(
+            &encoding,
+            &lookup_indices,
+            &prover.accumulator,
+            &mut prover.transcript,
+        );
+        let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> =
+            vec![ra_sumcheck, hw_sumcheck, bool_sumcheck];
+        let (ra_one_hot_proof, _) = BatchedSumcheck::prove(
+            instances.iter_mut().map(|v| &mut **v as _).collect(),
+            &mut prover.accumulator,
+            &mut prover.transcript,
+        );
+
+        // Plumbing: derive `a`'s input claim from `q` (this node's own output) and `R`.
+        cache_input_claim_prover(node, prover);
+
+        vec![
+            (ProofId(node.idx, ProofType::RangeCheck), rangecheck_proof),
+            (
+                ProofId(node.idx, ProofType::RaOneHotChecks),
+                ra_one_hot_proof,
+            ),
+        ]
     }
 
     #[tracing::instrument(skip_all, name = "ScalarConstDiv::verify")]
@@ -61,272 +90,145 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for ScalarConstDiv {
         node: &ComputationNode,
         verifier: &mut Verifier<'_, F, T>,
     ) -> Result<(), ProofVerifyError> {
-        // Execution verification
-        let proof = verifier
+        // Plumbing: cache the remainder's claim.
+        cache_remainder_verifier(node, verifier);
+
+        // Range check `0 <= R < b`.
+        let rangecheck_proof = verifier
             .proofs
-            .get(&ProofId(node.idx, ProofType::Execution))
+            .get(&ProofId(node.idx, ProofType::RangeCheck))
             .ok_or(ProofVerifyError::MissingProof(node.idx))?;
-        let exec_sumcheck = ScalarConstDivVerifier::new(node.clone(), &verifier.accumulator);
+        let rangecheck_provider = RangeCheckProvider::<ScalarConstDivRangeCheckOperands>::new(node);
+        let rangecheck_verifier = rangecheck_provider
+            .read_raf_verify::<F, T, UnsignedLessThanTable<XLEN>>(
+                &mut verifier.accumulator,
+                &mut verifier.transcript,
+            );
         Sumcheck::verify(
-            proof,
-            &exec_sumcheck,
+            rangecheck_proof,
+            &rangecheck_verifier,
             &mut verifier.accumulator,
             &mut verifier.transcript,
         )?;
+
+        // The range check's read-address one-hot correctness checks.
+        let ra_one_hot_proof = verifier
+            .proofs
+            .get(&ProofId(node.idx, ProofType::RaOneHotChecks))
+            .ok_or(ProofVerifyError::MissingProof(node.idx))?;
+        let rc_operands = RangeCheckOperands::<ScalarConstDivRangeCheckOperands>::new(node);
+        let encoding = rc_operands.get_encoding(node);
+        let [ra_sumcheck, hw_sumcheck, bool_sumcheck] =
+            shout::ra_onehot_verifiers(&encoding, &verifier.accumulator, &mut verifier.transcript);
+        BatchedSumcheck::verify(
+            ra_one_hot_proof,
+            vec![&*ra_sumcheck, &*hw_sumcheck, &*bool_sumcheck],
+            &mut verifier.accumulator,
+            &mut verifier.transcript,
+        )?;
+
+        // Plumbing: derive and verify `a`'s input claim from `q` and `R`.
+        verify_input_claim(node, verifier)?;
 
         Ok(())
     }
 
     fn get_committed_polynomials(&self, node: &ComputationNode) -> Vec<CommittedPoly> {
-        let polys = vec![CommittedPoly::ScalarConstDivNodeRemainder(node.idx)];
-        polys
+        let rc_operands = RangeCheckOperands::<ScalarConstDivRangeCheckOperands>::new(node);
+        let d = rc_operands
+            .get_encoding(node)
+            .one_hot_params()
+            .instruction_d;
+        (0..d)
+            .map(|i| CommittedPoly::ScalarConstDivRangeCheckRaD(node.idx, i))
+            .collect()
     }
 }
 
-const DEGREE_BOUND: usize = 2;
+/// Caches the remainder's claim (`VirtualPoly::ScalarConstDivRemainder`) at the node's
+/// reduced output-opening point, by directly evaluating the honest remainder tensor —
+/// no sumcheck needed, `R` is constrained only via [`cache_input_claim_prover`] and the
+/// range check.
+fn cache_remainder_prover<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    prover: &mut Prover<F, T>,
+) {
+    let Operator::ScalarConstDiv(op) = &node.operator else {
+        panic!("Expected ScalarConstDiv operator at node {}", node.idx);
+    };
+    let LayerData { operands, .. } = Trace::layer_data(&prover.trace, node);
+    let [left_operand] = operands[..] else {
+        panic!("Expected one operand for ScalarConstDiv operation")
+    };
+    let remainder = left_operand.map(|x| adjusted_remainder(x, op.divisor));
 
-/// Parameters for proving division by a scalar constant.
-///
-/// For division a/b where b is a constant, proves a = b*q + R where R is the remainder.
-/// This is more efficient than general division since the divisor is known.
-#[derive(Clone)]
-pub struct ScalarConstDivParams<F: JoltField> {
-    r_node_output: OpeningPoint<BIG_ENDIAN, F>,
-    computation_node: ComputationNode,
-    scalar_const_divisor: i32,
+    let accessor = AccOpeningAccessor::new(&mut prover.accumulator, node);
+    let (r_node_output, _) = accessor.get_reduced_opening();
+    let eval = MultilinearPolynomial::from(remainder).evaluate(&r_node_output.r);
+    accessor
+        .into_provider(&mut prover.transcript, r_node_output)
+        .append_advice(VirtualPoly::ScalarConstDivRemainder, eval);
 }
 
-impl<F: JoltField> ScalarConstDivParams<F> {
-    /// Create new scalar constant division parameters from a computation node and opening accumulator.
-    pub fn new(computation_node: ComputationNode, accumulator: &dyn OpeningAccumulator<F>) -> Self {
-        let accessor = AccOpeningAccessor::new(accumulator, &computation_node);
-        let r_node_output = accessor.get_reduced_opening().0;
-        let Operator::ScalarConstDiv(scalar_const_div) = &computation_node.operator else {
-            panic!("Expected ScalarConstDiv operator")
-        };
-        Self {
-            r_node_output,
-            scalar_const_divisor: scalar_const_div.divisor,
-            computation_node,
-        }
-    }
+/// Verifier counterpart of [`cache_remainder_prover`].
+fn cache_remainder_verifier<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    verifier: &mut Verifier<'_, F, T>,
+) {
+    let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, node);
+    let (r_node_output, _) = accessor.get_reduced_opening();
+    accessor
+        .into_provider(&mut verifier.transcript, r_node_output)
+        .append_advice(VirtualPoly::ScalarConstDivRemainder);
 }
 
-impl<F: JoltField> SumcheckInstanceParams<F> for ScalarConstDivParams<F> {
-    fn degree(&self) -> usize {
-        DEGREE_BOUND
-    }
+/// Derives the node's input claim `a = b·q + R` from `q` (this node's own reduced output
+/// claim) and the remainder claim `R`, caching it as `Target::Input(0)`. Holds identically
+/// as multilinear polynomials, so this is pure field arithmetic — no sumcheck needed. Must
+/// run after [`cache_remainder_prover`].
+fn cache_input_claim_prover<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    prover: &mut Prover<F, T>,
+) {
+    let Operator::ScalarConstDiv(op) = &node.operator else {
+        panic!("Expected ScalarConstDiv operator at node {}", node.idx);
+    };
+    let accessor = AccOpeningAccessor::new(&mut prover.accumulator, node);
+    let (r_node_output, q_claim) = accessor.get_reduced_opening();
+    let r_claim = accessor.get_advice(VirtualPoly::ScalarConstDivRemainder).1;
+    let a_claim = F::from_i32(op.divisor) * q_claim + r_claim;
 
-    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
-        let accessor = AccOpeningAccessor::new(accumulator, &self.computation_node);
-        let q_claim = accessor.get_reduced_opening().1;
-        q_claim * F::from_i32(self.scalar_const_divisor)
-    }
-
-    fn normalize_opening_point(&self, challenges: &[F]) -> OpeningPoint<BIG_ENDIAN, F> {
-        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
-    }
-
-    fn num_rounds(&self) -> usize {
-        self.computation_node
-            .pow2_padded_num_output_elements()
-            .log_2()
-    }
-
-    #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> InputClaimConstraint {
-        InputClaimConstraint::default()
-    }
-
-    #[cfg(feature = "zk")]
-    fn input_constraint_challenge_values(
-        &self,
-        _accumulator: &dyn OpeningAccumulator<F>,
-    ) -> Vec<F> {
-        Vec::new()
-    }
-
-    // output = eq_eval * (left_operand - R_claim)
-    //        = eq_eval * left + (-eq_eval) * R
-    #[cfg(feature = "zk")]
-    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        use crate::utils::opening_access::OpeningIdBuilder;
-        let builder = OpeningIdBuilder::new(&self.computation_node);
-        let left_id = builder.nodeio(Target::Input(0));
-        let r_id = builder.advice(CommittedPoly::ScalarConstDivNodeRemainder);
-        Some(OutputClaimConstraint::sum_of_products(vec![
-            ProductTerm::scaled(
-                ValueSource::Challenge(0),
-                vec![ValueSource::Opening(left_id)],
-            ),
-            ProductTerm::scaled(ValueSource::Challenge(1), vec![ValueSource::Opening(r_id)]),
-        ]))
-    }
-
-    #[cfg(feature = "zk")]
-    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
-        let r_node_output_prime: Vec<F> = self
-            .normalize_opening_point(&sumcheck_challenges.into_opening())
-            .r;
-        let eq_eval = EqPolynomial::mle(&self.r_node_output.r, &r_node_output_prime);
-        vec![eq_eval, -eq_eval]
-    }
+    accessor
+        .into_provider(&mut prover.transcript, r_node_output)
+        .append_nodeio(Target::Input(0), a_claim);
 }
 
-/// Prover state for scalar constant division sumcheck protocol.
-///
-/// Maintains the equality polynomial, operand polynomial, and remainder R
-/// needed to prove the division relation: operand = divisor * q + R where divisor is constant.
-pub struct ScalarConstDivProver<F: JoltField> {
-    params: ScalarConstDivParams<F>,
-    eq_r_node_output: GruenSplitEqPolynomial<F>,
-    left_operand: MultilinearPolynomial<F>,
-    R: MultilinearPolynomial<F>,
-}
+/// Verifier counterpart of [`cache_input_claim_prover`]: independently recomputes `b·q + R`
+/// and checks it against the prover's claimed `Target::Input(0)`.
+fn verify_input_claim<F: JoltField, T: Transcript>(
+    node: &ComputationNode,
+    verifier: &mut Verifier<'_, F, T>,
+) -> Result<(), ProofVerifyError> {
+    let Operator::ScalarConstDiv(op) = &node.operator else {
+        panic!("Expected ScalarConstDiv operator at node {}", node.idx);
+    };
+    let accessor = AccOpeningAccessor::new(&mut verifier.accumulator, node);
+    let (r_node_output, q_claim) = accessor.get_reduced_opening();
 
-impl<F: JoltField> ScalarConstDivProver<F> {
-    /// Initialize the prover with trace data and parameters.
-    #[tracing::instrument(skip_all)]
-    pub fn initialize(trace: &Trace, params: ScalarConstDivParams<F>) -> Self {
-        let eq_r_node_output =
-            GruenSplitEqPolynomial::new(&params.r_node_output.r, BindingOrder::LowToHigh);
-        let LayerData { operands, .. } = Trace::layer_data(trace, &params.computation_node);
-        let [left_operand] = operands[..] else {
-            panic!("Expected one operands for ScalarConstDiv operation")
-        };
-        let b = params.scalar_const_divisor;
-        let R_tensor = {
-            let data: Vec<i32> = left_operand
-                .iter()
-                .map(|&a| {
-                    let mut R = a % b;
-                    if (R < 0 && b > 0) || R > 0 && b < 0 {
-                        R += b
-                    }
-                    R
-                })
-                .collect();
-            Tensor::<i32>::construct(data, left_operand.dims().to_vec())
-        };
-        let left_operand = MultilinearPolynomial::from(left_operand.clone());
-        let R = MultilinearPolynomial::from(R_tensor);
-        Self {
-            params,
-            eq_r_node_output,
-            left_operand,
-            R,
-        }
+    let mut provider = accessor.into_provider(&mut verifier.transcript, r_node_output);
+    provider.append_nodeio(Target::Input(0));
+    let r_claim = provider.get_advice(VirtualPoly::ScalarConstDivRemainder).1;
+    let expected = F::from_i32(op.divisor) * q_claim + r_claim;
+    let input_claim = provider.get_nodeio(Target::Input(0)).1;
+
+    if input_claim != expected {
+        return Err(ProofVerifyError::InvalidOpeningProof(
+            "ScalarConstDiv input claim does not match b*q + R derived from the quotient and \
+             remainder claims"
+                .to_string(),
+        ));
     }
-}
-
-impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ScalarConstDivProver<F> {
-    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        &self.params
-    }
-
-    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
-        let Self {
-            eq_r_node_output,
-            left_operand,
-            R,
-            ..
-        } = self;
-        let [q_constant] = eq_r_node_output.par_fold_out_in_unreduced::<9, 1>(&|g| {
-            let lo0 = left_operand.get_bound_coeff(2 * g);
-            let R0 = R.get_bound_coeff(2 * g);
-            let c0 = lo0 - R0;
-            [c0]
-        });
-        eq_r_node_output.gruen_poly_deg_2(q_constant, previous_claim)
-    }
-
-    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
-        self.eq_r_node_output.bind(r_j);
-        self.left_operand
-            .bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.R.bind_parallel(r_j, BindingOrder::LowToHigh);
-    }
-
-    fn cache_openings(
-        &self,
-        accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut T,
-        sumcheck_challenges: &[F::Challenge],
-    ) {
-        let opening_point = self
-            .params
-            .normalize_opening_point(&sumcheck_challenges.into_opening());
-        let mut provider = AccOpeningAccessor::new(accumulator, &self.params.computation_node)
-            .into_provider(transcript, opening_point);
-
-        provider.append_nodeio(Target::Input(0), self.left_operand.final_claim());
-        provider.append_advice(
-            CommittedPoly::ScalarConstDivNodeRemainder,
-            self.R.final_claim(),
-        );
-    }
-}
-
-/// Verifier for scalar constant division sumcheck protocol.
-///
-/// Verifies that the prover's sumcheck messages are consistent with the claimed
-/// division by scalar constant output and the division relation.
-pub struct ScalarConstDivVerifier<F: JoltField> {
-    params: ScalarConstDivParams<F>,
-}
-
-impl<F: JoltField> ScalarConstDivVerifier<F> {
-    /// Create a new verifier for the scalar constant division operation.
-    pub fn new(
-        computation_node: ComputationNode,
-        accumulator: &VerifierOpeningAccumulator<F>,
-    ) -> Self {
-        let params = ScalarConstDivParams::new(computation_node, accumulator);
-        Self { params }
-    }
-}
-
-impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ScalarConstDivVerifier<F> {
-    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        &self.params
-    }
-
-    fn expected_output_claim(
-        &self,
-        accumulator: &VerifierOpeningAccumulator<F>,
-        sumcheck_challenges: &[F::Challenge],
-    ) -> F {
-        let accessor = AccOpeningAccessor::new(accumulator, &self.params.computation_node);
-
-        let r_node_output = &self.params.r_node_output.r;
-        let r_node_output_prime = self
-            .params
-            .normalize_opening_point(&sumcheck_challenges.into_opening())
-            .r;
-        let eq_eval = EqPolynomial::mle(r_node_output, &r_node_output_prime);
-
-        let R_claim = accessor
-            .get_advice(CommittedPoly::ScalarConstDivNodeRemainder)
-            .1;
-        let left_operand_claim = accessor.get_nodeio(Target::Input(0)).1;
-
-        eq_eval * (left_operand_claim - R_claim)
-    }
-
-    fn cache_openings(
-        &self,
-        accumulator: &mut VerifierOpeningAccumulator<F>,
-        transcript: &mut T,
-        sumcheck_challenges: &[F::Challenge],
-    ) {
-        let opening_point = self
-            .params
-            .normalize_opening_point(&sumcheck_challenges.into_opening());
-        let mut provider = AccOpeningAccessor::new(accumulator, &self.params.computation_node)
-            .into_provider(transcript, opening_point);
-        provider.append_nodeio(Target::Input(0));
-        provider.append_advice(CommittedPoly::ScalarConstDivNodeRemainder);
-    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/jolt-atlas-core/src/onnx_proof/ops/sin.rs
+++ b/jolt-atlas-core/src/onnx_proof/ops/sin.rs
@@ -5,12 +5,14 @@ use crate::onnx_proof::{
             cache_teleport_quotient_verify, compute_division, verify_teleport_input_claim,
         },
         sin::{SinTable, SIN_TABLE_VARS},
-        trig_downscale::{cache_downscaled_prove, cache_downscaled_verify, TrigDownscaleOperands},
+        trig_downscale::{
+            cache_downscaled_prove, cache_downscaled_verify, TeleportRangeCheckOperands,
+            TrigDownscaleOperands,
+        },
         utils::compute_ra_evals_from_usize_indices,
     },
     op_lookups::{OpLookupEncoding, OpLookupProvider},
     ops::OperatorProofTrait,
-    range_checking::{range_check_operands::TeleportRangeCheckOperands, RangeCheckProvider},
     ProofId, ProofType, Prover, Verifier,
 };
 use crate::utils::opening_access::AccOpeningAccessor;
@@ -33,7 +35,7 @@ use joltworks::subprotocols::blindfold::{
 use joltworks::{
     config::{OneHotConfig, OneHotParams},
     field::{IntoOpening, JoltField},
-    lookup_tables::{right_shift::RightShiftTable, unsigned_less_than::UnsignedLessThanTable},
+    lookup_tables::{less_than_const::TrigLessThanConstTable, right_shift::RightShiftTable},
     poly::{
         identity_poly::IdentityPolynomial,
         multilinear_polynomial::{
@@ -101,9 +103,10 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
         let (sin_exec, sin_lookup_indices) =
             SinProver::initialize(&downscaled, params, &mut prover.accumulator);
 
-        let rc_provider = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
-        let (rangecheck_exec, rc_lookup_indices) = rc_provider
-            .read_raf_prove::<F, T, UnsignedLessThanTable<XLEN>>(
+        let rc_provider: OpLookupProvider<TeleportRangeCheckOperands> =
+            OpLookupProvider::new(node.clone());
+        let (rangecheck_exec, _) = rc_provider
+            .read_raf_prove::<F, T, TrigLessThanConstTable<XLEN>, XLEN>(
                 &prover.trace,
                 &mut prover.accumulator,
                 &mut prover.transcript,
@@ -121,11 +124,11 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
         );
         results.push((ProofId(node.idx, ProofType::Execution), exec_proof));
 
-        // Stage 2: batch every one-hot correctness triple together — downscale, Sin,
-        // and the range-check.
+        // Stage 2: batch every one-hot correctness triple together — downscale and Sin. The
+        // range-check shares downscale's `TrigDownscaleRa`/`RaD` (same remainder, same batched
+        // rounds above), so it has no one-hot triple of its own.
         let dsc_encoding = dsc_provider.encoding();
         let sin_encoding = SinRaEncoding::new(node);
-        let rc_encoding = rc_provider.encoding();
 
         let mut onehot_instances: Vec<Box<dyn SumcheckInstanceProver<F, T>>> = Vec::new();
         onehot_instances.extend(shout::ra_onehot_provers(
@@ -137,12 +140,6 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
         onehot_instances.extend(shout::ra_onehot_provers(
             &sin_encoding,
             &sin_lookup_indices,
-            &prover.accumulator,
-            &mut prover.transcript,
-        ));
-        onehot_instances.extend(shout::ra_onehot_provers(
-            &rc_encoding,
-            &rc_lookup_indices,
             &prover.accumulator,
             &mut prover.transcript,
         ));
@@ -194,11 +191,13 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
             &mut verifier.transcript,
         );
 
-        let rc_provider = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node);
-        let rangecheck_verifier = rc_provider.read_raf_verify::<F, T, UnsignedLessThanTable<XLEN>>(
-            &mut verifier.accumulator,
-            &mut verifier.transcript,
-        );
+        let rc_provider: OpLookupProvider<TeleportRangeCheckOperands> =
+            OpLookupProvider::new(node.clone());
+        let rangecheck_verifier = rc_provider
+            .read_raf_verify::<F, T, TrigLessThanConstTable<XLEN>, XLEN>(
+                &mut verifier.accumulator,
+                &mut verifier.transcript,
+            );
 
         let sin_proof = verifier
             .proofs
@@ -211,11 +210,10 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
             &mut verifier.transcript,
         )?;
 
-        // Stage 2: batch every one-hot correctness triple together — downscale, Sin,
-        // and the range-check.
+        // Stage 2: batch every one-hot correctness triple together — downscale and Sin. The
+        // range-check shares downscale's `TrigDownscaleRa`/`RaD`, so it has no triple of its own.
         let dsc_encoding = dsc_provider.encoding();
         let sin_encoding = SinRaEncoding::new(node);
-        let rc_encoding = rc_provider.encoding();
 
         let onehot_proof = verifier
             .proofs
@@ -229,11 +227,6 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
         ));
         onehot_verifiers.extend(shout::ra_onehot_verifiers(
             &sin_encoding,
-            &verifier.accumulator,
-            &mut verifier.transcript,
-        ));
-        onehot_verifiers.extend(shout::ra_onehot_verifiers(
-            &rc_encoding,
             &verifier.accumulator,
             &mut verifier.transcript,
         ));
@@ -253,16 +246,14 @@ impl<F: JoltField, T: Transcript> OperatorProofTrait<F, T> for Sin {
 
     fn get_committed_polynomials(&self, node: &ComputationNode) -> Vec<CommittedPoly> {
         let sin_encoding = SinRaEncoding::new(node);
-        let rc_encoding = RangeCheckProvider::<TeleportRangeCheckOperands>::new(node).encoding();
         let dsc_encoding: OpLookupEncoding<TrigDownscaleOperands> =
             OpLookupProvider::<TrigDownscaleOperands>::new(node.clone()).encoding();
         let sin_d = sin_encoding.one_hot_params().instruction_d;
-        let rc_d = rc_encoding.one_hot_params().instruction_d;
         let dsc_d = dsc_encoding.one_hot_params().instruction_d;
         let mut polys = vec![CommittedPoly::TeleportNodeQuotient(node.idx)];
+        // The range-check shares downscale's `TrigDownscaleRaD` — no separate committed poly.
         polys.extend((0..dsc_d).map(|i| CommittedPoly::TrigDownscaleRaD(node.idx, i)));
         polys.extend((0..sin_d).map(|i| CommittedPoly::SinRaD(node.idx, i)));
-        polys.extend((0..rc_d).map(|i| CommittedPoly::TeleportRangeCheckRaD(node.idx, i)));
         polys
     }
 }

--- a/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
+++ b/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
@@ -3,7 +3,7 @@ use atlas_onnx_tracer::{
     ops::{MeanOfSquares, Operator},
     tensor::Tensor,
 };
-use common::{consts::TRIG_PERIOD_MODULUS, CommittedPoly, VirtualPoly};
+use common::{CommittedPoly, VirtualPoly};
 use joltworks::{
     field::JoltField,
     poly::opening_proof::{OpeningAccumulator, OpeningId, SumcheckId},
@@ -12,7 +12,7 @@ use joltworks::{
 use num::integer::Roots;
 
 use crate::{
-    onnx_proof::{neural_teleport::division::compute_division, range_checking::RangeCheckEncoding},
+    onnx_proof::range_checking::RangeCheckEncoding,
     utils::{adjusted_remainder, compute_lookup_indices_from_operands},
 };
 use atlas_onnx_tracer::ops::mean_of_squares::{mos_divisor, mos_remainder};
@@ -27,7 +27,8 @@ pub struct RangeCheckOperandsBase {
     pub node_idx: usize,
     /// Polynomial to be range-checked
     pub remainder: VirtualPoly,
-    /// Bound polynomial, or `None` when the bound is a field constant (e.g. τ for neural-teleport).
+    /// Bound polynomial, or `None` when the bound is a field constant (e.g. `MeanOfSquares`'s
+    /// divisor `D`).
     pub bound: Option<VirtualPoly>,
     /// Virtual polynomial representing the range-check read-address (Ra).
     pub virtual_ra: VirtualPoly,
@@ -53,8 +54,10 @@ pub trait RangeCheckingOperandsTrait {
     /// Create a new base instance from a computation node.
     fn new_params(node: &ComputationNode) -> RangeCheckOperandsBase;
 
-    // NOTE: In the future, range-checks with a constant value such as "tau" (neural teleportation) may be proven using a single-operand lookup table (#253).
-    // Hence, "build_lookup_operands" returns a vector of tensors, to account for both cases.
+    // NOTE: range-checks against a constant value (e.g. MeanOfSquares's divisor D) could be
+    // proven via a single-operand lookup table instead (#253; Cos/Sin's teleport range-check
+    // already moved to this, outside this trait — see LessThanConstTable). Hence
+    // "build_lookup_operands" returns a vector of tensors, to account for both cases.
     /// Builds the encoding operands for the lookup table from the model's operand tensors.
     fn build_lookup_operands(&self, operand_tensors: &[Tensor<i32>]) -> Vec<Tensor<i32>>;
 
@@ -250,9 +253,8 @@ impl RangeCheckingOperandsTrait for RsRangeCheckOperands {
 ///
 /// MoS computes `out = SatClamp((Σx²) / D)` with `D = N·2^S` (a per-node
 /// **constant**); the reduction binds `Σx² = rescaled·D + R` and this check
-/// proves `0 ≤ R < D`. Because the bound is constant it mirrors the
-/// [`TeleportRangeCheckOperands`] pattern (`bound: None`) rather than Div's
-/// per-element divisor .
+/// proves `0 ≤ R < D`. Because the bound is constant, `bound` is `None` here
+/// rather than Div's per-element divisor.
 pub struct MeanOfSquaresRangeCheckOperands {
     /// The mean of squares operator
     op: MeanOfSquares,
@@ -306,62 +308,6 @@ fn mean_of_squares_divisor_i32(op: &atlas_onnx_tracer::ops::MeanOfSquares) -> i3
 
 fn i32_divisor(divisor: i64) -> i32 {
     i32::try_from(divisor).expect("MeanOfSquares divisor N·2^S must fit i32 for the range check")
-}
-
-/// Operands for neural teleportation (cos/sin) range-checking.
-///
-/// For cos/sin computation involving division by τ, verifies that the remainder satisfies the bounds.
-pub struct TeleportRangeCheckOperands {
-    tau: i32,
-}
-
-impl RangeCheckingOperandsTrait for TeleportRangeCheckOperands {
-    fn new(node: &ComputationNode) -> Self {
-        let tau = match &node.operator {
-            Operator::Cos(_) | Operator::Sin(_) => TRIG_PERIOD_MODULUS as i32,
-            _ => {
-                panic!("Expected Cos or Sin operator for neural teleportation division")
-            }
-        };
-        Self { tau }
-    }
-
-    fn new_params(node: &ComputationNode) -> RangeCheckOperandsBase {
-        RangeCheckOperandsBase {
-            node_idx: node.idx,
-            remainder: VirtualPoly::TeleportRemainder(node.idx),
-            // The bound is the constant τ, not a committed polynomial.
-            bound: None,
-            virtual_ra: VirtualPoly::TeleportRangeCheckRa(node.idx),
-            operator: node.operator.clone(),
-        }
-    }
-
-    fn build_lookup_operands(&self, operand_tensors: &[Tensor<i32>]) -> Vec<Tensor<i32>> {
-        assert_eq!(
-            operand_tensors.len(),
-            1,
-            "Expected exactly one operand tensor for neural teleportation"
-        );
-        let input_tensor = &operand_tensors[0];
-
-        let (_, remainder) = compute_division(input_tensor, self.tau);
-        let divisor_tensor = Tensor::construct(vec![self.tau], vec![1])
-            .expand(input_tensor.dims())
-            .unwrap();
-
-        vec![remainder, divisor_tensor]
-    }
-
-    fn transform_operand_claims<F: JoltField>(&self, claims: Vec<F>) -> (F, F) {
-        let left_claim = claims[0];
-
-        (left_claim, F::from_i32(self.tau))
-    }
-
-    fn rad_poly(index: usize, d: usize) -> CommittedPoly {
-        CommittedPoly::TeleportRangeCheckRaD(index, d)
-    }
 }
 
 /// A wrapper struct that holds the range-checking information

--- a/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
+++ b/jolt-atlas-core/src/onnx_proof/range_checking/range_check_operands.rs
@@ -300,6 +300,58 @@ impl RangeCheckingOperandsTrait for MeanOfSquaresRangeCheckOperands {
     }
 }
 
+/// Operands for the scalar-constant-division remainder range check.
+///
+/// For `a / b = q` with constant divisor `b`, verifies the remainder `R = a - b·q`
+/// satisfies `0 ≤ R < b`. Like [`MeanOfSquaresRangeCheckOperands`], `b` is a per-node
+/// constant (not per-element data), so `bound` is `None`.
+pub struct ScalarConstDivRangeCheckOperands {
+    divisor: i32,
+}
+
+impl RangeCheckingOperandsTrait for ScalarConstDivRangeCheckOperands {
+    fn new(node: &ComputationNode) -> Self {
+        let Operator::ScalarConstDiv(op) = &node.operator else {
+            panic!("Expected ScalarConstDiv operator");
+        };
+        Self {
+            divisor: op.divisor,
+        }
+    }
+
+    fn new_params(node: &ComputationNode) -> RangeCheckOperandsBase {
+        RangeCheckOperandsBase {
+            node_idx: node.idx,
+            remainder: VirtualPoly::ScalarConstDivRemainder(node.idx),
+            bound: None,
+            virtual_ra: VirtualPoly::ScalarConstDivRangeCheckRa(node.idx),
+            operator: node.operator.clone(),
+        }
+    }
+
+    fn build_lookup_operands(&self, operand_tensors: &[Tensor<i32>]) -> Vec<Tensor<i32>> {
+        assert_eq!(
+            operand_tensors.len(),
+            1,
+            "Expected exactly one operand tensor"
+        );
+        let input_tensor = &operand_tensors[0];
+        let remainder = input_tensor.map(|x| adjusted_remainder(x, self.divisor));
+        let bound = Tensor::construct(vec![self.divisor], vec![1])
+            .expand(remainder.dims())
+            .unwrap();
+        vec![remainder, bound]
+    }
+
+    fn transform_operand_claims<F: JoltField>(&self, claims: Vec<F>) -> (F, F) {
+        (claims[0], F::from_i32(self.divisor))
+    }
+
+    fn rad_poly(index: usize, d: usize) -> CommittedPoly {
+        CommittedPoly::ScalarConstDivRangeCheckRaD(index, d)
+    }
+}
+
 /// The fused mean-of-squares divisor `D = N·2^S` as an `i32` (the range-check
 /// value domain), recovered from the operator's stored count + scale.
 fn mean_of_squares_divisor_i32(op: &atlas_onnx_tracer::ops::MeanOfSquares) -> i32 {

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -23,9 +23,10 @@ use crate::{
         range_checking::range_check_operands::{
             DivRangeCheckOperands, MeanOfSquaresRangeCheckOperands, RangeCheckOperands,
             RangeCheckingOperandsTrait, RiRangeCheckOperands, RsRangeCheckOperands,
+            ScalarConstDivRangeCheckOperands,
         },
     },
-    utils::{adjusted_remainder, compute_lookup_indices_from_operands},
+    utils::compute_lookup_indices_from_operands,
 };
 use atlas_onnx_tracer::{
     model::{trace::Trace, Model},
@@ -338,24 +339,10 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPoly {
                 let (quotient, _remainder) = compute_division(input, tau);
                 MultilinearPolynomial::from(quotient)
             }
-            CommittedPoly::ScalarConstDivNodeRemainder(node_idx) => {
-                let computation_node = &model.graph.nodes[node_idx];
-                let Operator::ScalarConstDiv(op) = &computation_node.operator else {
-                    panic!("Expected ScalarConstDiv operator at node {node_idx}");
-                };
-                let b = op.divisor;
-                let layer_data = Trace::layer_data(trace, computation_node);
-                let [left_operand] = layer_data.operands[..] else {
-                    panic!("Expected one operand for ScalarConstDiv operation")
-                };
-                let remainder_data: Vec<i32> = left_operand
-                    .iter()
-                    .map(|&a| adjusted_remainder(a, b))
-                    .collect();
-                MultilinearPolynomial::from(Tensor::<i32>::construct(
-                    remainder_data,
-                    left_operand.dims().to_vec(),
-                ))
+            CommittedPoly::ScalarConstDivRangeCheckRaD(node_idx, d) => {
+                build_range_check_rad_witness::<F, ScalarConstDivRangeCheckOperands>(
+                    model, trace, *node_idx, *d,
+                )
             }
             CommittedPoly::RsqrtQuotient(node_idx) => {
                 let computation_node = &model.graph.nodes[node_idx];

--- a/jolt-atlas-core/src/onnx_proof/witness.rs
+++ b/jolt-atlas-core/src/onnx_proof/witness.rs
@@ -23,7 +23,6 @@ use crate::{
         range_checking::range_check_operands::{
             DivRangeCheckOperands, MeanOfSquaresRangeCheckOperands, RangeCheckOperands,
             RangeCheckingOperandsTrait, RiRangeCheckOperands, RsRangeCheckOperands,
-            TeleportRangeCheckOperands,
         },
     },
     utils::{adjusted_remainder, compute_lookup_indices_from_operands},
@@ -389,11 +388,6 @@ impl<F: JoltField> WitnessGenerator<F> for CommittedPoly {
             }
             CommittedPoly::SqrtDivRangeCheckRaD(node_idx, d) => {
                 build_range_check_rad_witness::<F, RiRangeCheckOperands>(
-                    model, trace, *node_idx, *d,
-                )
-            }
-            CommittedPoly::TeleportRangeCheckRaD(node_idx, d) => {
-                build_range_check_rad_witness::<F, TeleportRangeCheckOperands>(
                     model, trace, *node_idx, *d,
                 )
             }

--- a/joltworks/src/lookup_tables/less_than_const.rs
+++ b/joltworks/src/lookup_tables/less_than_const.rs
@@ -1,0 +1,118 @@
+use super::{
+    prefixes::{
+        less_than_const::{TrigEqConstPrefix, TrigLessThanConstPrefix},
+        PrefixEval, PrefixVariant, Prefixes,
+    },
+    suffixes::{less_than_const::TrigLessThanConstSuffix, SuffixEval, SuffixVariant, Suffixes},
+    JoltLookupTable, PrefixSuffixDecompositionTrait,
+};
+use crate::field::{ChallengeFieldOps, FieldChallengeOps, JoltField};
+use common::consts::TRIG_PERIOD_MODULUS;
+use serde::{Deserialize, Serialize};
+
+/// An unsigned `XLEN`-bit input `x`, compared against a compile-time constant `BOUND` (not
+/// restricted to a power of two): `x < BOUND`. Single-operand analogue of
+/// [`UnsignedLessThanTable`](super::unsigned_less_than::UnsignedLessThanTable), used to
+/// range-check against a constant.
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct LessThanConstTable<const XLEN: usize, const BOUND: u64>;
+
+impl<const XLEN: usize, const BOUND: u64> JoltLookupTable for LessThanConstTable<XLEN, BOUND> {
+    fn materialize_entry(&self, index: u64) -> u64 {
+        let masked = if XLEN == 64 {
+            index
+        } else {
+            index & ((1u64 << XLEN) - 1)
+        };
+        (masked < BOUND).into()
+    }
+
+    fn evaluate_mle<F, C>(&self, r: &[C]) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: JoltField + FieldChallengeOps<C>,
+    {
+        let offset = r.len() - XLEN;
+
+        // \sum_{i: k_i=1} (1 - x_i) * \prod_{j<i} (x_j if k_j=1 else (1-x_j))
+        let mut result = F::zero();
+        let mut eq = F::one();
+        for i in 0..XLEN {
+            let x_i: F = r[offset + i].into();
+            if (BOUND >> (XLEN - 1 - i)) & 1 == 1 {
+                result += (F::one() - x_i) * eq;
+                eq *= x_i;
+            } else {
+                eq *= F::one() - x_i;
+            }
+        }
+        result
+    }
+}
+
+/// `LessThanConstTable` specialized to `BOUND = TRIG_PERIOD_MODULUS`, for the Cos/Sin
+/// teleportation remainder's range-check (`remainder < TRIG_PERIOD_MODULUS`).
+///
+/// Not a blanket impl over arbitrary `BOUND`: `Prefixes`/`Suffixes` are static enums, so each
+/// distinct `BOUND` needs its own registered variant (mirrors `ClampSpec` in `clamp.rs`). Add
+/// another concrete impl like this one if a second `BOUND` is needed.
+pub type TrigLessThanConstTable<const XLEN: usize> =
+    LessThanConstTable<XLEN, { TRIG_PERIOD_MODULUS as u64 }>;
+
+impl<const XLEN: usize> PrefixSuffixDecompositionTrait<XLEN> for TrigLessThanConstTable<XLEN> {
+    fn prefixes(&self) -> Vec<Prefixes> {
+        vec![
+            TrigEqConstPrefix::<XLEN>::VARIANT,
+            TrigLessThanConstPrefix::<XLEN>::VARIANT,
+        ]
+    }
+
+    fn suffixes(&self) -> Vec<Suffixes> {
+        vec![Suffixes::One, TrigLessThanConstSuffix::<XLEN>::VARIANT]
+    }
+
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        let [eq, less_than] = prefixes.try_into().unwrap();
+        let [one, less_than_suffix] = suffixes.try_into().unwrap();
+        less_than * one + eq * less_than_suffix
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        lookup_tables::test::{
+            lookup_table_mle_full_hypercube_test, lookup_table_mle_linearity_test,
+            lookup_table_mle_random_test, prefix_suffix_test_unary,
+        },
+        subprotocols::ps_shout::unary::tests::test_read_raf_sumcheck,
+    };
+    use ark_bn254::Fr;
+    use common::consts::XLEN;
+
+    #[test]
+    fn prefix_suffix() {
+        prefix_suffix_test_unary::<XLEN, Fr, TrigLessThanConstTable<XLEN>>();
+    }
+
+    #[test]
+    fn mle_full_hypercube() {
+        lookup_table_mle_full_hypercube_test::<Fr, LessThanConstTable<16, 12345>>();
+    }
+
+    #[test]
+    fn mle_random() {
+        lookup_table_mle_random_test::<Fr, TrigLessThanConstTable<XLEN>>();
+    }
+
+    #[test]
+    fn mle_linearity() {
+        lookup_table_mle_linearity_test::<XLEN, Fr, TrigLessThanConstTable<XLEN>>();
+    }
+
+    #[test]
+    fn read_raf() {
+        test_read_raf_sumcheck::<TrigLessThanConstTable<XLEN>, XLEN>();
+    }
+}

--- a/joltworks/src/lookup_tables/mod.rs
+++ b/joltworks/src/lookup_tables/mod.rs
@@ -100,6 +100,8 @@ pub mod and;
 /// Clamps the input to a specified range: floor-at-0 (`SoftmaxClampTable`) or natively
 /// symmetric (`ClampTable`/`SaturationTable`/`ActivationClampTable`), via one generic `ClampSpec`.
 pub mod clamp;
+/// Single-operand, const-bound less-than comparison lookup table (`x < K`).
+pub mod less_than_const;
 /// Bitwise OR lookup table.
 pub mod or;
 /// ReLU (Rectified Linear Unit) activation lookup table.

--- a/joltworks/src/lookup_tables/prefixes/less_than_const.rs
+++ b/joltworks/src/lookup_tables/prefixes/less_than_const.rs
@@ -1,0 +1,207 @@
+use super::{PrefixCheckpoint, SparseDensePrefix};
+use crate::{
+    field::{ChallengeFieldOps, FieldChallengeOps, JoltField},
+    lookup_tables::prefixes::{PrefixCheckpoints, Prefixes},
+    utils::lookup_bits::LookupBits,
+};
+use common::consts::TRIG_PERIOD_MODULUS;
+
+/// `bit` if `k_bit` is set, else `1 - bit` — the per-position term of `EQ(x, K)`.
+fn eq_term<F: JoltField>(bit: F, k_bit: bool) -> F {
+    if k_bit {
+        bit
+    } else {
+        F::one() - bit
+    }
+}
+
+/// Running product `Π_{j<=i} [x_j if k_j=1 else (1-x_j)]`: are the bound bits of `x` equal to
+/// `K`'s corresponding bits so far. Self-contained (no cross-prefix dependency), unlike
+/// [`LessThanConstPrefix`] below.
+pub enum EqConstPrefix<const XLEN: usize, const K: u64, const CP_INDEX: usize> {}
+
+impl<const XLEN: usize, const K: u64, const CP_INDEX: usize> EqConstPrefix<XLEN, K, CP_INDEX> {
+    /// The `i`-th bit of `K` (MSB-first), truncated to `XLEN` bits. `false` for `i >= XLEN`,
+    /// since every registered prefix's checkpoint updates every round regardless of which
+    /// table is being proven.
+    fn k_bit(i: usize) -> bool {
+        i < XLEN && (K >> (XLEN - 1 - i)) & 1 == 1
+    }
+}
+
+impl<const XLEN: usize, const K: u64, const CP_INDEX: usize, F: JoltField> SparseDensePrefix<F>
+    for EqConstPrefix<XLEN, K, CP_INDEX>
+{
+    fn prefix_mle<C>(
+        checkpoints: &PrefixCheckpoints<F>,
+        r_x: Option<C>,
+        c: u32,
+        b: LookupBits,
+        j: usize,
+    ) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        let mut result = checkpoints[CP_INDEX].unwrap_or(F::one());
+
+        if let Some(r_x) = r_x {
+            let r_x: F = r_x.into();
+            if j > 0 {
+                result *= eq_term(r_x, Self::k_bit(j - 1));
+            }
+        }
+        result *= eq_term(F::from_u32(c), Self::k_bit(j));
+
+        let b_len = b.len();
+        let b_u64: u64 = b.into();
+        for pos in 0..b_len {
+            let global_index = j + 1 + pos;
+            let bit = F::from_u8(((b_u64 >> (b_len - 1 - pos)) & 1) as u8);
+            result *= eq_term(bit, Self::k_bit(global_index));
+        }
+
+        result
+    }
+
+    fn update_prefix_checkpoint<C>(
+        checkpoints: &PrefixCheckpoints<F>,
+        r_x: C,
+        r_y: C,
+        j: usize,
+        _suffix_len: usize,
+    ) -> PrefixCheckpoint<F>
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        let mut result = checkpoints[CP_INDEX].unwrap_or(F::one());
+        if j > 0 {
+            result *= eq_term(r_x.into(), Self::k_bit(j - 1));
+        }
+        result *= eq_term(r_y.into(), Self::k_bit(j));
+        Some(result).into()
+    }
+}
+
+/// Running sum `Σ_{i: k_i=1} (1-x_i) · Π_{j<i} EQ(x_j,k_j)`: the "less than constant `K`"
+/// comparator, reading [`EqConstPrefix`]'s *previous* checkpoint at `EQ_CP_INDEX` the same way
+/// `LessThanPrefix` reads `Prefixes::Eq`.
+pub enum LessThanConstPrefix<
+    const XLEN: usize,
+    const K: u64,
+    const EQ_CP_INDEX: usize,
+    const LT_CP_INDEX: usize,
+> {}
+
+impl<const XLEN: usize, const K: u64, const EQ_CP_INDEX: usize, const LT_CP_INDEX: usize>
+    LessThanConstPrefix<XLEN, K, EQ_CP_INDEX, LT_CP_INDEX>
+{
+    /// See [`EqConstPrefix::k_bit`] — identical formula, duplicated per-type so callers don't
+    /// need to spell out `XLEN`/`K` at each call site.
+    fn k_bit(i: usize) -> bool {
+        i < XLEN && (K >> (XLEN - 1 - i)) & 1 == 1
+    }
+}
+
+impl<
+        const XLEN: usize,
+        const K: u64,
+        const EQ_CP_INDEX: usize,
+        const LT_CP_INDEX: usize,
+        F: JoltField,
+    > SparseDensePrefix<F> for LessThanConstPrefix<XLEN, K, EQ_CP_INDEX, LT_CP_INDEX>
+{
+    fn prefix_mle<C>(
+        checkpoints: &PrefixCheckpoints<F>,
+        r_x: Option<C>,
+        c: u32,
+        b: LookupBits,
+        j: usize,
+    ) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        let mut lt = checkpoints[LT_CP_INDEX].unwrap_or(F::zero());
+        let mut eq = checkpoints[EQ_CP_INDEX].unwrap_or(F::one());
+
+        if let Some(r_x) = r_x {
+            let r_x: F = r_x.into();
+            if j > 0 {
+                let idx = j - 1;
+                if Self::k_bit(idx) {
+                    lt += eq * (F::one() - r_x);
+                }
+                eq *= eq_term(r_x, Self::k_bit(idx));
+            }
+            let c = F::from_u32(c);
+            if Self::k_bit(j) {
+                lt += eq * (F::one() - c);
+            }
+            eq *= eq_term(c, Self::k_bit(j));
+        } else {
+            let c = F::from_u32(c);
+            if Self::k_bit(j) {
+                lt += eq * (F::one() - c);
+            }
+            eq *= eq_term(c, Self::k_bit(j));
+        }
+
+        let b_len = b.len();
+        let b_u64: u64 = b.into();
+        for pos in 0..b_len {
+            let global_index = j + 1 + pos;
+            let bit = F::from_u8(((b_u64 >> (b_len - 1 - pos)) & 1) as u8);
+            if Self::k_bit(global_index) {
+                lt += eq * (F::one() - bit);
+            }
+            eq *= eq_term(bit, Self::k_bit(global_index));
+        }
+
+        lt
+    }
+
+    fn update_prefix_checkpoint<C>(
+        checkpoints: &PrefixCheckpoints<F>,
+        r_x: C,
+        r_y: C,
+        j: usize,
+        _suffix_len: usize,
+    ) -> PrefixCheckpoint<F>
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        let mut lt = checkpoints[LT_CP_INDEX].unwrap_or(F::zero());
+        let mut eq = checkpoints[EQ_CP_INDEX].unwrap_or(F::one());
+
+        let r_x: F = r_x.into();
+        let r_y: F = r_y.into();
+        if j > 0 {
+            let idx = j - 1;
+            if Self::k_bit(idx) {
+                lt += eq * (F::one() - r_x);
+            }
+            eq *= eq_term(r_x, Self::k_bit(idx));
+        }
+        if Self::k_bit(j) {
+            lt += eq * (F::one() - r_y);
+        }
+
+        Some(lt).into()
+    }
+}
+
+/// `EqConstPrefix` specialized to `K = TRIG_PERIOD_MODULUS`, for the trig remainder
+/// range-check's single-operand `LessThanConstTable`.
+pub type TrigEqConstPrefix<const XLEN: usize> =
+    EqConstPrefix<XLEN, { TRIG_PERIOD_MODULUS as u64 }, { Prefixes::TrigEqConst as usize }>;
+
+/// `LessThanConstPrefix` specialized to `K = TRIG_PERIOD_MODULUS`.
+pub type TrigLessThanConstPrefix<const XLEN: usize> = LessThanConstPrefix<
+    XLEN,
+    { TRIG_PERIOD_MODULUS as u64 },
+    { Prefixes::TrigEqConst as usize },
+    { Prefixes::TrigLessThanConst as usize },
+>;

--- a/joltworks/src/lookup_tables/prefixes/mod.rs
+++ b/joltworks/src/lookup_tables/prefixes/mod.rs
@@ -16,6 +16,7 @@ use crate::{
             ActivationHigherAllZeroPrefix, ClampHigherAllZeroPrefix, SatClampHigherAllZeroPrefix,
             SoftmaxClampHigherAllZeroPrefix,
         },
+        less_than_const::{TrigEqConstPrefix, TrigLessThanConstPrefix},
         lower_msb::LowerMsbPrefix,
         lower_word::{
             ActivationLowerWordPrefix, ClampLowerWordPrefix, SatClampLowerWordPrefix,
@@ -56,6 +57,8 @@ pub mod higher_all_one;
 pub mod higher_all_zero;
 /// Less-than comparison prefix implementation.
 pub mod less_than;
+/// Const-bound less-than comparison prefix implementation (single-operand, `x < K`).
+pub mod less_than_const;
 /// Lower 32-bit word sign bit (i32 sign bit) prefix implementation.
 pub mod lower_msb;
 /// Outputs the lower word of the input without bits of significance >= bound.
@@ -291,6 +294,9 @@ impl_sparse_dense_prefix!(
     SoftmaxClampLowerWord       : SoftmaxClampLowerWordPrefix,      // Lower word without bits of significance >= bound, used by softmax's saturating-clamp table.
 
     TrigRightShift               : TrigRightShiftPrefix,            // Value of the high bits of an unsigned input, right-shifted by `TRIG_DOWNSCALE_BITS`, used by `RightShiftTable`.
+
+    TrigEqConst                  : TrigEqConstPrefix,               // Indicator that the bound bits of `x` equal `TRIG_PERIOD_MODULUS`'s bits so far, used by `LessThanConstTable`.
+    TrigLessThanConst            : TrigLessThanConstPrefix,         // `x < TRIG_PERIOD_MODULUS`, used by `LessThanConstTable`.
 );
 
 #[derive(Clone, Copy)]

--- a/joltworks/src/lookup_tables/suffixes/less_than_const.rs
+++ b/joltworks/src/lookup_tables/suffixes/less_than_const.rs
@@ -1,0 +1,41 @@
+use crate::utils::lookup_bits::LookupBits;
+use common::consts::TRIG_PERIOD_MODULUS;
+
+use super::SparseDenseSuffix;
+
+/// The `i`-th bit of `K` (global bit index, 0 = MSB), truncated to `XLEN` bits.
+fn k_bit<const XLEN: usize, const K: u64>(i: usize) -> bool {
+    (K >> (XLEN - 1 - i)) & 1 == 1
+}
+
+/// `Σ_{i: k_i=1} (1-x_i) · Π_{j<i} EQ(x_j,k_j)`, restricted to this suffix's bit window
+/// (same per-bit accumulation as `LessThanConstPrefix`, with a local running `eq`).
+pub enum LessThanConstSuffix<const XLEN: usize, const K: u64> {}
+
+impl<const XLEN: usize, const K: u64> SparseDenseSuffix for LessThanConstSuffix<XLEN, K> {
+    fn suffix_mle(b: LookupBits) -> u32 {
+        let b_len = b.len();
+        let global_start = XLEN - b_len;
+        let b_u64: u64 = b.into();
+
+        let mut lt = 0u32;
+        let mut eq = 1u32;
+        for pos in 0..b_len {
+            let global_index = global_start + pos;
+            let bit = ((b_u64 >> (b_len - 1 - pos)) & 1) as u32;
+            if k_bit::<XLEN, K>(global_index) {
+                lt += eq * (1 - bit);
+            }
+            eq *= if k_bit::<XLEN, K>(global_index) {
+                bit
+            } else {
+                1 - bit
+            };
+        }
+        lt
+    }
+}
+
+/// `LessThanConstSuffix` specialized to `K = TRIG_PERIOD_MODULUS`.
+pub type TrigLessThanConstSuffix<const XLEN: usize> =
+    LessThanConstSuffix<XLEN, { TRIG_PERIOD_MODULUS as u64 }>;

--- a/joltworks/src/lookup_tables/suffixes/mod.rs
+++ b/joltworks/src/lookup_tables/suffixes/mod.rs
@@ -19,6 +19,7 @@ use crate::{
             ActivationHZeroMulLWordSuffix, ClampHZeroMulLWordSuffix, SatClampHZeroMulLWordSuffix,
             SoftmaxClampHZeroMulLWordSuffix,
         },
+        less_than_const::TrigLessThanConstSuffix,
         lower_msb_upper_eqo_low::LowerMsbUpperEqoLowSuffix,
         neg_relu::NegReluSuffix,
         not_lower_msb_upper_eqz::NotLowerMsbUpperEqzSuffix,
@@ -45,6 +46,8 @@ pub mod hone_mul_lword;
 pub mod hzero_mul_lword;
 /// Less-than comparison suffix implementation.
 pub mod less_than;
+/// Const-bound less-than comparison suffix implementation (single-operand, `x < K`).
+pub mod less_than_const;
 /// `m * upper_eqo * low` suffix implementation, used in `sat_clamp` decomposition.
 pub mod lower_msb_upper_eqo_low;
 /// Negated ReLU suffix (Relu(-x)): `neg_relu(x) = max(-x, 0)`.
@@ -141,6 +144,8 @@ impl_sparse_dense_suffix!(
     SoftmaxClampHZeroMulLWord   : SoftmaxClampHZeroMulLWordSuffix,  // `higher_all_zero(bits) * lower_word(bits)`, used by softmax's saturating-clamp table.
 
     TrigRightShift               : TrigRightShiftSuffix,            // Value of the high bits of an unsigned input, right-shifted by `TRIG_DOWNSCALE_BITS`, used by `RightShiftTable`.
+
+    TrigLessThanConst            : TrigLessThanConstSuffix,         // `x < TRIG_PERIOD_MODULUS` restricted to the suffix's bit window, used by `LessThanConstTable`.
 );
 
 /// Type alias for suffix evaluation results in the field.


### PR DESCRIPTION
NOTE: waiting for pull request #284 to be merged

This pull request implements the follow-up work introduced in the above-mentionned pull request.

### Context
Trigonometric operators perform a division by a compile-time constant, and require a rangecheck to be executed against that constant.

 ### Previous behavior
The existing proving flow for trigonometric operators proved the remainder rangecheck by a 64-bits lookup table over a remainder/divisor interleaved one-hot encoding.

### Proposed solution
Since the divisor is here a constant, we can rather use a single-operand (unary) lookup table, constructed at compile-time given the constant bound.

### Gains
We swap a 64-bits lookup table for a 32-bits one, and by the same mean reuse the already committed `remainder` one-hot encoding instead of committing to an additional remainder/divisor interleaved one-hot encoding.
This allows for one less set od `d` committed polynomials, together with one less set of 3 one-hotness sumchecks.

### Performances
Evaluated at 2 input lengths:

#### Input length = 256

| Stage | Before | After | Δ |
|---|---|---|---|
| `commit_witness_polynomials` | 4.56ms | 2.03ms | −55% |
| `iop` | 80.0ms | 47.2ms | −41% |
| `prove_reduced_openings` | 83.8ms | 55.1ms | −34% |
| **total prove** | **168.7ms** | **104.7ms** | **−38%** |
| verify | 7.41ms | 5.04ms | −32% |

#### Input length = 65536

| Stage | Before | After | Δ |
|---|---|---|---|
| `commit_witness_polynomials` | 147.9ms | 40.6ms | −73% |
| `iop` | 253.8ms | 155.3ms | −39% |
| `prove_reduced_openings` | 3.277s | 3.055s | −7% |
| **total prove** | **3.681s** | **3.253s** | **−12%** |
| verify | 8.15ms | 6.25ms | −23% |

## Additional change
Fix of Scalar Const Div, which uses an unnecessary division sumcheck given its divisor is constant, and also lacked a remainder range-check, making it unsound.

#### Follow-up work
Use the unary rangechecking for its rangecheck; currently blocked by the constant being non compile-time.

---

Closes #253 , closes #280 